### PR TITLE
Update state slices 2+ partners

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -1,7 +1,7 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { PARTNER_ACCESS_CODE_STATUS } from '../constants/enums';
-import { Course } from './coursesSlice';
-import { PartnerAccess } from './partnerAccessSlice';
+import { Courses } from './coursesSlice';
+import { PartnerAccess, PartnerAccesses } from './partnerAccessSlice';
 import { PartnerAdmin } from './partnerAdminSlice';
 import { Partner } from './partnerSlice';
 import { RootState } from './store';
@@ -9,9 +9,9 @@ import { User } from './userSlice';
 
 export interface GetUserResponse {
   user: User;
-  partnerAccess: PartnerAccess[];
+  partnerAccesses: PartnerAccesses;
   partnerAdmin: PartnerAdmin;
-  courses: Course[];
+  courses: Courses;
 }
 
 export const api = createApi({

--- a/app/api.ts
+++ b/app/api.ts
@@ -1,5 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { PARTNER_ACCESS_CODE_STATUS } from '../constants/responses';
+import { PARTNER_ACCESS_CODE_STATUS } from '../constants/enums';
+import { Course } from './coursesSlice';
 import { PartnerAccess } from './partnerAccessSlice';
 import { PartnerAdmin } from './partnerAdminSlice';
 import { Partner } from './partnerSlice';
@@ -8,9 +9,9 @@ import { User } from './userSlice';
 
 export interface GetUserResponse {
   user: User;
-  partnerAccess: PartnerAccess;
+  partnerAccess: PartnerAccess[];
   partnerAdmin: PartnerAdmin;
-  partner: Partner;
+  courses: Course[];
 }
 
 export const api = createApi({
@@ -42,6 +43,9 @@ export const api = createApi({
           body,
         };
       },
+    }),
+    getPartner: builder.query<Partner, string>({
+      query: (name) => ({ url: `partner/${name}` }),
     }),
     validateCode: builder.mutation<
       | { status: PARTNER_ACCESS_CODE_STATUS }

--- a/app/coursesSlice.tsx
+++ b/app/coursesSlice.tsx
@@ -1,0 +1,50 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { STORYBLOK_STORY_STATUS_ENUM } from '../constants/enums';
+import { api } from './api';
+import type { RootState } from './store';
+
+export interface Session {
+  id?: string | null;
+  name?: string | null;
+  slug?: string | null;
+  storyblokId?: string | null;
+  status?: STORYBLOK_STORY_STATUS_ENUM | null;
+  completed?: string | null;
+}
+
+export interface Course {
+  id: string | null;
+  name: string | null;
+  slug: string | null;
+  status: STORYBLOK_STORY_STATUS_ENUM | null;
+  storyblokId: string | null;
+  completed: boolean | null;
+  session: Session[];
+}
+
+export interface Courses extends Array<Course> {}
+
+const initialState: Courses = [];
+
+const slice = createSlice({
+  name: 'courses',
+  initialState: initialState,
+  reducers: {
+    clearCoursesSlice: (state) => {
+      state = initialState;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addMatcher(api.endpoints.addUser.matchFulfilled, (state, { payload }) => {
+      return payload.courses;
+    });
+    builder.addMatcher(api.endpoints.getUser.matchFulfilled, (state, { payload }) => {
+      return payload.courses;
+    });
+  },
+});
+
+const { actions, reducer } = slice;
+export const { clearCoursesSlice } = actions;
+export const selectCourses = (state: RootState) => state.courses;
+export default reducer;

--- a/app/partnerAccessSlice.tsx
+++ b/app/partnerAccessSlice.tsx
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { api } from './api';
+import { Partner } from './partnerSlice';
 import type { RootState } from './store';
 
 export interface PartnerAccess {
@@ -10,17 +11,12 @@ export interface PartnerAccess {
   accessCode: string | null;
   therapySessionsRemaining: number | null;
   therapySessionsRedeemed: number | null;
+  partner: Partner;
 }
 
-const initialState: PartnerAccess = {
-  id: null,
-  activatedAt: null,
-  featureLiveChat: null,
-  featureTherapy: null,
-  accessCode: null,
-  therapySessionsRemaining: null,
-  therapySessionsRedeemed: null,
-};
+export interface PartnerAccesses extends Array<PartnerAccess> {}
+
+const initialState: PartnerAccesses = [];
 
 const slice = createSlice({
   name: 'partnerAccess',
@@ -32,7 +28,7 @@ const slice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addMatcher(api.endpoints.addPartnerAccess.matchFulfilled, (state, { payload }) => {
-      state = payload;
+      state.push(payload);
     });
     builder.addMatcher(api.endpoints.addUser.matchFulfilled, (state, { payload }) => {
       return payload.partnerAccess;

--- a/app/partnerAccessSlice.tsx
+++ b/app/partnerAccessSlice.tsx
@@ -19,10 +19,10 @@ export interface PartnerAccesses extends Array<PartnerAccess> {}
 const initialState: PartnerAccesses = [];
 
 const slice = createSlice({
-  name: 'partnerAccess',
+  name: 'partnerAccesses',
   initialState: initialState,
   reducers: {
-    clearPartnerAccessSlice: (state) => {
+    clearPartnerAccessesSlice: (state) => {
       state = initialState;
     },
   },
@@ -31,15 +31,15 @@ const slice = createSlice({
       state.push(payload);
     });
     builder.addMatcher(api.endpoints.addUser.matchFulfilled, (state, { payload }) => {
-      return payload.partnerAccess;
+      return payload.partnerAccesses;
     });
     builder.addMatcher(api.endpoints.getUser.matchFulfilled, (state, { payload }) => {
-      return payload.partnerAccess;
+      return payload.partnerAccesses;
     });
   },
 });
 
 const { actions, reducer } = slice;
-export const { clearPartnerAccessSlice } = actions;
-export const selectPartnerAccess = (state: RootState) => state.partnerAccess;
+export const { clearPartnerAccessesSlice } = actions;
+export const selectPartnerAccesses = (state: RootState) => state.partnerAccesses;
 export default reducer;

--- a/app/partnerSlice.tsx
+++ b/app/partnerSlice.tsx
@@ -25,11 +25,8 @@ const slice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addMatcher(api.endpoints.addUser.matchFulfilled, (state, { payload }) => {
-      return payload.partner;
-    });
-    builder.addMatcher(api.endpoints.getUser.matchFulfilled, (state, { payload }) => {
-      return payload.partner;
+    builder.addMatcher(api.endpoints.getPartner.matchFulfilled, (state, { payload }) => {
+      return payload;
     });
   },
 });

--- a/app/store.ts
+++ b/app/store.ts
@@ -2,6 +2,7 @@ import { configureStore, ThunkAction } from '@reduxjs/toolkit';
 import { createWrapper } from 'next-redux-wrapper';
 import { Action } from 'redux';
 import { api } from './api';
+import coursesReducer from './coursesSlice';
 import currentReducer from './currentSlice';
 import partnerAccessReducer from './partnerAccessSlice';
 import partnerAdminReducer from './partnerAdminSlice';
@@ -13,6 +14,7 @@ const initStore = () =>
     reducer: {
       [api.reducerPath]: api.reducer,
       user: userReducer,
+      courses: coursesReducer,
       partnerAccess: partnerAccessReducer,
       partnerAdmin: partnerAdminReducer,
       partner: partnerReducer,

--- a/app/store.ts
+++ b/app/store.ts
@@ -4,7 +4,7 @@ import { Action } from 'redux';
 import { api } from './api';
 import coursesReducer from './coursesSlice';
 import currentReducer from './currentSlice';
-import partnerAccessReducer from './partnerAccessSlice';
+import partnerAccessesReducer from './partnerAccessSlice';
 import partnerAdminReducer from './partnerAdminSlice';
 import partnerReducer from './partnerSlice';
 import userReducer from './userSlice';
@@ -15,7 +15,7 @@ const initStore = () =>
       [api.reducerPath]: api.reducer,
       user: userReducer,
       courses: coursesReducer,
-      partnerAccess: partnerAccessReducer,
+      partnerAccesses: partnerAccessesReducer,
       partnerAdmin: partnerAdminReducer,
       partner: partnerReducer,
       current: currentReducer,

--- a/app/userSlice.tsx
+++ b/app/userSlice.tsx
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { LANGUAGES } from '../constants/languages';
+import { LANGUAGES } from '../constants/enums';
 import { api } from './api';
 import type { RootState } from './store';
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -53,10 +53,8 @@ const socialsContainerStyle = {
 const Footer = () => {
   const tS = useTranslations('Shared');
 
-  const { user, partnerAccess, partnerAdmin, partner } = useTypedSelector(
-    (state: RootState) => state,
-  );
-  const eventUserData = getEventUserData({ user, partnerAccess, partnerAdmin, partner });
+  const { user, partnerAccesses } = useTypedSelector((state: RootState) => state);
+  const eventUserData = getEventUserData({ user, partnerAccesses });
 
   return (
     <Container sx={footerContainerStyle}>
@@ -74,7 +72,9 @@ const Footer = () => {
           <IconButton
             aria-label="Instagram"
             href="https://www.instagram.com/chaynhq"
-            onClick={() => logEvent(SOCIAL_LINK_CLICKED, { ...eventUserData, social_account: '' })}
+            onClick={() =>
+              logEvent(SOCIAL_LINK_CLICKED, { ...eventUserData, social_account: 'Instagram' })
+            }
           >
             <InstagramIcon />
           </IconButton>

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -14,6 +14,7 @@ import { useAddUserMutation, useValidateCodeMutation } from '../app/api';
 import Link from '../components/Link';
 import { auth } from '../config/firebase';
 import rollbar from '../config/rollbar';
+import { LANGUAGES, PARTNER_ACCESS_CODE_STATUS } from '../constants/enums';
 import {
   REGISTER_ERROR,
   REGISTER_FIREBASE_ERROR,
@@ -23,8 +24,6 @@ import {
   VALIDATE_ACCESS_CODE_REQUEST,
   VALIDATE_ACCESS_CODE_SUCCESS,
 } from '../constants/events';
-import { LANGUAGES } from '../constants/languages';
-import { PARTNER_ACCESS_CODE_STATUS } from '../constants/responses';
 import { getErrorMessage } from '../utils/errorMessage';
 import logEvent, { getEventUserData } from '../utils/logEvent';
 

--- a/constants/enums.ts
+++ b/constants/enums.ts
@@ -1,3 +1,14 @@
+export enum STORYBLOK_STORY_STATUS_ENUM {
+  PUBLISHED = 'published',
+  UNPUBLISHED = 'unpublished',
+  DELETED = 'deleted',
+}
+
+export enum LANGUAGES {
+  en = 'en',
+  es = 'es',
+}
+
 export enum PARTNER_ACCESS_CODE_STATUS {
   VALID = 'VALID',
   INVALID_CODE = 'INVALID_CODE',

--- a/constants/languages.ts
+++ b/constants/languages.ts
@@ -1,4 +1,0 @@
-export enum LANGUAGES {
-  en = 'en',
-  es = 'es',
-}

--- a/hooks/store.ts
+++ b/hooks/store.ts
@@ -1,6 +1,6 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { clearCurrentSlice } from '../app/currentSlice';
-import { clearPartnerAccessSlice } from '../app/partnerAccessSlice';
+import { clearPartnerAccessesSlice } from '../app/partnerAccessSlice';
 import { clearPartnerAdminSlice } from '../app/partnerAdminSlice';
 import { clearPartnerSlice } from '../app/partnerSlice';
 import type { AppDispatch, RootState } from '../app/store';
@@ -11,7 +11,7 @@ export const useAppDispatch = () => useDispatch<AppDispatch>();
 
 export const clearStore = async () => {
   clearCurrentSlice();
-  clearPartnerAccessSlice();
+  clearPartnerAccessesSlice();
   clearPartnerAdminSlice();
   clearPartnerSlice();
   clearUserSlice();

--- a/pages/therapy/book-session.tsx
+++ b/pages/therapy/book-session.tsx
@@ -52,10 +52,12 @@ const BookSession: NextPage = () => {
   const tS = useTranslations('Shared');
   const [widgetOpen, setWidgetOpen] = useState(false);
 
-  const { user, partnerAccess, partnerAdmin, partner } = useTypedSelector(
-    (state: RootState) => state,
-  );
-  const eventUserData = getEventUserData({ user, partnerAccess, partnerAdmin, partner });
+  const { user, partnerAccesses } = useTypedSelector((state: RootState) => state);
+  const eventUserData = getEventUserData({ user, partnerAccesses });
+
+  const therapyAccess = partnerAccesses.find(function (partnerAccess) {
+    return partnerAccess.featureTherapy === true;
+  });
 
   useEffect(() => {
     logEvent(THERAPY_BOOKING_VIEWED, eventUserData);
@@ -142,7 +144,7 @@ const BookSession: NextPage = () => {
         <Box mt={4} textAlign="left">
           <Typography variant="body1" component="p">
             {t.rich('bookingDescription1', {
-              strongText: () => <strong>{partnerAccess.therapySessionsRemaining}</strong>,
+              strongText: () => <strong>{therapyAccess?.therapySessionsRemaining}</strong>,
             })}
           </Typography>
           <Button

--- a/utils/authGuard.tsx
+++ b/utils/authGuard.tsx
@@ -13,7 +13,7 @@ import logEvent, { getEventUserData } from './logEvent';
 export function AuthGuard({ children }: { children: JSX.Element }) {
   const router = useRouter();
   const [verified, setVerified] = useState(false);
-  const { user, partnerAccess } = useTypedSelector((state: RootState) => state);
+  const { user, partnerAccesses } = useTypedSelector((state: RootState) => state);
   const [getUser, { isLoading: getUserIsLoading }] = useGetUserMutation();
 
   const loadingContainerStyle = {
@@ -63,9 +63,13 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
     );
   }
 
+  const liveChatAccess = partnerAccesses.find(function (partnerAccess) {
+    return partnerAccess.featureLiveChat === true;
+  });
+
   return (
     <>
-      {partnerAccess.featureLiveChat && <Crisp email={user.email} />}
+      {liveChatAccess && <Crisp email={user.email} />}
       {children}
     </>
   );

--- a/utils/logEvent.ts
+++ b/utils/logEvent.ts
@@ -5,27 +5,20 @@ export const logEvent = (event: string, params?: {}) => {
   analytics?.logEvent(event, params!);
 };
 
-export const getEventUserData = (data: GetUserResponse) => {
-  const userData = {
-    createdAt: data.user.createdAt,
-    updatedAt: data.user.updatedAt,
-    languageDefault: data.user.languageDefault,
+export const getEventUserData = (data: Partial<GetUserResponse>) => {
+  return {
+    registered_at: data.user?.createdAt,
+    partner_access: data.partnerAccesses?.map((partnerAccess) => {
+      return {
+        partner_name: partnerAccess.partner.name,
+        feature_live_chat: partnerAccess.featureLiveChat,
+        feature_therapy: partnerAccess.featureTherapy,
+        therapy_sessions_remaining: partnerAccess.therapySessionsRemaining,
+        therapy_sessions_redeemed: partnerAccess.therapySessionsRedeemed,
+        activated_at: partnerAccess.activatedAt,
+      };
+    }),
   };
-
-  if (data.partnerAccess) {
-    const userPartnerData = {
-      ...userData,
-      partner: data.partner.name,
-      partner_activated_at: data.partnerAccess.activatedAt,
-      feature_live_chat: data.partnerAccess.featureLiveChat,
-      feature_therapy: data.partnerAccess.featureTherapy,
-      therapy_sessions_remaining: data.partnerAccess.therapySessionsRemaining,
-      therapy_sessions_redeemed: data.partnerAccess.therapySessionsRedeemed,
-    };
-    return userPartnerData;
-  }
-
-  return userData;
 };
 
 export default logEvent;

--- a/utils/partnerAdminGuard.tsx
+++ b/utils/partnerAdminGuard.tsx
@@ -9,7 +9,7 @@ import { useTypedSelector } from '../hooks/store';
 import illustrationTeaPeach from '../public/illustration_tea_peach.png';
 
 export function PartnerAdminGuard({ children }: { children: JSX.Element }) {
-  const { partnerAdmin, user } = useTypedSelector((state: RootState) => state);
+  const { partnerAdmin } = useTypedSelector((state: RootState) => state);
   const t = useTranslations('PartnerAdmin.accessGuard');
   const tS = useTranslations('Shared');
 

--- a/utils/therapyAccessGuard.tsx
+++ b/utils/therapyAccessGuard.tsx
@@ -9,11 +9,15 @@ import { useTypedSelector } from '../hooks/store';
 import illustrationTeaPeach from '../public/illustration_tea_peach.png';
 
 export function TherapyAccessGuard({ children }: { children: JSX.Element }) {
-  const { partnerAccess } = useTypedSelector((state: RootState) => state);
+  const { partnerAccesses } = useTypedSelector((state: RootState) => state);
   const t = useTranslations('Therapy.accessGuard');
   const tS = useTranslations('Shared');
 
-  if (!partnerAccess || !partnerAccess.featureTherapy) {
+  const therapyAccess = partnerAccesses.find(function (partnerAccess) {
+    return partnerAccess.featureTherapy === true;
+  });
+
+  if (!therapyAccess) {
     const imageContainerStyle = {
       position: 'relative',
       width: { xs: 150, md: 210 },


### PR DESCRIPTION
[Ticket](https://www.notion.so/chayn/Update-state-to-include-courses-and-2-partners-fb601d109dd848d5ba5a9075c159368d) - Update state to include courses and 2+ partners

Related to backend changes - [here](https://github.com/chaynHQ/bloom-backend/pull/69) and [here](https://github.com/chaynHQ/bloom-backend/pull/70) 

The frontend previously assumed only 1 Partner and partnerAccess. Theses change include
-  The existing `partnerAccess` state was changed from singular to `partnerAccesses` plural, and now stores a list of `PartnerAccess` records. The partner access's `Partner` data is now nested in each `PartnerAccess` record, whereas before it was stored in the `partner` slice on the top level.
- The top level `partner` slice is now to be used as the "current" parter - e.g. before authentication on /welcome/bumble