### PR TITLE
Redirect to original url after authguard login

### DIFF
--- a/components/forms/LoginForm.tsx
+++ b/components/forms/LoginForm.tsx
@@ -62,7 +62,15 @@ const LoginForm = () => {
 
         if ('data' in userResponse) {
           logEvent(GET_USER_SUCCESS, { ...getEventUserData(userResponse.data) });
-          if (userResponse.data.partnerAdmin?.id) {
+
+          // Checking if the query type is a string to keep typescript happy
+          // because a query value can be an array
+          const returnUrl =
+            typeof router.query.return_url === 'string' ? router.query.return_url : null;
+
+          if (returnUrl) {
+            router.push(returnUrl);
+          } else if (userResponse.data.partnerAdmin?.id) {
             router.push('/partner-admin/create-access-code');
           } else {
             router.push('/courses');

--- a/guards/authGuard.tsx
+++ b/guards/authGuard.tsx
@@ -8,8 +8,8 @@ import rollbar from '../config/rollbar';
 import { GET_USER_ERROR, GET_USER_REQUEST, GET_USER_SUCCESS } from '../constants/events';
 import { useTypedSelector } from '../hooks/store';
 import { getErrorMessage } from '../utils/errorMessage';
+import generateReturnQuery from '../utils/generateReturnQuery';
 import logEvent, { getEventUserData } from '../utils/logEvent';
-import generateReturnQuery from './generateReturnQuery';
 
 export function AuthGuard({ children }: { children: JSX.Element }) {
   const router = useRouter();

--- a/guards/authGuard.tsx
+++ b/guards/authGuard.tsx
@@ -9,6 +9,7 @@ import { GET_USER_ERROR, GET_USER_REQUEST, GET_USER_SUCCESS } from '../constants
 import { useTypedSelector } from '../hooks/store';
 import { getErrorMessage } from '../utils/errorMessage';
 import logEvent, { getEventUserData } from '../utils/logEvent';
+import generateReturnQuery from './generateReturnQuery';
 
 export function AuthGuard({ children }: { children: JSX.Element }) {
   const router = useRouter();
@@ -32,7 +33,7 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
           logEvent(GET_USER_ERROR, { message: getErrorMessage(userResponse.error) });
         }
 
-        router.replace('/auth/login');
+        router.replace(`/auth/login${generateReturnQuery(router.pathname)}`);
       }
     }
 
@@ -51,7 +52,7 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
     }
 
     if (!user.token) {
-      router.replace('/auth/login');
+      router.replace(`/auth/login${generateReturnQuery(router.pathname)}`);
       return;
     }
 

--- a/utils/generateReturnQuery.ts
+++ b/utils/generateReturnQuery.ts
@@ -1,0 +1,3 @@
+export default function generateReturnUrlQuery(pathname: string) {
+  return `?return_url=${encodeURIComponent(pathname)}`;
+}


### PR DESCRIPTION
See https://www.notion.so/chayn/Redirect-after-login-f7442ca310d1450d8d79463d3cf6aba3 for ticket

- Note the choice of underscore was to avoid having to do router.query['return-url']. 
- Have dropped the requirement to do it after password reset as it adds alot of complexity