### PR TITLE
Flatten firebase event params

### DIFF
--- a/components/forms/ApplyCodeForm.tsx
+++ b/components/forms/ApplyCodeForm.tsx
@@ -54,7 +54,7 @@ const ApplyCodeForm = () => {
 
     if ('data' in partnerAccessResponse) {
       const eventData = {
-        partner: partnerAccessResponse.data.partner?.name,
+        new_partner: partnerAccessResponse.data.partner?.name,
         feature_courses: true,
         feature_live_chat: partnerAccessResponse.data.featureLiveChat,
         feature_therapy: partnerAccessResponse.data.featureTherapy,

--- a/pages/courses/[slug].tsx
+++ b/pages/courses/[slug].tsx
@@ -72,6 +72,7 @@ const CourseOverview: NextPage<Props> = ({ story, preview, sbParams, locale }) =
     ...eventUserData,
     course_name: story.content.name,
     course_storyblok_id: story.id,
+    course_progress: courseProgress,
   };
 
   useEffect(() => {

--- a/pages/courses/[slug]/[sessionSlug].tsx
+++ b/pages/courses/[slug]/[sessionSlug].tsx
@@ -103,6 +103,7 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
     ...eventUserData,
     session_name: story.content.name,
     session_storyblok_id: story.id,
+    session_progress: sessionProgress,
     course_name: story.content.course.content.name,
     course_storyblok_id: story.content.course.id,
   };

--- a/utils/logEvent.ts
+++ b/utils/logEvent.ts
@@ -2,6 +2,7 @@ import { GetUserResponse } from '../app/api';
 import { analytics } from '../config/firebase';
 
 export const logEvent = (event: string, params?: {}) => {
+  console.log(event, params);
   analytics?.logEvent(event, params!);
 };
 
@@ -37,7 +38,7 @@ export const getEventUserData = (data: Partial<GetUserResponse>) => {
           return total + pa.therapySessionsRedeemed;
         }, 0)
       : 0,
-    partner_activated_at: data.partnerAccesses ? data.partnerAccesses[0].activatedAt : null,
+    partner_activated_at: data.partnerAccesses ? data.partnerAccesses[0]?.activatedAt : null,
   };
 };
 

--- a/utils/logEvent.ts
+++ b/utils/logEvent.ts
@@ -8,16 +8,36 @@ export const logEvent = (event: string, params?: {}) => {
 export const getEventUserData = (data: Partial<GetUserResponse>) => {
   return {
     registered_at: data.user?.createdAt,
-    partner_access: data.partnerAccesses?.map((partnerAccess) => {
-      return {
-        partner_name: partnerAccess.partner.name,
-        feature_live_chat: partnerAccess.featureLiveChat,
-        feature_therapy: partnerAccess.featureTherapy,
-        therapy_sessions_remaining: partnerAccess.therapySessionsRemaining,
-        therapy_sessions_redeemed: partnerAccess.therapySessionsRedeemed,
-        activated_at: partnerAccess.activatedAt,
-      };
-    }),
+    partner: data.partnerAccesses
+      ? data.partnerAccesses.map((pa) => pa.partner.name).join(', ')
+      : 'none',
+    partner_live_chat: data.partnerAccesses
+      ? data.partnerAccesses
+          .map((pa) => {
+            if (pa.featureLiveChat) return pa.partner.name;
+          })
+          .join(', ')
+      : 'none',
+    partner_therapy: data.partnerAccesses
+      ? data.partnerAccesses
+          .map((pa) => {
+            if (pa.featureTherapy) return pa.partner.name;
+          })
+          .join(', ')
+      : 'none',
+    partner_therapy_remaining: data.partnerAccesses
+      ? data.partnerAccesses.reduce(function (total, pa) {
+          // return the sum with previous value
+          return total + pa.therapySessionsRemaining;
+        }, 0)
+      : 0,
+    partner_therapy_redeemed: data.partnerAccesses
+      ? data.partnerAccesses.reduce(function (total, pa) {
+          // return the sum with previous value
+          return total + pa.therapySessionsRedeemed;
+        }, 0)
+      : 0,
+    partner_activated_at: data.partnerAccesses ? data.partnerAccesses[0].activatedAt : null,
   };
 };
 


### PR DESCRIPTION
Firebase event params previously weren't loading params correctly, due to nested params not being supported by firebase/google analytics UI. Whilst its possible to make use of the nested params with big query, it's unlikely we'll implement this in the near future, so for now we're flattening the event params. 