### PR TITLE
Base styles

### DIFF
--- a/messages/index/en.json
+++ b/messages/index/en.json
@@ -1,0 +1,8 @@
+{
+  "Index": {
+    "title": "Home",
+    "introduction": "Starter <nextLink>Next.js</nextLink>, <reduxLink>Redux</reduxLink> and <muiLink>MUI</muiLink> project",
+    "getStarted": "Get started by editing the <code>pages/index.tsx</code> file",
+    "nextDocs": "Next.js docs"
+  }
+}

--- a/messages/index/es.json
+++ b/messages/index/es.json
@@ -1,0 +1,8 @@
+{
+  "Index": {
+    "title": "Home",
+    "introduction": "Proyecto inicial con <nextLink>Next.js</nextLink>, <reduxLink>Redux</reduxLink> y <muiLink>MUI</muiLink>",
+    "getStarted": "Empieza editando el archivo <code>pages/index.tsx</code>",
+    "nextDocs": "Next.js docs"
+  }
+}

--- a/messages/shared/en.json
+++ b/messages/shared/en.json
@@ -1,0 +1,5 @@
+{
+  "Shared": {
+    "bloom": "Bloom"
+  }
+}

--- a/messages/shared/es.json
+++ b/messages/shared/es.json
@@ -1,0 +1,5 @@
+{
+  "Shared": {
+    "bloom": "Bloom"
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -7,4 +7,9 @@ module.exports = {
     NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN: process.env.NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN,
     NEXT_PUBLIC_ROLLBAR_ENVIRONMENT: process.env.NEXT_PUBLIC_ROLLBAR_ENVIRONMENT,
   },
+  i18n: {
+    locales: ['en', 'es',],
+    defaultLocale: 'en',
+    localeDetection: false
+  },
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/react": "^11.4.1",
     "@emotion/server": "^11.4.0",
     "@emotion/styled": "^11.3.0",
+    "@mui/icons-material": "^5.0.4",
     "@mui/material": "^5.0.2",
     "@reduxjs/toolkit": "^1.6.1",
     "axios": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@reduxjs/toolkit": "^1.6.1",
     "axios": "^0.22.0",
     "next": "11.1.2",
+    "next-intl": "^2.0.5",
     "next-redux-wrapper": "^7.0.5",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { CacheProvider, EmotionCache } from '@emotion/react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
+import { NextIntlProvider } from 'next-intl';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import createEmotionCache from '../config/emotionCache';
@@ -20,16 +21,18 @@ function MyApp(props: MyAppProps) {
   const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
 
   return (
-    <CacheProvider value={emotionCache}>
-      <Head>
-        <title>My page</title>
-        <meta name="viewport" content="initial-scale=1, width=device-width" />
-      </Head>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <Component {...pageProps} />
-      </ThemeProvider>
-    </CacheProvider>
+    <NextIntlProvider messages={pageProps.messages}>
+      <CacheProvider value={emotionCache}>
+        <Head>
+          <title>My page</title>
+          <meta name="viewport" content="initial-scale=1, width=device-width" />
+        </Head>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <Component {...pageProps} />
+        </ThemeProvider>
+      </CacheProvider>
+    </NextIntlProvider>
   );
 }
 export default wrapper.withRedux(MyApp);

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -12,9 +12,13 @@ export default class MyDocument extends Document {
           {/* PWA primary color */}
           <meta name="theme-color" content={theme.palette.primary.main} />
           <link
+            href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap"
             rel="stylesheet"
-            href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
-          />
+          ></link>
+          <link
+            href="https://fonts.googleapis.com/css2?family=Montserrat&family=Open+Sans&display=swap"
+            rel="stylesheet"
+          ></link>
         </Head>
         <body>
           <Main />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -12,13 +12,9 @@ export default class MyDocument extends Document {
           {/* PWA primary color */}
           <meta name="theme-color" content={theme.palette.primary.main} />
           <link
-            href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,600;1,300;1,400;1,600&family=Open+Sans:ital,wght@0,300;0,400;0,600;1,300;1,400;1,600&display=swap"
             rel="stylesheet"
-          ></link>
-          <link
-            href="https://fonts.googleapis.com/css2?family=Montserrat&family=Open+Sans&display=swap"
-            rel="stylesheet"
-          ></link>
+          />
         </Head>
         <body>
           <Main />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,41 @@
+import LanguageIcon from '@mui/icons-material/Language';
+import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import type { NextPage } from 'next';
+import { useRouter } from 'next/router';
 import Link from '../components/Link';
 
 const Home: NextPage = () => {
+  const router = useRouter();
+  const locale = router.locale;
+  const locales = router.locales;
+
   return (
     <Container maxWidth="sm">
       <Box sx={{ my: 6 }}>
+        <AppBar sx={{ flexDirection: 'row' }}>
+          {locales?.map((language) => {
+            const currentLocale = language === locale;
+
+            return (
+              <Button
+                key={language}
+                component={Link}
+                noLinkStyle
+                color={currentLocale ? 'secondary' : 'primary'}
+                variant="contained"
+                startIcon={currentLocale && <LanguageIcon />}
+                href="/"
+                locale={language}
+              >
+                {language}
+              </Button>
+            );
+          })}
+        </AppBar>
         <Typography variant="h2" component="h1" gutterBottom>
           Starter <Link href="https://nextjs.org">Next.js</Link>,{' '}
           <Link href="https://redux.js.org/">Redux</Link> and{' '}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,8 +18,8 @@ const Home: NextPage = () => {
 
   return (
     <Container maxWidth="sm">
-      <Box sx={{ my: 6 }}>
-        <AppBar sx={{ flexDirection: 'row' }}>
+      <Box sx={{ mt: 10 }}>
+        <AppBar sx={{ bgcolor: 'primary.light', flexDirection: 'row' }}>
           {locales?.map((language) => {
             const currentLocale = language === locale;
 
@@ -28,8 +28,8 @@ const Home: NextPage = () => {
                 key={language}
                 component={Link}
                 noLinkStyle
-                color={currentLocale ? 'secondary' : 'primary'}
-                variant="contained"
+                variant={currentLocale ? 'outlined' : 'contained'}
+                disabled={currentLocale}
                 startIcon={currentLocale && <LanguageIcon />}
                 href="/"
                 locale={language}
@@ -39,7 +39,48 @@ const Home: NextPage = () => {
             );
           })}
         </AppBar>
-        <Typography variant="h2" component="h1" gutterBottom>
+        <Typography variant="h1" component="h1" gutterBottom>
+          H1 -{' '}
+          {t.rich('introduction', {
+            nextLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            reduxLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            muiLink: (children) => <Link href="https://mui.com/">{children}</Link>,
+          })}
+        </Typography>
+        <Typography variant="h2" component="h2" gutterBottom>
+          H2 -{' '}
+          {t.rich('introduction', {
+            nextLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            reduxLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            muiLink: (children) => <Link href="https://mui.com/">{children}</Link>,
+          })}
+        </Typography>
+        <Typography variant="h3" component="h3" gutterBottom>
+          H3 -{' '}
+          {t.rich('introduction', {
+            nextLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            reduxLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            muiLink: (children) => <Link href="https://mui.com/">{children}</Link>,
+          })}
+        </Typography>
+        <Typography variant="h4" component="h4" gutterBottom>
+          H4 -{' '}
+          {t.rich('introduction', {
+            nextLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            reduxLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            muiLink: (children) => <Link href="https://mui.com/">{children}</Link>,
+          })}
+        </Typography>
+        <Typography variant="h5" component="h5" gutterBottom>
+          H5 -{' '}
+          {t.rich('introduction', {
+            nextLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            reduxLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            muiLink: (children) => <Link href="https://mui.com/">{children}</Link>,
+          })}
+        </Typography>
+        <Typography variant="h6" component="h6" gutterBottom>
+          H6 -{' '}
           {t.rich('introduction', {
             nextLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
             reduxLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
@@ -52,7 +93,7 @@ const Home: NextPage = () => {
           })}
         </Typography>
         <Button
-          sx={{ mt: 2 }}
+          sx={{ mt: 2, mr: 1.5 }}
           variant="contained"
           component={Link}
           noLinkStyle
@@ -60,7 +101,32 @@ const Home: NextPage = () => {
         >
           {t.rich('nextDocs')}
         </Button>
+        <Button
+          component={Link}
+          sx={{ mt: 2, mr: 1.5 }}
+          variant="contained"
+          color="secondary"
+          noLinkStyle
+          href="https://nextjs.org/docs"
+        >
+          {t.rich('nextDocs')}
+        </Button>
+        <Button
+          component={Link}
+          sx={{ mt: 2, mr: 1.5 }}
+          variant="outlined"
+          noLinkStyle
+          href="https://nextjs.org/docs"
+        >
+          {t.rich('nextDocs')}
+        </Button>
       </Box>
+      <Box sx={{ bgcolor: 'primary.main', height: '2.5rem', mt: 2.5 }}></Box>
+      <Box sx={{ bgcolor: 'primary.light', height: '2.5rem' }}></Box>
+      <Box sx={{ bgcolor: 'primary.dark', height: '2.5rem' }}></Box>
+      <Box sx={{ bgcolor: 'secondary.main', height: '2.5rem' }}></Box>
+      <Box sx={{ bgcolor: 'secondary.light', height: '2.5rem' }}></Box>
+      <Box sx={{ bgcolor: 'secondary.dark', height: '2.5rem' }}></Box>
     </Container>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,8 @@ import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import type { NextPage } from 'next';
+import { GetStaticPropsContext } from 'next';
+import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import Link from '../components/Link';
 
@@ -12,6 +14,7 @@ const Home: NextPage = () => {
   const router = useRouter();
   const locale = router.locale;
   const locales = router.locales;
+  const t = useTranslations('Index');
 
   return (
     <Container maxWidth="sm">
@@ -37,12 +40,16 @@ const Home: NextPage = () => {
           })}
         </AppBar>
         <Typography variant="h2" component="h1" gutterBottom>
-          Starter <Link href="https://nextjs.org">Next.js</Link>,{' '}
-          <Link href="https://redux.js.org/">Redux</Link> and{' '}
-          <Link href="https://mui.com/">MUI</Link> project
+          {t.rich('introduction', {
+            nextLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            reduxLink: (children) => <Link href="https://redux.js.org/">{children}</Link>,
+            muiLink: (children) => <Link href="https://mui.com/">{children}</Link>,
+          })}
         </Typography>
         <Typography variant="body1" component="p" gutterBottom>
-          Get started by editing the <code>pages/index.tsx</code> file
+          {t.rich('getStarted', {
+            code: (children) => <code>{children}</code>,
+          })}
         </Typography>
         <Button
           sx={{ mt: 2 }}
@@ -51,11 +58,22 @@ const Home: NextPage = () => {
           noLinkStyle
           href="https://nextjs.org/docs"
         >
-          Next.js docs
+          {t.rich('nextDocs')}
         </Button>
       </Box>
     </Container>
   );
 };
+
+export function getStaticProps({ locale }: GetStaticPropsContext) {
+  return {
+    props: {
+      messages: {
+        ...require(`../messages/shared/${locale}.json`),
+        ...require(`../messages/index/${locale}.json`),
+      },
+    },
+  };
+}
 
 export default Home;

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -4,10 +4,14 @@ import { createTheme, responsiveFontSizes } from '@mui/material/styles';
 let theme = createTheme({
   palette: {
     primary: {
-      main: '#F3D6D8',
+      main: '#d81b60',
+      light: '#F3D6D8',
+      dark: '#a00037',
     },
     secondary: {
-      main: '#F0244D',
+      main: '#ffbfa4',
+      light: '#FFEAE1',
+      dark: '#FF976A',
     },
     background: {
       default: '#FDF3EF',
@@ -17,16 +21,20 @@ let theme = createTheme({
       main: '#F3D6D8',
     },
   },
+  shape: {
+    borderRadius: 20,
+  },
   typography: {
     fontFamily: 'Open Sans, sans-serif',
     h1: {
-      fontFamily: 'Montserrat, sans-serif',
-      fontSize: '3.25rem',
+      fontFamily: 'Montserrat Semibold, sans-serif',
+      fontSize: '2.75rem',
     },
     h2: {
       fontSize: '2.25rem',
     },
     h3: {
+      fontFamily: 'Open Sans Semibold, sans-serif',
       fontSize: '1.75rem',
     },
     h4: {
@@ -37,7 +45,16 @@ let theme = createTheme({
     },
     h6: {
       fontSize: '1rem',
-      fontWeight: 'bold',
+      fontWeight: 'bolder',
+    },
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          fontWeight: 'bolder',
+        },
+      },
     },
   },
 });

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -7,7 +7,7 @@ const theme = createTheme({
       main: '#556cd6',
     },
     secondary: {
-      main: '#19857b',
+      main: '#0c42a4',
     },
   },
 });

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,15 +1,46 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme, responsiveFontSizes } from '@mui/material/styles';
 
 // Create a theme instance.
-const theme = createTheme({
+let theme = createTheme({
   palette: {
     primary: {
-      main: '#556cd6',
+      main: '#F3D6D8',
     },
     secondary: {
-      main: '#0c42a4',
+      main: '#F0244D',
+    },
+    background: {
+      default: '#FDF3EF',
+      paper: '#F3D6D8',
+    },
+    info: {
+      main: '#F3D6D8',
+    },
+  },
+  typography: {
+    fontFamily: 'Open Sans, sans-serif',
+    h1: {
+      fontFamily: 'Montserrat, sans-serif',
+      fontSize: '3.25rem',
+    },
+    h2: {
+      fontSize: '2.25rem',
+    },
+    h3: {
+      fontSize: '1.75rem',
+    },
+    h4: {
+      fontSize: '1.5rem',
+    },
+    h5: {
+      fontSize: '1.25rem',
+    },
+    h6: {
+      fontSize: '1rem',
+      fontWeight: 'bold',
     },
   },
 });
+theme = responsiveFontSizes(theme);
 
 export default theme;

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,6 +472,45 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@formatjs/ecma402-abstract@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.10.0.tgz#f51b9167535c9463113c24644de90262aa5d31a7"
+  integrity sha512-WNkcUHC6xw12rWY87TUw6KXzb1LnOooYBLLqtyn1kW2j197rcwpqmUOJMBED56YcLzaJPfVw1L2ShiDhL5pVnQ==
+  dependencies:
+    "@formatjs/intl-localematcher" "0.2.21"
+    tslib "^2.1.0"
+
+"@formatjs/fast-memoize@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-1.2.0.tgz#1123bfcc5d21d761f15d8b1c32d10e1b6530355d"
+  integrity sha512-fObitP9Tlc31SKrPHgkPgQpGo4+4yXfQQITTCNH8AZdEqB7Mq4nPrjpUL/tNGN3lEeJcFxDbi0haX8HM7QvQ8w==
+  dependencies:
+    tslib "^2.1.0"
+
+"@formatjs/icu-messageformat-parser@2.0.13":
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.13.tgz#fcd7816b3d0b799daf20ff9e5e0fe81d3618276e"
+  integrity sha512-dIdcNnuJj1V+DnXQUjJTA+uES/UCpxLPbIA8R1wSrWY/yCgv9N1beSY1lTHrhcG0XC++ShP+AEqqVV/zX3BMZg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.10.0"
+    "@formatjs/icu-skeleton-parser" "1.3.0"
+    tslib "^2.1.0"
+
+"@formatjs/icu-skeleton-parser@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.0.tgz#fedf604bf788a587b23c9a03ec148c1f2c3177f7"
+  integrity sha512-ORUHdglLuE0Vvg3KlxeeguDq2ErUlCWmIU9EmQAhqwhtRwf78nNy2WAJ9qvxzSsp4dAv1CJ9AoS43RdY8JTVaA==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.10.0"
+    tslib "^2.1.0"
+
+"@formatjs/intl-localematcher@0.2.21":
+  version "0.2.21"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.2.21.tgz#39ef33d701fe8084f3d693cd3ff7cbe03cdd3a49"
+  integrity sha512-JTJeLiNwexN4Gy0cMxoUPvJbKhXdnSuo5jPrDafEZpnDWlJ5VDYta8zUVVozO/pwzEmFVHEUpgiEDj+39L4oMg==
+  dependencies:
+    tslib "^2.1.0"
+
 "@hapi/accept@5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.2.tgz#ab7043b037e68b722f93f376afb05e85c0699523"
@@ -3079,6 +3118,15 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+intl-messageformat@^9.3.18:
+  version "9.9.3"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-9.9.3.tgz#bf577b3a78c38f6cb81dda3952390df9be5be01d"
+  integrity sha512-YeXTVG1QAfDySO/gbpIrnMw3sKZvmNljahaTWFSGWNs0cNtR6vzwwvg6tzlda4buOw7xzJU3DgLm+skyMC85ow==
+  dependencies:
+    "@formatjs/fast-memoize" "1.2.0"
+    "@formatjs/icu-messageformat-parser" "2.0.13"
+    tslib "^2.1.0"
+
 is-arguments@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
@@ -4106,6 +4154,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+next-intl@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/next-intl/-/next-intl-2.0.5.tgz#af9d8247284bddc4fcd58755bf18bc604c45f0c6"
+  integrity sha512-5oY4kPDARPI4HkeTGGvPXVHB7FIWD8boEGiUwrQn2VHQdeNvbo7K5N3tX92BAz2yeYRxMo6/Gola+hJo9ZoqzQ==
+  dependencies:
+    use-intl "^2.0.5"
 
 next-redux-wrapper@^7.0.5:
   version "7.0.5"
@@ -5561,6 +5616,11 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -5658,6 +5718,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-intl@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/use-intl/-/use-intl-2.0.5.tgz#436febab07dc3985be83be495e6cd64bfc0d62a5"
+  integrity sha512-akFJE2ElSxguSPRwnwk+Xj/f1Dv7i3i87UL9f9mspDeBzyNYU9iyyZHu6Nw+GFQXpHVuCXA5lBUANw03PiDyig==
+  dependencies:
+    intl-messageformat "^9.3.18"
 
 use-subscription@1.5.1:
   version "1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,6 +702,13 @@
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
+"@mui/icons-material@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.0.4.tgz#2d1e69c323695a1c6e26be3abcc532818dd442d2"
+  integrity sha512-pW/2bjRGnBZujoLdtH/C+ghT0Tmlk9HmZHF6HuALuVOnRiHF9VwrcNrx0FLHYT0aMARZR4dBA15nU/53R1YNeQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+
 "@mui/material@^5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.0.2.tgz#380cf0ef42c538a68158b4da19c317178b22d10f"


### PR DESCRIPTION
[Ticket](https://www.notion.so/chayn/Setup-basic-styles-d5c5f51152984a22b567f4f8353e1b45)

- Configure material-ui theme with fonts, colours and core styles.
- Style card and button components

Note that colours are not definite and are currently being reviewed. This primary pink is suggested by material-ui and passes accessibility tests. The secondary peach is taken from chayn.co styleguide.

<img width="501" alt="Screenshot 2021-10-19 at 18 14 52" src="https://user-images.githubusercontent.com/11525717/137959693-f08ad5f5-fe36-4ad1-8d6e-5ec224d78ad5.png">

