### PR TITLE
Add email field type

### DIFF
--- a/components/forms/LoginForm.tsx
+++ b/components/forms/LoginForm.tsx
@@ -114,6 +114,7 @@ const LoginForm = () => {
           onChange={(e) => setEmailInput(e.target.value)}
           label={t('emailLabel')}
           variant="standard"
+          type="email"
           fullWidth
           required
         />

--- a/components/forms/RegisterForm.tsx
+++ b/components/forms/RegisterForm.tsx
@@ -208,6 +208,7 @@ const RegisterForm = (props: RegisterFormProps) => {
           onChange={(e) => setEmailInput(e.target.value)}
           label={t('emailLabel')}
           variant="standard"
+          type="email"
           fullWidth
           required
         />

--- a/components/forms/ResetPasswordForm.tsx
+++ b/components/forms/ResetPasswordForm.tsx
@@ -60,6 +60,7 @@ export const EmailForm = () => {
           onChange={(e) => setEmailInput(e.target.value)}
           label={t('emailLabel')}
           variant="standard"
+          type="email"
           fullWidth
           required
         />


### PR DESCRIPTION
Previously missed adding the field type to the `TextField` component for email fields.