### PR TITLE
Fix welcome code form - missing event.preventDefault

### DIFF
--- a/components/forms/WelcomeCodeForm.tsx
+++ b/components/forms/WelcomeCodeForm.tsx
@@ -27,6 +27,7 @@ const WelcomeCodeForm = (props: WelcomeCodeFormProps) => {
   }, [codeParam]);
 
   const submitHandler = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     router.push({
       pathname: '/auth/register',
       ...(partnerParam && {


### PR DESCRIPTION
This missing `event.preventDefault()` was causing a redirect error from the register page, back to the welcome page.