### PR TITLE
190322-0749/ set password reset language

### DIFF
--- a/components/forms/ResetPasswordForm.tsx
+++ b/components/forms/ResetPasswordForm.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/router';
 import * as React from 'react';
 import { useState } from 'react';
 import { auth } from '../../config/firebase';
@@ -24,12 +25,17 @@ export const EmailForm = () => {
     | React.ReactNodeArray
     | React.ReactElement<any, string | React.JSXElementConstructor<any>>
   >();
+  const router = useRouter();
   const t = useTranslations('Auth.form');
 
   const sendResetEmailSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setFormError('');
     logEvent(RESET_PASSWORD_REQUEST);
+
+    if (router.locale) {
+      auth.languageCode = router.locale;
+    }
 
     auth
       .sendPasswordResetEmail(emailInput)


### PR DESCRIPTION
- You need to use the default Firebase email to get translations. We are doing this.
- We only use password reset email as far as I can tell so I only needed to change the language of that email.
- There are two ways of changing the language  `Firebase.auth().languageCode = “es”` or   the function `Firebase.auth().useDeviceLanguage().` This sets the current language to the default device/browser preference. I opted to go by Url to give a bit more choice to the user. But equally I could be wrong. Please update PR if this isn't the best method