### PR TITLE
Remove "about" link from nav bar

### DIFF
--- a/components/layout/NavigationMenu.tsx
+++ b/components/layout/NavigationMenu.tsx
@@ -51,17 +51,7 @@ const NavigationMenu = (props: NavigationMenuProps) => {
     let links: Array<NavigationItem> = [];
 
     if (partnerAdmin && partnerAdmin.partner) {
-      const partnerName = partnerAdmin.partner.name.toLocaleLowerCase();
       links.push({ title: t('admin'), href: '/partner-admin/create-access-code' });
-      links.push({
-        title: t('about'),
-        href: `/welcome/${partnerName}`,
-      });
-    } else {
-      links.push({
-        title: t('about'),
-        href: '/',
-      });
     }
 
     if (user.token) {


### PR DESCRIPTION
Currently, the "about" link shows information which is correct for
public users but not bumble users. Since both types of users are
shown this page, bumble users might find it confusing.

The temporary fix is to remove the "about" link.