### PR TITLE
Fix logout state

### DIFF
--- a/app/coursesSlice.tsx
+++ b/app/coursesSlice.tsx
@@ -68,7 +68,7 @@ const slice = createSlice({
   initialState: initialState,
   reducers: {
     clearCoursesSlice: (state) => {
-      state = initialState;
+      return initialState;
     },
   },
   extraReducers: (builder) => {

--- a/app/partnerAccessSlice.tsx
+++ b/app/partnerAccessSlice.tsx
@@ -42,7 +42,7 @@ const slice = createSlice({
   initialState: initialState,
   reducers: {
     clearPartnerAccessesSlice: (state) => {
-      state = initialState;
+      return initialState;
     },
   },
   extraReducers: (builder) => {

--- a/app/partnerAdminSlice.tsx
+++ b/app/partnerAdminSlice.tsx
@@ -37,7 +37,7 @@ const slice = createSlice({
   initialState: initialState,
   reducers: {
     clearPartnerAdminSlice: (state) => {
-      state = initialState;
+      return initialState;
     },
   },
   extraReducers: (builder) => {

--- a/app/userSlice.tsx
+++ b/app/userSlice.tsx
@@ -36,7 +36,7 @@ const slice = createSlice({
   initialState: initialState,
   reducers: {
     clearUserSlice: (state) => {
-      state = initialState;
+      return initialState;
     },
     setUserToken(state, action: PayloadAction<string>) {
       state.token = action.payload;

--- a/components/forms/LoginForm.tsx
+++ b/components/forms/LoginForm.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/router';
 import * as React from 'react';
 import { useState } from 'react';
 import { useGetUserMutation } from '../../app/api';
-import { setUserToken } from '../../app/userSlice';
+import { setUserLoading, setUserToken } from '../../app/userSlice';
 import { auth } from '../../config/firebase';
 import rollbar from '../../config/rollbar';
 import {
@@ -51,6 +51,7 @@ const LoginForm = () => {
       .then(async (userCredential) => {
         logEvent(LOGIN_SUCCESS);
         logEvent(GET_USER_REQUEST);
+        dispatch(setUserLoading(true));
 
         const token = await userCredential.user?.getIdToken();
 
@@ -67,6 +68,7 @@ const LoginForm = () => {
           // because a query value can be an array
           const returnUrl =
             typeof router.query.return_url === 'string' ? router.query.return_url : null;
+          dispatch(setUserLoading(false));
 
           if (userResponse.data.partnerAdmin?.id) {
             router.push('/partner-admin/create-access-code');
@@ -88,6 +90,7 @@ const LoginForm = () => {
               ),
             }),
           );
+          dispatch(setUserLoading(false));
         }
       })
       .catch((error) => {

--- a/components/forms/RegisterForm.tsx
+++ b/components/forms/RegisterForm.tsx
@@ -11,7 +11,7 @@ import { useRouter } from 'next/router';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { useAddUserMutation, useValidateCodeMutation } from '../../app/api';
-import { setUserToken } from '../../app/userSlice';
+import { setUserLoading, setUserToken } from '../../app/userSlice';
 import { auth } from '../../config/firebase';
 import rollbar from '../../config/rollbar';
 import { LANGUAGES, PARTNER_ACCESS_CODE_STATUS } from '../../constants/enums';
@@ -173,8 +173,10 @@ const RegisterForm = (props: RegisterFormProps) => {
 
     try {
       partnerContent && (await validateAccessCode());
+      dispatch(setUserLoading(true));
       const firebaseUser = await createFirebaseUser();
       await createUserRecord(firebaseUser!);
+      dispatch(setUserLoading(false));
       router.push('/courses');
     } catch {
       // errors handled in each function

--- a/components/layout/NavigationMenu.tsx
+++ b/components/layout/NavigationMenu.tsx
@@ -68,7 +68,7 @@ const NavigationMenu = (props: NavigationMenuProps) => {
       links.push({ title: t('therapy'), href: '/therapy/book-session' });
     }
     setNavigationLinks(links);
-  }, [partnerAccesses, t, user.token, partnerAdmin]);
+  }, [partnerAccesses, t, user, partnerAdmin]);
 
   return (
     <List sx={listStyle} onClick={() => setAnchorEl && setAnchorEl(null)}>

--- a/components/layout/NavigationMenu.tsx
+++ b/components/layout/NavigationMenu.tsx
@@ -50,23 +50,26 @@ const NavigationMenu = (props: NavigationMenuProps) => {
   useEffect(() => {
     let links: Array<NavigationItem> = [];
 
-    if (partnerAdmin && partnerAdmin.partner) {
-      links.push({ title: t('admin'), href: '/partner-admin/create-access-code' });
+    if (!user.loading) {
+      if (partnerAdmin && partnerAdmin.partner) {
+        links.push({ title: t('admin'), href: '/partner-admin/create-access-code' });
+      }
+
+      if (user.token) {
+        links.push({ title: t('courses'), href: '/courses' });
+      } else {
+        links.push({ title: t('login'), href: '/auth/login' });
+      }
+
+      const therapyAccess = partnerAccesses.find(
+        (partnerAccess) => partnerAccess.featureTherapy === true,
+      );
+
+      if (!!therapyAccess) {
+        links.push({ title: t('therapy'), href: '/therapy/book-session' });
+      }
     }
 
-    if (user.token) {
-      links.push({ title: t('courses'), href: '/courses' });
-    } else {
-      links.push({ title: t('login'), href: '/auth/login' });
-    }
-
-    const therapyAccess = partnerAccesses.find(
-      (partnerAccess) => partnerAccess.featureTherapy === true,
-    );
-
-    if (!!therapyAccess) {
-      links.push({ title: t('therapy'), href: '/therapy/book-session' });
-    }
     setNavigationLinks(links);
   }, [partnerAccesses, t, user, partnerAdmin]);
 

--- a/components/layout/UserMenu.tsx
+++ b/components/layout/UserMenu.tsx
@@ -6,8 +6,13 @@ import MenuItem from '@mui/material/MenuItem';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import * as React from 'react';
+import { api } from '../../app/api';
+import { clearCoursesSlice } from '../../app/coursesSlice';
+import { clearPartnerAccessesSlice } from '../../app/partnerAccessSlice';
+import { clearPartnerAdminSlice } from '../../app/partnerAdminSlice';
+import { clearUserSlice } from '../../app/userSlice';
 import { auth } from '../../config/firebase';
-import { clearStore } from '../../hooks/store';
+import { useAppDispatch } from '../../hooks/store';
 
 const menuButtonStyle = {
   color: 'text.primary',
@@ -33,6 +38,7 @@ const buttonStyle = {
 export default function UserMenu() {
   const router = useRouter();
   const t = useTranslations('Navigation');
+  const dispatch: any = useAppDispatch();
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -45,8 +51,15 @@ export default function UserMenu() {
   };
 
   const logout = async () => {
-    await clearStore();
+    // clear all state
+    await dispatch(clearPartnerAccessesSlice());
+    await dispatch(clearPartnerAdminSlice());
+    await dispatch(clearCoursesSlice());
+    await dispatch(clearUserSlice());
+    await dispatch(api.util.resetApiState());
+    // sign out of firebase
     await auth.signOut();
+
     router.push('/auth/login');
   };
 

--- a/hooks/store.ts
+++ b/hooks/store.ts
@@ -1,16 +1,5 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
-import { clearCoursesSlice } from '../app/coursesSlice';
-import { clearPartnerAccessesSlice } from '../app/partnerAccessSlice';
-import { clearPartnerAdminSlice } from '../app/partnerAdminSlice';
 import type { AppDispatch, RootState } from '../app/store';
-import { clearUserSlice } from '../app/userSlice';
 
 export const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
 export const useAppDispatch = () => useDispatch<AppDispatch>();
-
-export const clearStore = async () => {
-  await clearPartnerAccessesSlice();
-  await clearPartnerAdminSlice();
-  await clearCoursesSlice();
-  await clearUserSlice();
-};

--- a/hooks/store.ts
+++ b/hooks/store.ts
@@ -9,8 +9,8 @@ export const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 
 export const clearStore = async () => {
-  clearPartnerAccessesSlice();
-  clearPartnerAdminSlice();
-  clearCoursesSlice();
-  clearUserSlice();
+  await clearPartnerAccessesSlice();
+  await clearPartnerAdminSlice();
+  await clearCoursesSlice();
+  await clearUserSlice();
 };


### PR DESCRIPTION
Previously the state wasn't being cleared on logout. This wasn't easy to detect previously, as the menu wasn't in place, so just picked up on the bug. Before these changes, when logging out, the navigation menu remained as though you were logged in, because the state wasn't being cleared. 

This change clears the state by calling the `clearNameSlice` method on each slice individually, and removes the global `clearState()` function. This fixes the dispatch issue that was causing the bug, and also allows more control in the future to e.g. not clear one of the states like a new `browser` state that includes user preferences.