### PR TITLE
Build welcome fix

### DIFF
--- a/components/layout/NavigationMenu.tsx
+++ b/components/layout/NavigationMenu.tsx
@@ -70,7 +70,7 @@ const NavigationMenu = () => {
       links.push({ title: t('therapy'), href: '/therapy/book-session' });
     }
     setNavigationLinks(links);
-  }, [partnerAccesses, t]);
+  }, [partnerAccesses, t, user.token, partnerAdmin]);
 
   return (
     <List sx={listStyle}>

--- a/next.config.js
+++ b/next.config.js
@@ -26,13 +26,4 @@ module.exports = withPWA({
     dest: 'public',
     skipWaiting: true,
   },
-  async redirects() {
-    return [
-      {
-        source: '/',
-        destination: '/therapy/book-session',
-        permanent: false,
-      },
-    ];
-  },
 });

--- a/pages/action-handler.tsx
+++ b/pages/action-handler.tsx
@@ -1,4 +1,4 @@
-import { NextPage } from 'next';
+import { GetStaticPropsContext, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import LoadingContainer from '../components/common/LoadingContainer';
 
@@ -16,5 +16,16 @@ const ActionHandler: NextPage = () => {
   }
   return <LoadingContainer />;
 };
+
+export function getStaticProps({ locale }: GetStaticPropsContext) {
+  return {
+    props: {
+      messages: {
+        ...require(`../messages/shared/${locale}.json`),
+        ...require(`../messages/navigation/${locale}.json`),
+      },
+    },
+  };
+}
 
 export default ActionHandler;

--- a/pages/courses/[slug].tsx
+++ b/pages/courses/[slug].tsx
@@ -208,6 +208,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
     ...extraSbParams,
     version: preview ? 'draft' : 'published',
     cv: preview ? Date.now() : 0,
+    language: locale,
   };
 
   let { data } = await Storyblok.get(`cdn/stories/courses/${slug}`, sbParams);

--- a/pages/courses/[slug]/[sessionSlug].tsx
+++ b/pages/courses/[slug]/[sessionSlug].tsx
@@ -403,6 +403,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
     ...extraSbParams,
     version: preview ? 'draft' : 'published',
     cv: preview ? Date.now() : 0,
+    language: locale,
   };
 
   let { data } = await Storyblok.get(`cdn/stories/courses/${slug}/${sessionSlug}/`, sbParams);

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -158,6 +158,7 @@ const CourseList: NextPage<Props> = ({ stories, preview, messages, locale }) => 
 
 export async function getStaticProps({ locale, preview = false }: GetStaticPropsContext) {
   let sbParams = {
+    language: locale,
     version: preview ? 'draft' : 'published',
     cv: preview ? Date.now() : 0,
     starts_with: 'courses/',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,6 @@ import type { NextPage } from 'next';
 import { GetStaticPropsContext } from 'next';
 import { useTranslations } from 'next-intl';
 import Head from 'next/head';
-import { useRouter } from 'next/router';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
 import { RootState } from '../app/store';
 import Link from '../components/common/Link';
@@ -39,9 +38,8 @@ interface Props {
   locale: LANGUAGES;
 }
 
-const Welcome: NextPage<Props> = ({ story, preview, sbParams, messages, locale }) => {
+const Index: NextPage<Props> = ({ story, preview, sbParams, messages, locale }) => {
   const t = useTranslations('Welcome');
-  const router = useRouter();
   const { user } = useTypedSelector((state: RootState) => state);
 
   story = useStoryblok(story, preview, sbParams, locale);
@@ -127,14 +125,16 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     version: preview ? 'draft' : 'published',
     cv: preview ? Date.now() : 0,
+    language: locale,
   };
 
-  let { data } = await Storyblok.get(`cdn/stories/welcome`, sbParams);
+  let { data } = await Storyblok.get(`cdn/stories/home`, sbParams);
 
   return {
     props: {
       story: data ? data.story : null,
       preview,
+      sbParams,
       messages: {
         ...require(`../messages/shared/${locale}.json`),
         ...require(`../messages/navigation/${locale}.json`),
@@ -146,4 +146,4 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   };
 }
 
-export default Welcome;
+export default Index;

--- a/pages/meet-the-team.tsx
+++ b/pages/meet-the-team.tsx
@@ -165,6 +165,7 @@ export async function getStaticProps({ locale, preview = false }: GetStaticProps
   let sbParams = {
     version: preview ? 'draft' : 'published',
     cv: preview ? Date.now() : 0,
+    language: locale,
   };
 
   let { data } = await Storyblok.get(`cdn/stories/meet-the-team`, sbParams);
@@ -176,7 +177,6 @@ export async function getStaticProps({ locale, preview = false }: GetStaticProps
       messages: {
         ...require(`../messages/shared/${locale}.json`),
         ...require(`../messages/navigation/${locale}.json`),
-        ...require(`../messages/courses/${locale}.json`),
       },
       locale,
     },

--- a/pages/welcome/[partnerName].tsx
+++ b/pages/welcome/[partnerName].tsx
@@ -132,6 +132,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     version: preview ? 'draft' : 'published',
     cv: preview ? Date.now() : 0,
+    language: locale,
   };
 
   let { data } = await Storyblok.get(`cdn/stories/welcome/${partnerName}`, sbParams);
@@ -163,7 +164,7 @@ export async function getStaticPaths({ locales }: GetStaticPathsContext) {
     if (locales) {
       // create additional languages
       for (const locale of locales) {
-        paths.push({ params: { slug: splittedSlug[1] }, locale });
+        paths.push({ params: { partnerName: splittedSlug[1] }, locale });
       }
     }
   });


### PR DESCRIPTION
Moved the public welcome in storyblok to the top level, as it was causing issues on `welcome/[partnerName]`

Multiple other fixes found whilst bug hunting - including including the language locale in the call to storyblok