### PR TITLE
For course url, redirect to /courses in authguard

### DIFF
--- a/utils/generateReturnQuery.ts
+++ b/utils/generateReturnQuery.ts
@@ -1,3 +1,5 @@
 export default function generateReturnUrlQuery(pathname: string) {
-  return `?return_url=${encodeURIComponent(pathname)}`;
+  return pathname.indexOf('/courses/') > -1
+    ? `?return_url=${encodeURIComponent('/courses')}`
+    : `?return_url=${encodeURIComponent(pathname)}`;
 }


### PR DESCRIPTION
Just a quick fix to cover the bug I created. I cannot use `router.pathname` to get the course slug. For now I am just going to redirect to courses but this can be improved. 