### PR TITLE
Setup pilot environment & deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Bloom CI Pipeline
+
+on:
+  push:
+    branches: [develop, staging, main]
+  pull_request:
+    branches: [develop, staging, main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Use NodeJs
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: Run linting
+        run: yarn lint
+
+      - name: Build app
+        run: yarn build
+        env:
+          NEXT_PUBLIC_ROLLBAR_ENV: CI

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn start:heroku

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --watch"
+    "test": "jest --watch",
+    "start:heroku": "NODE_OPTIONS='--max_old_space_size=460' next start -p $PORT"
   },
   "dependencies": {
     "@emotion/cache": "^11.4.0",


### PR DESCRIPTION
[Ticket](https://www.notion.so/chayn/Setup-pilot-environment-deployment-d91182849a1248959ae81fa3c229c6b0)

This ticket includes setting up both frontend and backend app pipelines together, in a similar way.

Setup `bloom-frontend` and `bloom-backend` Heroku apps with one pilot environment for now.  Using heroku urls is okay for now, we'll set up a pilot subdomain for [chayn.co](http://chayn.co) later. Setup auto deployment with github, with a merge to `main` branch triggering a deployment to the pilot apps. Setup `dev` as the "base" branch in github.

Pipeline to mostly mirror YSM.

Add Github actions for linting and building as in YSM but keep lightweight for now.

Later when we're moving beyond pilot, we'll add a `pilot` branch (that auto deploys to the pilot apps) and new `staging` and `production` environments - [ticket](https://www.notion.so/Setup-deployment-and-environments-1f37fa8642594e1e93b6b29e7542cd23).