### PR TITLE
Keep user logged in + refresh tokens

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -18,7 +18,7 @@ export const api = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: process.env.NEXT_PUBLIC_API_URL,
     prepareHeaders: (headers, { getState }) => {
-      const token = (getState() as RootState).user.token || localStorage.getItem('accessToken');
+      const token = (getState() as RootState).user.token;
       if (token) {
         headers.set('authorization', `Bearer ${token}`);
       }

--- a/app/api.ts
+++ b/app/api.ts
@@ -47,7 +47,8 @@ const baseQueryWithReauth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQue
     const token = await auth.currentUser?.getIdToken(true);
 
     if (token) {
-      await delay(200); // allow time for new token to update in state
+      // allow time for new token to update in state
+      await delay(200);
       // retry the initial query
       result = await baseQuery(args, api, extraOptions);
     }

--- a/app/userSlice.tsx
+++ b/app/userSlice.tsx
@@ -3,6 +3,8 @@ import { LANGUAGES } from '../constants/enums';
 import { api } from './api';
 import type { RootState } from './store';
 
+const lodashMerge = require('lodash/merge');
+
 export interface User {
   loading: boolean;
   token: string | null;
@@ -38,25 +40,25 @@ const slice = createSlice({
     clearUserSlice: (state) => {
       state = initialState;
     },
-    setToken(state, action: PayloadAction<string>) {
+    setUserToken(state, action: PayloadAction<string>) {
       state.token = action.payload;
     },
-    setLoading(state, action: PayloadAction<boolean>) {
+    setUserLoading(state, action: PayloadAction<boolean>) {
       state.loading = action.payload;
     },
   },
 
   extraReducers: (builder) => {
     builder.addMatcher(api.endpoints.addUser.matchFulfilled, (state, { payload }) => {
-      return payload.user;
+      return lodashMerge({}, state, payload.user);
     });
     builder.addMatcher(api.endpoints.getUser.matchFulfilled, (state, { payload }) => {
-      return payload.user;
+      return lodashMerge({}, state, payload.user);
     });
   },
 });
 
 const { actions, reducer } = slice;
-export const { clearUserSlice, setToken, setLoading } = actions;
+export const { clearUserSlice, setUserToken, setUserLoading } = actions;
 export const selectCurrentUser = (state: RootState) => state.user;
 export default reducer;

--- a/app/userSlice.tsx
+++ b/app/userSlice.tsx
@@ -1,14 +1,15 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { LANGUAGES } from '../constants/enums';
 import { api } from './api';
 import type { RootState } from './store';
 
 export interface User {
+  loading: boolean;
+  token: string | null;
   id: string | null;
   createdAt: Date | null;
   updatedAt: Date | null;
   firebaseUid: string | null;
-  token: string | null;
   name: string | null;
   email: string | null;
   partnerAccessCode: string | null;
@@ -17,11 +18,12 @@ export interface User {
 }
 
 const initialState: User = {
+  loading: true,
+  token: null,
   id: null,
   createdAt: null,
   updatedAt: null,
   firebaseUid: null,
-  token: null,
   name: null,
   email: null,
   partnerAccessCode: null,
@@ -36,7 +38,14 @@ const slice = createSlice({
     clearUserSlice: (state) => {
       state = initialState;
     },
+    setToken(state, action: PayloadAction<string>) {
+      state.token = action.payload;
+    },
+    setLoading(state, action: PayloadAction<boolean>) {
+      state.loading = action.payload;
+    },
   },
+
   extraReducers: (builder) => {
     builder.addMatcher(api.endpoints.addUser.matchFulfilled, (state, { payload }) => {
       return payload.user;
@@ -48,6 +57,6 @@ const slice = createSlice({
 });
 
 const { actions, reducer } = slice;
-export const { clearUserSlice } = actions;
+export const { clearUserSlice, setToken, setLoading } = actions;
 export const selectCurrentUser = (state: RootState) => state.user;
 export default reducer;

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 import * as React from 'react';
 import { useState } from 'react';
 import { useGetUserMutation } from '../app/api';
+import { setToken } from '../app/userSlice';
 import Link from '../components/Link';
 import { auth } from '../config/firebase';
 import rollbar from '../config/rollbar';
@@ -18,6 +19,7 @@ import {
   LOGIN_REQUEST,
   LOGIN_SUCCESS,
 } from '../constants/events';
+import { useAppDispatch } from '../hooks/store';
 import { getErrorMessage } from '../utils/errorMessage';
 import logEvent, { getEventUserData } from '../utils/logEvent';
 
@@ -37,6 +39,7 @@ const LoginForm = () => {
   const [emailInput, setEmailInput] = useState<string>('');
   const [passwordInput, setPasswordInput] = useState<string>('');
   const [getUser, { isLoading: getUserIsLoading }] = useGetUserMutation();
+  const dispatch: any = useAppDispatch();
 
   const submitHandler = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -46,13 +49,14 @@ const LoginForm = () => {
     auth
       .signInWithEmailAndPassword(emailInput, passwordInput)
       .then(async (userCredential) => {
-        const user = userCredential.user;
-        const token = await user?.getIdToken();
-        if (token) {
-          localStorage.setItem('accessToken', token);
-        }
         logEvent(LOGIN_SUCCESS);
         logEvent(GET_USER_REQUEST);
+
+        const token = await userCredential.user?.getIdToken();
+
+        if (token) {
+          await dispatch(setToken(token));
+        }
 
         const userResponse = await getUser('');
 

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/router';
 import * as React from 'react';
 import { useState } from 'react';
 import { useGetUserMutation } from '../app/api';
-import { setToken } from '../app/userSlice';
+import { setUserToken } from '../app/userSlice';
 import Link from '../components/Link';
 import { auth } from '../config/firebase';
 import rollbar from '../config/rollbar';
@@ -55,7 +55,7 @@ const LoginForm = () => {
         const token = await userCredential.user?.getIdToken();
 
         if (token) {
-          await dispatch(setToken(token));
+          await dispatch(setUserToken(token));
         }
 
         const userResponse = await getUser('');

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -11,7 +11,7 @@ import { useRouter } from 'next/router';
 import * as React from 'react';
 import { useState } from 'react';
 import { useAddUserMutation, useValidateCodeMutation } from '../app/api';
-import { setToken } from '../app/userSlice';
+import { setUserToken } from '../app/userSlice';
 import Link from '../components/Link';
 import { auth } from '../config/firebase';
 import rollbar from '../config/rollbar';
@@ -99,7 +99,7 @@ const RegisterForm = () => {
       .createUserWithEmailAndPassword(emailInput, passwordInput)
       .then(async (userCredential) => {
         if (userCredential.user) {
-          await dispatch(setToken(userCredential.user.refreshToken));
+          await dispatch(setUserToken(userCredential.user.refreshToken));
         }
         return userCredential.user;
       })

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/router';
 import * as React from 'react';
 import { useState } from 'react';
 import { useAddUserMutation, useValidateCodeMutation } from '../app/api';
+import { setToken } from '../app/userSlice';
 import Link from '../components/Link';
 import { auth } from '../config/firebase';
 import rollbar from '../config/rollbar';
@@ -24,6 +25,7 @@ import {
   VALIDATE_ACCESS_CODE_REQUEST,
   VALIDATE_ACCESS_CODE_SUCCESS,
 } from '../constants/events';
+import { useAppDispatch } from '../hooks/store';
 import { getErrorMessage } from '../utils/errorMessage';
 import logEvent, { getEventUserData } from '../utils/logEvent';
 
@@ -53,6 +55,7 @@ const RegisterForm = () => {
 
   const [createUser, { isLoading: createIsLoading }] = useAddUserMutation();
   const [validateCode, { isLoading: validateIsLoading }] = useValidateCodeMutation();
+  const dispatch: any = useAppDispatch();
 
   const validateAccessCode = async () => {
     logEvent(VALIDATE_ACCESS_CODE_REQUEST, { partner: 'bumble' });
@@ -95,12 +98,10 @@ const RegisterForm = () => {
     const firebaseUser = await auth
       .createUserWithEmailAndPassword(emailInput, passwordInput)
       .then(async (userCredential) => {
-        const user = userCredential.user;
-        const token = await user?.getIdToken();
-        if (token) {
-          localStorage.setItem('accessToken', token);
+        if (userCredential.user) {
+          await dispatch(setToken(userCredential.user.refreshToken));
         }
-        return user;
+        return userCredential.user;
       })
       .catch((error) => {
         const errorCode = error.code;

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 import * as React from 'react';
 import { RootState } from '../app/store';
+import { auth } from '../config/firebase';
 import { useTypedSelector } from '../hooks/store';
 import bloomLogo from '../public/bloom_logo.svg';
 import { rowStyle } from '../styles/common';
@@ -37,7 +38,9 @@ const TopBar = () => {
   const router = useRouter();
   const pathname = router.pathname.split('/')[1]; // e.g. courses | therapy | partner-admin
   const homepage =
-    pathname === 'partner-admin' ? '/partner-admin/create-access-code' : '/therapy/book-session';
+    pathname === 'partner-admin'
+      ? '/partner-admin/create-access-code'
+      : '/therapy/confirmed-session';
 
   const { user } = useTypedSelector((state: RootState) => state);
 
@@ -48,7 +51,7 @@ const TopBar = () => {
         <Link href={homepage} aria-label={t('home')} sx={logoContainerStyle}>
           <Image alt={tS('alt.bloomLogo')} src={bloomLogo} layout="fill" objectFit="contain" />
         </Link>
-        {user.id && localStorage.getItem('accessToken') && <UserMenu />}
+        {user.id && auth.currentUser && <UserMenu />}
         {/* {!isSmallScreen && <NavigationMenu />} */}
         {/* <LanguageMenu /> */}
       </Container>

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -24,7 +24,6 @@ export default function UserMenu() {
   };
 
   const logout = async () => {
-    localStorage.removeItem('accessToken');
     await clearStore();
     auth.signOut();
     router.push('/auth/login');

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/jest": "^27.0.2",
     "@types/react": "17.0.27",
     "babel-jest": "^27.2.4",
+    "lodash": "^4.17.21",
     "eslint": "7.32.0",
     "eslint-config-next": "11.1.2",
     "eslint-config-prettier": "^8.3.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,7 +8,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { wrapper } from '../app/store';
-import { setLoading, setToken } from '../app/userSlice';
+import { setUserLoading, setUserToken } from '../app/userSlice';
 import Footer from '../components/Footer';
 import LeaveSiteButton from '../components/LeaveSiteButton';
 import TopBar from '../components/TopBar';
@@ -45,14 +45,13 @@ function MyApp(props: MyAppProps) {
   const pathname = router.pathname.split('/')[1]; // e.g. courses | therapy | partner-admin
 
   useEffect(() => {
-    auth.onAuthStateChanged(async function (user) {
-      if (user) {
-        // Gets current (or refreshed if expired) firebase token
-        const token = await user.getIdToken();
-        await dispatch(setToken(token));
-      }
+    auth.onIdTokenChanged(async function (user) {
+      const token = await user?.getIdToken();
 
-      dispatch(setLoading(false));
+      if (token) {
+        await dispatch(setUserToken(token));
+      }
+      dispatch(setUserLoading(false));
     });
   }, [dispatch]);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,15 +1,20 @@
 import { CacheProvider, EmotionCache } from '@emotion/react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
+// Import the functions you need from the SDKs you need
 import { NextIntlProvider } from 'next-intl';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { wrapper } from '../app/store';
+import { setLoading, setToken } from '../app/userSlice';
 import Footer from '../components/Footer';
 import LeaveSiteButton from '../components/LeaveSiteButton';
 import TopBar from '../components/TopBar';
 import createEmotionCache from '../config/emotionCache';
+import { auth } from '../config/firebase';
+import { useAppDispatch } from '../hooks/store';
 import '../styles/globals.css';
 import theme from '../styles/theme';
 import { AuthGuard } from '../utils/authGuard';
@@ -35,8 +40,21 @@ function MyApp(props: MyAppProps) {
     pageProps: any;
   } = props;
 
+  const dispatch: any = useAppDispatch();
   const router = useRouter();
   const pathname = router.pathname.split('/')[1]; // e.g. courses | therapy | partner-admin
+
+  useEffect(() => {
+    auth.onAuthStateChanged(async function (user) {
+      if (user) {
+        // Gets current (or refreshed if expired) firebase token
+        const token = await user.getIdToken();
+        await dispatch(setToken(token));
+      }
+
+      dispatch(setLoading(false));
+    });
+  }, [dispatch]);
 
   // Adds required permissions guard to pages, redirecting where required permissions are missing
   // New pages will default to requiring authenticated and public pages must be added to the array below

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -45,6 +45,8 @@ function MyApp(props: MyAppProps) {
   const pathname = router.pathname.split('/')[1]; // e.g. courses | therapy | partner-admin
 
   useEffect(() => {
+    // Add listener for new firebase auth token, updating it in state to be used in request headers
+    // Required for restoring user state following app reload or revisiting site
     auth.onIdTokenChanged(async function (user) {
       const token = await user?.getIdToken();
 

--- a/utils/authGuard.tsx
+++ b/utils/authGuard.tsx
@@ -14,6 +14,7 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
   const router = useRouter();
   const { user, partnerAccesses } = useTypedSelector((state: RootState) => state);
   const [verified, setVerified] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const loadingContainerStyle = {
     display: 'flex',
@@ -27,7 +28,6 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
 
   useEffect(() => {
     async function callGetUser() {
-      console.log('authgruard callGetUser');
       logEvent(GET_USER_REQUEST);
       const userResponse = await getUser('');
 
@@ -42,14 +42,15 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
 
         router.replace('/auth/login');
       }
+      setLoading(false);
+    }
+
+    if (loading || user.loading) {
+      return;
     }
 
     if (user.id) {
       setVerified(true);
-      return;
-    }
-
-    if (user.loading) {
       return;
     }
 
@@ -58,10 +59,11 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
       return;
     }
 
+    setLoading(true);
     callGetUser();
-  }, [getUser, router, user]);
+  }, [getUser, router, user, loading]);
 
-  if (user.loading || !verified) {
+  if (!verified) {
     return (
       <Container sx={loadingContainerStyle}>
         <CircularProgress color="error" />

--- a/utils/delay.tsx
+++ b/utils/delay.tsx
@@ -1,0 +1,3 @@
+export function delay(time: number) {
+  return new Promise((resolve) => setTimeout(resolve, time));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4494,7 +4494,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@4.x, lodash@^4.17.15, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Refactors AuthGuard and baseQuery to refresh the firebase user token if expired, and restore the user data again.
Handles app reloads and revisiting the app after e.g. a day.

The token passed to request headers is now loaded from state, not localstorage