### PR TITLE
Dynamic page + faq page

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Integrations are chosen with internationalisation as a priority, with Crisp and 
 
 ### Storyblok CMS
 
-Content is delivered by [Storyblok](https://www.storyblok.com/), a headless CMS that allows the team to edit and preview content as it would appear in the app, before publishing changes. . Stricter pages such as Course and Session pages, or pages with a mix of custom functionality and changing content, are handled in custom pages and components e.g. [/courses/[slug].tsx](pages/courses/[slug].tsx).
+Content is delivered by [Storyblok](https://www.storyblok.com/), a headless CMS that allows the team to edit and preview content as it would appear in the app, before publishing changes. Some pages are fully flexible, using [pages/[slug].tsx](/pages/[slug].tsx) to dynamically render components. Stricter pages such as Course and Session pages, or pages with a mix of custom functionality and changing content, are handled in custom pages and components e.g. [/courses/[slug].tsx](pages/courses/[slug].tsx).
 
 **Courses structure**
 
@@ -179,7 +179,8 @@ Storyblok components allow the team to add richtext, images, videos, page sectio
 
 **Dynamic pages**
 
-Dynamic pages allow the team to create new content pages in Storyblok e.g. `/about-topic`, without requiring developer work. Our top level dynamic route [[slug].tsx](pages/[slug].tsx) and [DynamicComponent.tsx](components/DynamicComponent.tsx) render the components on the page.
+Dynamic pages allow the team to create new content pages in Storyblok e.g. `/about-topic`, without requiring developer work*. Our top level dynamic route [[slug].tsx](pages/[slug].tsx) allows new pages to be added, with an infinite number of [StoryblokPageSection.tsx](components/storyblok/StoryblokPageSection.tsx) with nested components. [DynamicComponent.tsx](components/storyblok/DynamicComponent.tsx) can also be used to dynamically render components on a page, where the storyblok field is of type `blocks` and we don't know which blocks to expect.
+*Note: If a page is to be public/unauthenticated, it must be added to `publicPaths` in [\_app.tsx](pages/_app.tsx).
 
 ## Git flow and deployment
 

--- a/components/storyblok/DynamicComponent.tsx
+++ b/components/storyblok/DynamicComponent.tsx
@@ -11,7 +11,7 @@ import StoryblokVideo from './StoryblokVideo';
 
 interface Component {
   name: string;
-  component: any;
+  component: (props: any) => JSX.Element;
 }
 
 const components: Component[] = [

--- a/components/storyblok/DynamicComponent.tsx
+++ b/components/storyblok/DynamicComponent.tsx
@@ -1,0 +1,43 @@
+import { StoryblokComponent } from 'storyblok-js-client';
+import Placeholder from './Placeholder';
+import StoryblokButton from './StoryblokButton';
+import StoryblokCard from './StoryblokCard';
+import StoryblokFaqs from './StoryblokFaqs';
+import StoryblokImage from './StoryblokImage';
+import StoryblokPageSection from './StoryblokPageSection';
+import StoryblokQuote from './StoryblokQuote';
+import StoryblokRow from './StoryblokRow';
+import StoryblokVideo from './StoryblokVideo';
+
+interface Component {
+  name: string;
+  component: any;
+}
+
+const components: Component[] = [
+  { name: 'page_section', component: StoryblokPageSection },
+  { name: 'image', component: StoryblokImage },
+  { name: 'video', component: StoryblokVideo },
+  { name: 'row', component: StoryblokRow },
+  { name: 'quote', component: StoryblokQuote },
+  { name: 'card', component: StoryblokCard },
+  { name: 'button', component: StoryblokButton },
+  { name: 'faqs', component: StoryblokFaqs },
+];
+
+interface DynamicComponentProps {
+  blok: StoryblokComponent<string>;
+}
+
+const DynamicComponent = (props: DynamicComponentProps) => {
+  const { blok } = props;
+  const component = components.find((c) => c.name === blok.component);
+
+  if (component) {
+    const Component = component.component;
+    return <Component blok={blok} />;
+  }
+  return <Placeholder componentName={blok.component} />;
+};
+
+export default DynamicComponent;

--- a/components/storyblok/Placeholder.tsx
+++ b/components/storyblok/Placeholder.tsx
@@ -1,0 +1,20 @@
+import { Typography } from '@mui/material';
+import { Box } from '@mui/system';
+
+interface PlaceholderProps {
+  componentName: string;
+}
+
+const Placeholder = (props: PlaceholderProps) => {
+  const { componentName } = props;
+
+  return (
+    <Box>
+      <Typography>
+        The component <strong>{componentName}</strong> does not exist created yet.
+      </Typography>
+    </Box>
+  );
+};
+
+export default Placeholder;

--- a/components/storyblok/StoryblokFaqs.tsx
+++ b/components/storyblok/StoryblokFaqs.tsx
@@ -10,10 +10,6 @@ import { faqItem } from '../../constants/faqs';
 import logEvent from '../../utils/logEvent';
 import { RichTextOptions } from '../../utils/richText';
 
-const containerStyle = {
-  width: '100%',
-  maxWidth: 650,
-} as const;
 interface StoryblokFaqsProps {
   faqs: Array<faqItem>;
 }
@@ -29,7 +25,7 @@ const StoryblokFaqs = (props: StoryblokFaqsProps) => {
     };
 
   return (
-    <Box sx={containerStyle}>
+    <Box>
       {faqs.map((faq, i) => (
         <Accordion key={`panel${i}`} onChange={handleChange(faq.title)}>
           <AccordionSummary

--- a/components/storyblok/StoryblokFaqs.tsx
+++ b/components/storyblok/StoryblokFaqs.tsx
@@ -10,6 +10,10 @@ import { faqItem } from '../../constants/faqs';
 import logEvent from '../../utils/logEvent';
 import { RichTextOptions } from '../../utils/richText';
 
+const containerStyle = {
+  width: '100%',
+  maxWidth: 650,
+} as const;
 interface StoryblokFaqsProps {
   faqs: Array<faqItem>;
 }
@@ -25,7 +29,7 @@ const StoryblokFaqs = (props: StoryblokFaqsProps) => {
     };
 
   return (
-    <Box>
+    <Box sx={containerStyle}>
       {faqs.map((faq, i) => (
         <Accordion key={`panel${i}`} onChange={handleChange(faq.title)}>
           <AccordionSummary

--- a/guards/authGuard.tsx
+++ b/guards/authGuard.tsx
@@ -33,7 +33,7 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
           logEvent(GET_USER_ERROR, { message: getErrorMessage(userResponse.error) });
         }
 
-        router.replace(`/auth/login${generateReturnQuery(router.pathname)}`);
+        router.replace(`/auth/login${generateReturnQuery(router.asPath)}`);
       }
     }
 
@@ -52,7 +52,7 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
     }
 
     if (!user.token) {
-      router.replace(`/auth/login${generateReturnQuery(router.pathname)}`);
+      router.replace(`/auth/login${generateReturnQuery(router.asPath)}`);
       return;
     }
 

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -1,0 +1,103 @@
+import { Box } from '@mui/system';
+import { GetStaticPathsContext, GetStaticPropsContext, NextPage } from 'next';
+import Head from 'next/head';
+import { StoriesParams, StoryData } from 'storyblok-js-client';
+import Header from '../components/layout/Header';
+import StoryblokPageSection from '../components/storyblok/StoryblokPageSection';
+import Storyblok, { useStoryblok } from '../config/storyblok';
+import { LANGUAGES } from '../constants/enums';
+
+interface Props {
+  story: StoryData;
+  preview: boolean;
+  sbParams: StoriesParams;
+  locale: LANGUAGES;
+}
+
+const Page: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
+  story = useStoryblok(story, preview, sbParams, locale);
+
+  const headerProps = {
+    title: story.content.title,
+    introduction: story.content.description,
+    imageSrc: story.content.header_image?.filename,
+    translatedImageAlt: story.content.header_image?.alt,
+  };
+
+  return (
+    <Box>
+      <Head>{story.content.title}</Head>
+
+      <Header
+        title={headerProps.title}
+        introduction={headerProps.introduction}
+        imageSrc={headerProps.imageSrc}
+        translatedImageAlt={headerProps.translatedImageAlt}
+      />
+      {story.content.page_sections?.length > 0 &&
+        story.content.page_sections.map((section: any, index: number) => (
+          <StoryblokPageSection
+            key={`page_section_${index}`}
+            content={section.content}
+            alignment={section.alignment}
+            color={section.color}
+          />
+        ))}
+    </Box>
+  );
+};
+
+export async function getStaticProps({ locale, preview = false, params }: GetStaticPropsContext) {
+  const slug = params?.slug instanceof Array ? params.slug.join('/') : params?.slug;
+
+  const sbParams = {
+    version: preview ? 'draft' : 'published',
+    // cv: Date.now(),
+    language: locale,
+  };
+
+  let { data } = await Storyblok.get(`cdn/stories/${slug}`, sbParams);
+
+  return {
+    props: {
+      story: data ? data.story : null,
+      preview,
+      sbParams: sbParams,
+      messages: {
+        ...require(`../messages/shared/${locale}.json`),
+        ...require(`../messages/navigation/${locale}.json`),
+      },
+      locale,
+    },
+    revalidate: 3600, // revalidate every hour
+  };
+}
+
+export async function getStaticPaths({ locales }: GetStaticPathsContext) {
+  let { data } = await Storyblok.get('cdn/links/');
+
+  const excludePaths: string[] = ['home', 'welcome', 'meet-the-team', 'courses'];
+  let paths: any = [];
+  Object.keys(data.links).forEach((linkKey) => {
+    if (data.links[linkKey].is_folder) {
+      return;
+    }
+
+    const slug = data.links[linkKey].slug;
+    let splittedSlug = slug.split('/');
+
+    if (locales && !excludePaths.includes(splittedSlug[0])) {
+      // create additional languages
+      for (const locale of locales) {
+        paths.push({ params: { slug: slug }, locale });
+      }
+    }
+  });
+
+  return {
+    paths: paths,
+    fallback: false,
+  };
+}
+
+export default Page;

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -53,7 +53,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     version: preview ? 'draft' : 'published',
     language: locale,
-    ...(preview && { cv: Date.now() }),
+    // ...(preview && { cv: Date.now() }),
   };
 
   let { data } = await Storyblok.get(`cdn/stories/${slug}`, sbParams);
@@ -62,7 +62,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
     props: {
       story: data ? data.story : null,
       preview,
-      sbParams: JSON.stringify(sbParams),
+      sbParams: sbParams,
       messages: {
         ...require(`../messages/shared/${locale}.json`),
         ...require(`../messages/navigation/${locale}.json`),

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -53,6 +53,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     version: preview ? 'draft' : 'published',
     language: locale,
+    ...(preview && { cv: Date.now() }),
   };
 
   let { data } = await Storyblok.get(`cdn/stories/${slug}`, sbParams);
@@ -76,6 +77,7 @@ export async function getStaticPaths({ locales }: GetStaticPathsContext) {
   let { data } = await Storyblok.get('cdn/links/');
 
   const excludePaths: string[] = ['home', 'welcome', 'meet-the-team', 'courses'];
+
   let paths: any = [];
   Object.keys(data.links).forEach((linkKey) => {
     if (data.links[linkKey].is_folder) {

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -52,7 +52,6 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
 
   const sbParams = {
     version: preview ? 'draft' : 'published',
-    // cv: Date.now(),
     language: locale,
   };
 

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -53,7 +53,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     version: preview ? 'draft' : 'published',
     language: locale,
-    ...(preview && { cv: Date.now() }),
+    cv: preview ? Date.now() : null,
   };
 
   let { data } = await Storyblok.get(`cdn/stories/${slug}`, sbParams);

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -53,16 +53,16 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     version: preview ? 'draft' : 'published',
     language: locale,
-    // ...(preview && { cv: Date.now() }),
+    ...(preview && { cv: Date.now() }),
   };
 
   let { data } = await Storyblok.get(`cdn/stories/${slug}`, sbParams);
-
+  console.log(sbParams);
   return {
     props: {
       story: data ? data.story : null,
       preview,
-      sbParams: sbParams,
+      sbParams: JSON.stringify(sbParams),
       messages: {
         ...require(`../messages/shared/${locale}.json`),
         ...require(`../messages/navigation/${locale}.json`),

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -53,7 +53,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     version: preview ? 'draft' : 'published',
     language: locale,
-    cv: preview ? Date.now() : null,
+    cv: preview ? Date.now() : 0,
   };
 
   let { data } = await Storyblok.get(`cdn/stories/${slug}`, sbParams);

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -53,7 +53,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     version: preview ? 'draft' : 'published',
     language: locale,
-    cv: preview ? Date.now() : 0,
+    ...(preview && { cv: Date.now() }),
   };
 
   let { data } = await Storyblok.get(`cdn/stories/${slug}`, sbParams);
@@ -62,7 +62,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
     props: {
       story: data ? data.story : null,
       preview,
-      sbParams: sbParams,
+      sbParams: JSON.stringify(sbParams),
       messages: {
         ...require(`../messages/shared/${locale}.json`),
         ...require(`../messages/navigation/${locale}.json`),

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -43,7 +43,7 @@ function MyApp(props: MyAppProps) {
 
   const dispatch: any = useAppDispatch();
   const router = useRouter();
-  const pathname = router.pathname.split('/')[1]; // e.g. courses | therapy | partner-admin
+  const pathname = router.asPath.split('/')[1]; // e.g. courses | therapy | partner-admin
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_ENV === 'staging') {
@@ -65,7 +65,17 @@ function MyApp(props: MyAppProps) {
   // Adds required permissions guard to pages, redirecting where required permissions are missing
   // New pages will default to requiring authenticated and public pages must be added to the array below
   const ComponentWithGuard = () => {
-    const publicPaths = ['', 'index', 'welcome', 'auth', 'action-handler', '404', '500'];
+    const publicPaths = [
+      '',
+      'index',
+      'welcome',
+      'auth',
+      'action-handler',
+      '404',
+      '500',
+      'faqs',
+      'meet-the-team',
+    ];
     const component = <Component {...pageProps} />;
     let children = null;
 

--- a/pages/courses/[slug].tsx
+++ b/pages/courses/[slug].tsx
@@ -210,7 +210,6 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     ...extraSbParams,
     version: preview ? 'draft' : 'published',
-    cv: preview ? Date.now() : 0,
     language: locale,
   };
 

--- a/pages/courses/[slug].tsx
+++ b/pages/courses/[slug].tsx
@@ -203,14 +203,11 @@ const CourseOverview: NextPage<Props> = ({ story, preview, sbParams, locale }) =
 export async function getStaticProps({ locale, preview = false, params }: GetStaticPropsContext) {
   const slug = params?.slug instanceof Array ? params.slug.join('/') : params?.slug;
 
-  const extraSbParams = {
-    resolve_relations: 'week.sessions',
-  };
-
   const sbParams = {
-    ...extraSbParams,
+    resolve_relations: 'week.sessions',
     version: preview ? 'draft' : 'published',
     language: locale,
+    ...(preview && { cv: Date.now() }),
   };
 
   let { data } = await Storyblok.get(`cdn/stories/courses/${slug}`, sbParams);
@@ -219,7 +216,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
     props: {
       story: data ? data.story : null,
       preview,
-      sbParams: extraSbParams,
+      sbParams: JSON.stringify(sbParams),
       messages: {
         ...require(`../../messages/shared/${locale}.json`),
         ...require(`../../messages/navigation/${locale}.json`),

--- a/pages/courses/[slug]/[sessionSlug].tsx
+++ b/pages/courses/[slug]/[sessionSlug].tsx
@@ -409,7 +409,6 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     ...extraSbParams,
     version: preview ? 'draft' : 'published',
-    cv: preview ? Date.now() : 0,
     language: locale,
   };
 

--- a/pages/courses/[slug]/[sessionSlug].tsx
+++ b/pages/courses/[slug]/[sessionSlug].tsx
@@ -402,14 +402,11 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   let sessionSlug =
     params?.sessionSlug instanceof Array ? params.sessionSlug.join('/') : params?.sessionSlug;
 
-  const extraSbParams = {
-    resolve_relations: 'Session.course',
-  };
-
   const sbParams = {
-    ...extraSbParams,
+    resolve_relations: 'Session.course',
     version: preview ? 'draft' : 'published',
     language: locale,
+    ...(preview && { cv: Date.now() }),
   };
 
   let { data } = await Storyblok.get(`cdn/stories/courses/${slug}/${sessionSlug}/`, sbParams);
@@ -418,7 +415,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
     props: {
       story: data ? data.story : null,
       preview,
-      sbParams: extraSbParams,
+      sbParams: JSON.stringify(sbParams),
       messages: {
         ...require(`../../../messages/shared/${locale}.json`),
         ...require(`../../../messages/navigation/${locale}.json`),

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -161,7 +161,6 @@ export async function getStaticProps({ locale, preview = false }: GetStaticProps
   let sbParams = {
     language: locale,
     version: preview ? 'draft' : 'published',
-    cv: preview ? Date.now() : 0,
     starts_with: 'courses/',
     sort_by: 'position:desc',
     filter_query: {

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -168,6 +168,7 @@ export async function getStaticProps({ locale, preview = false }: GetStaticProps
         in: 'Course',
       },
     },
+    ...(preview && { cv: Date.now() }),
   };
 
   let { data } = await Storyblok.get('cdn/stories/', sbParams);
@@ -176,7 +177,7 @@ export async function getStaticProps({ locale, preview = false }: GetStaticProps
     props: {
       stories: data ? data.stories : null,
       preview,
-      sbParams,
+      sbParams: JSON.stringify(sbParams),
       messages: {
         ...require(`../../messages/shared/${locale}.json`),
         ...require(`../../messages/navigation/${locale}.json`),

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -132,6 +132,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     version: preview ? 'draft' : 'published',
     language: locale,
+    ...(preview && { cv: Date.now() }),
   };
 
   let { data } = await Storyblok.get(`cdn/stories/home`, sbParams);
@@ -140,7 +141,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
     props: {
       story: data ? data.story : null,
       preview,
-      sbParams,
+      sbParams: JSON.stringify(sbParams),
       messages: {
         ...require(`../messages/shared/${locale}.json`),
         ...require(`../messages/navigation/${locale}.json`),

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -131,7 +131,6 @@ const Index: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
 export async function getStaticProps({ locale, preview = false, params }: GetStaticPropsContext) {
   const sbParams = {
     version: preview ? 'draft' : 'published',
-    cv: preview ? Date.now() : 0,
     language: locale,
   };
 

--- a/pages/meet-the-team.tsx
+++ b/pages/meet-the-team.tsx
@@ -169,6 +169,7 @@ export async function getStaticProps({ locale, preview = false }: GetStaticProps
   let sbParams = {
     version: preview ? 'draft' : 'published',
     language: locale,
+    ...(preview && { cv: Date.now() }),
   };
 
   let { data } = await Storyblok.get(`cdn/stories/meet-the-team`, sbParams);
@@ -177,7 +178,7 @@ export async function getStaticProps({ locale, preview = false }: GetStaticProps
     props: {
       story: data ? data.story : null,
       preview,
-      sbParams,
+      sbParams: JSON.stringify(sbParams),
       messages: {
         ...require(`../messages/shared/${locale}.json`),
         ...require(`../messages/navigation/${locale}.json`),

--- a/pages/meet-the-team.tsx
+++ b/pages/meet-the-team.tsx
@@ -168,7 +168,6 @@ const MeetTheTeam: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
 export async function getStaticProps({ locale, preview = false }: GetStaticPropsContext) {
   let sbParams = {
     version: preview ? 'draft' : 'published',
-    cv: preview ? Date.now() : 0,
     language: locale,
   };
 

--- a/pages/welcome/[partnerName].tsx
+++ b/pages/welcome/[partnerName].tsx
@@ -139,7 +139,6 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
 
   const sbParams = {
     version: preview ? 'draft' : 'published',
-    cv: preview ? Date.now() : 0,
     language: locale,
   };
 

--- a/pages/welcome/[partnerName].tsx
+++ b/pages/welcome/[partnerName].tsx
@@ -140,6 +140,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
   const sbParams = {
     version: preview ? 'draft' : 'published',
     language: locale,
+    ...(preview && { cv: Date.now() }),
   };
 
   let { data } = await Storyblok.get(`cdn/stories/welcome/${partnerName}`, sbParams);
@@ -148,6 +149,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
     props: {
       story: data ? data.story : null,
       preview,
+      sbParams: JSON.stringify(sbParams),
       messages: {
         ...require(`../../messages/shared/${locale}.json`),
         ...require(`../../messages/navigation/${locale}.json`),


### PR DESCRIPTION
- Adds dynamic storyblok page (`pages/[slug].tsx`) and components (`DynamicComponent.tsx`), as described below
- Adds support for faq page - by adding it to the `publicPaths` list in `_app.tsx`
- Removes `cv` param as it was causing errors and i dont believe its required

As in readme:

**Dynamic pages**

Dynamic pages allow the team to create new content pages in Storyblok e.g. `/about-topic`, without requiring developer work*. Our top level dynamic route [[slug].tsx](pages/[slug].tsx) allows new pages to be added, with an infinite number of [StoryblokPageSection.tsx](components/storyblok/StoryblokPageSection.tsx) with nested components. [DynamicComponent.tsx](components/storyblok/DynamicComponent.tsx) can also be used to dynamically render components on a page, where the storyblok field is of type `blocks` and we don't know which blocks to expect.
*Note: If a page is to be public/unauthenticated, it must be added to `publicPaths` in [\_app.tsx](pages/_app.tsx).
