### PR TITLE
Refactor - remove unnecessary typography body1

### DIFF
--- a/components/CourseCard.tsx
+++ b/components/CourseCard.tsx
@@ -88,9 +88,7 @@ const CourseCard = (props: CourseCardProps) => {
                 {courseProgress === PROGRESS_STATUS.COMPLETED && (
                   <CheckCircleIcon color="error"></CheckCircleIcon>
                 )}
-                <Typography component="p" variant="body1">
-                  {courseProgress}
-                </Typography>
+                <Typography>{courseProgress}</Typography>
               </Box>
             )}
           </Box>

--- a/components/CourseIntroduction.tsx
+++ b/components/CourseIntroduction.tsx
@@ -52,14 +52,10 @@ const CourseIntroduction = (props: CourseIntroductionProps) => {
         <Typography component="h2" variant="h2">
           {t('courseDetail.introductionTitle')}
         </Typography>
-        <Typography component="p" variant="body1">
+        <Typography>
           {t.rich('courseDetail.introductionDescription', {
             transcriptLink: (children) => (
-              <MuiLink
-                component="button"
-                variant="body1"
-                onClick={() => setOpenTranscriptModal(true)}
-              >
+              <MuiLink component="button" onClick={() => setOpenTranscriptModal(true)}>
                 {children}
               </MuiLink>
             ),

--- a/components/CreateAccessCodeForm.tsx
+++ b/components/CreateAccessCodeForm.tsx
@@ -122,12 +122,12 @@ const CreateAccessCodeForm = (props: CreateAccessCodeFormProps) => {
           ? t('liveChatAccess')
           : t('therapyAccess')}
       </Typography>
-      <Typography variant="body1" component="p">
+      <Typography>
         {t.rich('resultLink', {
           welcomeURL: (children) => <Link href={welcomeURL}>{welcomeURL}</Link>,
         })}
       </Typography>
-      <Typography variant="body1" component="p">
+      <Typography>
         {t.rich('resultCode', {
           partnerAccessCode: (children) => <strong>{partnerAccessCode}</strong>,
         })}
@@ -166,7 +166,7 @@ const CreateAccessCodeForm = (props: CreateAccessCodeFormProps) => {
       </FormControl>
 
       {formError && (
-        <Typography variant="body1" component="p" color="error.main" mt={2}>
+        <Typography color="error.main" mt={2}>
           {formError}
         </Typography>
       )}

--- a/components/Faqs.tsx
+++ b/components/Faqs.tsx
@@ -39,7 +39,7 @@ const Faqs = (props: FaqsProps) => {
             aria-controls={`panel${i}-content`}
             id={`panel${i}-header`}
           >
-            <Typography variant="body1" component="h3">
+            <Typography component="h3">
               {t.rich(faq.title, {
                 partnerName: partnerName,
               })}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -175,9 +175,7 @@ const Footer = () => {
       })}
 
       <Box sx={descriptionContainerStyle}>
-        <Typography variant="body1" component="p" sx={{ mb: 1 }}>
-          {tS('footer.chaynDescription')}
-        </Typography>
+        <Typography sx={{ mb: 1 }}>{tS('footer.chaynDescription')}</Typography>
         <Link href="#">{tS('footer.policies')}</Link>
       </Box>
     </Container>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -78,9 +78,7 @@ const Header = (props: HeaderProps) => {
           <Typography variant="h1" component="h1">
             {title}
           </Typography>
-          <Typography variant="body1" component="p">
-            {introduction}
-          </Typography>
+          <Typography>{introduction}</Typography>
         </Box>
         {progressStatus && <ProgressStatus status={progressStatus} />}
       </Box>

--- a/components/ImageTextGrid.tsx
+++ b/components/ImageTextGrid.tsx
@@ -55,9 +55,7 @@ const ImageTextGrid = (props: ImageTextGridProps) => {
               objectFit="contain"
             />
           </Box>
-          <Typography variant="body1" component="p">
-            {t(item.text)}
-          </Typography>
+          <Typography>{t(item.text)}</Typography>
         </Box>
       ))}
     </Box>

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -119,7 +119,7 @@ const LoginForm = () => {
           required
         />
         {formError && (
-          <Typography variant="body1" component="p" color="error.main" mb={2}>
+          <Typography color="error.main" mb={2}>
             {formError}
           </Typography>
         )}

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -221,7 +221,7 @@ const RegisterForm = (props: RegisterFormProps) => {
           required
         />
         {formError && (
-          <Typography variant="body1" component="p" color="error.main" mb={2}>
+          <Typography color="error.main" mb={2}>
             {formError}
           </Typography>
         )}

--- a/components/ResetPasswordForm.tsx
+++ b/components/ResetPasswordForm.tsx
@@ -53,9 +53,7 @@ export const EmailForm = () => {
   };
   return (
     <Box>
-      <Typography variant="body1" component="p" mb={2}>
-        {t('resetPasswordStep1')}
-      </Typography>
+      <Typography mb={2}>{t('resetPasswordStep1')}</Typography>
       <form autoComplete="off" onSubmit={sendResetEmailSubmit}>
         <TextField
           id="email"
@@ -66,7 +64,7 @@ export const EmailForm = () => {
           required
         />
         {formError && (
-          <Typography variant="body1" component="p" color="error.main" mb={2}>
+          <Typography color="error.main" mb={2}>
             {formError}
           </Typography>
         )}
@@ -83,9 +81,7 @@ export const EmailForm = () => {
           </Button>
         ) : (
           <Box>
-            <Typography variant="body1" component="p" mb={2}>
-              {t('resetPasswordSent')}
-            </Typography>
+            <Typography mb={2}>{t('resetPasswordSent')}</Typography>
             <Button
               sx={{ mt: 2, mr: 1.5 }}
               variant="contained"
@@ -154,9 +150,7 @@ export const PasswordForm = (props: PasswordFormProps) => {
   if (formSuccess) {
     return (
       <Box>
-        <Typography variant="body1" component="p" mb={2}>
-          {t('passwordResetSuccess')}
-        </Typography>
+        <Typography mb={2}>{t('passwordResetSuccess')}</Typography>
         <Button
           sx={{ mt: 2, mr: 1.5 }}
           variant="contained"
@@ -173,9 +167,7 @@ export const PasswordForm = (props: PasswordFormProps) => {
 
   return (
     <Box>
-      <Typography variant="body1" component="p" mb={2}>
-        {t('resetPasswordStep2')}
-      </Typography>
+      <Typography mb={2}>{t('resetPasswordStep2')}</Typography>
       <form autoComplete="off" onSubmit={resetPasswordSubmit}>
         <TextField
           id="password"
@@ -187,7 +179,7 @@ export const PasswordForm = (props: PasswordFormProps) => {
           required
         />
         {formError && (
-          <Typography variant="body1" component="p" color="error.main" mb={2}>
+          <Typography color="error.main" mb={2}>
             {formError}
           </Typography>
         )}

--- a/components/SessionCard.tsx
+++ b/components/SessionCard.tsx
@@ -81,7 +81,7 @@ const SessionCard = (props: SessionCardProps) => {
               {session.content.name}
             </Typography>
           </Box>
-          <Typography component="p" variant="body1" color="grey.700">
+          <Typography color="grey.700">
             {t('session')} {session.position / 10 - 1}
           </Typography>
         </CardContent>

--- a/components/VideoTranscriptModal.tsx
+++ b/components/VideoTranscriptModal.tsx
@@ -66,7 +66,7 @@ const VideoTranscriptModal = (props: TranscriptModalProps) => {
           <Typography id="modal-title" component="h2" variant="h2">
             {tS('videoTranscript.title')}
           </Typography>
-          <Typography id="modal-description" component="p" variant="body1" fontStyle="italic">
+          <Typography id="modal-description" fontStyle="italic">
             {tS('videoTranscript.description')}
             {videoName}
           </Typography>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -51,7 +51,7 @@ const Custom404: NextPage = () => {
       <Typography variant="h1" component="h1">
         {t('404.title')}
       </Typography>
-      <Typography variant="body1" component="p">
+      <Typography>
         {user.token ? t('404.authenticatedDescription') : t('404.unauthenticatedDescription')}
       </Typography>
       <Button

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -51,9 +51,7 @@ const Custom500: NextPage = () => {
       <Typography variant="h1" component="h1">
         {t('500.title')}
       </Typography>
-      <Typography variant="body1" component="p">
-        {t('500.description')}
-      </Typography>
+      <Typography>{t('500.description')}</Typography>
       <Button
         sx={{ mt: 3 }}
         variant="contained"

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -107,12 +107,10 @@ const Login: NextPage = () => {
             <Typography variant="h2" component="h2">
               {t('login.title')}
             </Typography>
-            <Typography variant="body1" component="p">
-              {t('login.description')}
-            </Typography>
+            <Typography>{t('login.description')}</Typography>
 
             <LoginForm />
-            <Typography variant="body1" component="p" textAlign="center">
+            <Typography textAlign="center">
               {t.rich('login.resetPasswordLink', {
                 resetLink: (children) => <Link href="/auth/reset-password">{children}</Link>,
               })}

--- a/pages/auth/register.tsx
+++ b/pages/auth/register.tsx
@@ -140,9 +140,7 @@ const Register: NextPage = () => {
               <Typography variant="h2" component="h2">
                 {t('register.title')}
               </Typography>
-              <Typography variant="body1" component="p">
-                {t('register.description')}
-              </Typography>
+              <Typography>{t('register.description')}</Typography>
 
               <RegisterForm codeParam={codeParam} partnerContent={partnerContent} />
 

--- a/pages/courses/[slug].tsx
+++ b/pages/courses/[slug].tsx
@@ -144,7 +144,7 @@ const CourseOverview: NextPage<Props> = ({ story, preview, sbParams, messages, l
         <Typography variant="h2" component="h2" mb={2}>
           {t('accessGuard.title')}
         </Typography>
-        <Typography variant="body1" component="p" mb={2}>
+        <Typography mb={2}>
           {t.rich('accessGuard.introduction', {
             contactLink: (children) => <Link href="/courses">{children}</Link>,
           })}

--- a/pages/courses/[slug]/[sessionSlug].tsx
+++ b/pages/courses/[slug]/[sessionSlug].tsx
@@ -289,7 +289,6 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, messages, lo
                           transcriptLink: (children) => (
                             <MuiLink
                               component="button"
-                              variant="body1"
                               onClick={() => setOpenTranscriptModal(true)}
                             >
                               {children}
@@ -381,11 +380,7 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, messages, lo
                   </>
                 )}
 
-                {error && (
-                  <Typography sx={errorStyle} variant="body1">
-                    {error}
-                  </Typography>
-                )}
+                {error && <Typography sx={errorStyle}>{error}</Typography>}
               </Box>
             )}
           </Container>

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -131,9 +131,7 @@ const CourseList: NextPage<Props> = ({ stories, preview, messages }) => {
           </Box>
         ) : loadedCourses.length === 0 ? (
           <Box>
-            <Typography component="p" variant="body1">
-              {t('noCourses')}
-            </Typography>
+            <Typography>{t('noCourses')}</Typography>
           </Box>
         ) : (
           <Box sx={cardsContainerStyle}>

--- a/pages/partner-admin/create-access-code.tsx
+++ b/pages/partner-admin/create-access-code.tsx
@@ -57,9 +57,7 @@ const CreateAccessCode: NextPage = () => {
             <Typography variant="h2" component="h2">
               {t('title')}
             </Typography>
-            <Typography variant="body1" component="p" mb={2}>
-              {t('introduction')}
-            </Typography>
+            <Typography mb={2}>{t('introduction')}</Typography>
 
             <CreateAccessCodeForm partnerAdmin={partnerAdmin} />
           </CardContent>

--- a/pages/therapy/book-session.tsx
+++ b/pages/therapy/book-session.tsx
@@ -133,7 +133,7 @@ const BookSession: NextPage = () => {
       />
       <Container sx={containerStyle}>
         <Box sx={ctaContent}>
-          <Typography variant="body1" component="p">
+          <Typography>
             {hasTherapyRemaining
               ? t.rich('therapySessionsRemaining', {
                   strongText: () => <strong>{partnerAccess?.therapySessionsRemaining}</strong>,

--- a/pages/therapy/confirmed-session.tsx
+++ b/pages/therapy/confirmed-session.tsx
@@ -74,10 +74,8 @@ const ConfirmedSession: NextPage = () => {
         imageAlt={headerProps.imageAlt}
       />
       <Container sx={containerStyle}>
-        <Typography variant="body1" component="p">
-          {t('confirmation.returnDescription')}
-        </Typography>
-        <Typography variant="body1" component="p">
+        <Typography>{t('confirmation.returnDescription')}</Typography>
+        <Typography>
           {t.rich('confirmation.bookmarkDescription', {
             bookingLink: (children) => (
               <Link href={`${process.env.NEXT_PUBLIC_BASE_URL}/`}>{children}</Link>

--- a/pages/welcome.tsx
+++ b/pages/welcome.tsx
@@ -106,9 +106,7 @@ const Welcome: NextPage = () => {
             <Typography variant="h2" component="h2">
               {t('getStarted')}
             </Typography>
-            <Typography variant="body1" component="p">
-              {t('accessIntroduction')}
-            </Typography>
+            <Typography>{t('accessIntroduction')}</Typography>
 
             <CodeForm codeParam={codeParam} partnerParam={partnerParam} />
           </CardContent>
@@ -122,13 +120,11 @@ const Welcome: NextPage = () => {
           <Typography variant="h2" component="h2">
             {t('programTitle')}
           </Typography>
-          <Typography variant="body1" component="p">
-            {t('programIntroduction')}
-          </Typography>
+          <Typography>{t('programIntroduction')}</Typography>
         </Box>
       </Container>
       <Container sx={{ backgroundColor: 'common.white' }}>
-        <Typography sx={resourcesStyle} variant="body1" component="p">
+        <Typography sx={resourcesStyle}>
           {t.rich('resourcesIntroduction', {
             resourcesLink: (children) => (
               <Link target={'_blank'} href="https://www.chayn.co/bumble-resources">
@@ -146,7 +142,7 @@ const Welcome: NextPage = () => {
           <Typography variant="h2" component="h2">
             {t('bloomTitle')}
           </Typography>
-          <Typography variant="body1" component="p">
+          <Typography>
             {t.rich('bloomIntroduction', {
               bloomLink: (children) => <Link href="https://chayn.co/">{children}</Link>,
             })}
@@ -169,7 +165,7 @@ const Welcome: NextPage = () => {
           <Typography variant="h2" component="h2">
             {t('bumbleTitle')}
           </Typography>
-          <Typography variant="body1" component="p">
+          <Typography>
             {t.rich('bumbleIntroduction', {
               bumbleLink: (children) => (
                 <Link href="https://bumble.com/?pid=press&c=press-release">{children}</Link>

--- a/utils/partnerAdminGuard.tsx
+++ b/utils/partnerAdminGuard.tsx
@@ -42,7 +42,7 @@ export function PartnerAdminGuard({ children }: { children: JSX.Element }) {
         <Typography variant="h2" component="h2" mb={2}>
           {t('title')}
         </Typography>
-        <Typography variant="body1" component="p" mb={2}>
+        <Typography mb={2}>
           {t.rich('introduction', {
             contactLink: (children) => (
               <Link href="https://chayn.typeform.com/to/OY9Wdk4h">{children}</Link>

--- a/utils/therapyAccessGuard.tsx
+++ b/utils/therapyAccessGuard.tsx
@@ -46,7 +46,7 @@ export function TherapyAccessGuard({ children }: { children: JSX.Element }) {
         <Typography variant="h2" component="h2" mb={2}>
           {t('title')}
         </Typography>
-        <Typography variant="body1" component="p" mb={2}>
+        <Typography mb={2}>
           {t.rich('introduction', {
             contactLink: (children) => (
               <Link href="https://chayn.typeform.com/to/OY9Wdk4h">{children}</Link>


### PR DESCRIPTION
The default for the MUI `<Typography>` component is `component="p" variant="body1"`. So we don't need to include these. This PR removes this unnecessary code throughout the codebase