### PR TITLE
Show language menu + default browser  locale

### DIFF
--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -11,6 +11,7 @@ import { useTypedSelector } from '../../hooks/store';
 import bloomLogo from '../../public/bloom_logo.svg';
 import { rowStyle } from '../../styles/common';
 import Link from '../common/Link';
+import LanguageMenu from './LanguageMenu';
 import NavigationDrawer from './NavigationDrawer';
 import NavigationMenu from './NavigationMenu';
 import UserMenu from './UserMenu';
@@ -52,7 +53,7 @@ const TopBar = () => {
         </Link>
         {!isSmallScreen && <NavigationMenu />}
         {user.token && <UserMenu />}
-        {/* <LanguageMenu /> */}
+        <LanguageMenu />
       </Container>
     </AppBar>
   );

--- a/next.config.js
+++ b/next.config.js
@@ -20,7 +20,7 @@ module.exports = withPWA({
   i18n: {
     locales: ['en', 'es'],
     defaultLocale: 'en',
-    localeDetection: false,
+    localeDetection: true,
   },
   pwa: {
     dest: 'public',


### PR DESCRIPTION
Adds back language menu to allow users to select language. 

Also sets `localeDetection` to `true`, taking the users browser locale as default, or falling back to `en` if we don't support their browser default.