### PR TITLE
Meet the team added to nav + image fix

### DIFF
--- a/components/cards/TeamMemberCard.tsx
+++ b/components/cards/TeamMemberCard.tsx
@@ -79,7 +79,7 @@ const TeamMemberCard = (props: TeamMemberCardProps) => {
               alt={teamMember.image.alt}
               src={teamMember.image.filename}
               layout="fill"
-              objectFit="contain"
+              objectFit="cover"
             />
           </Box>
           <Box sx={cardHeaderStyle}>

--- a/components/layout/NavigationMenu.tsx
+++ b/components/layout/NavigationMenu.tsx
@@ -64,6 +64,8 @@ const NavigationMenu = (props: NavigationMenuProps) => {
         links.push({ title: t('admin'), href: '/partner-admin/create-access-code' });
       }
 
+      links.push({ title: t('meetTheTeam'), href: '/meet-the-team' });
+
       if (!partnerAdmin.partner) {
         links.push({
           title: t('immediateHelp'),

--- a/messages/navigation/en.json
+++ b/messages/navigation/en.json
@@ -11,6 +11,7 @@
     "home": "Home",
     "admin": "Admin",
     "about": "About",
+    "meetTheTeam": "Meet the Bloom team",
     "immediateHelp": "Immediate help",
     "therapy": "Therapy",
     "courses": "Courses",

--- a/messages/navigation/es.json
+++ b/messages/navigation/es.json
@@ -11,6 +11,7 @@
     "home": "Inicio",
     "admin": "Admin",
     "about": "Acerca de Bloom",
+    "meetTheTeam": "Conoce al equipo Bloom",
     "immediateHelp": "Ayuda inmediata",
     "therapy": "Terapia",
     "courses": "Cursos",


### PR DESCRIPTION
Fixes image objectFit to `cover`

Before
![WhatsApp Image 2022-04-05 at 12 46 20](https://user-images.githubusercontent.com/11525717/161749082-fba5d1a8-a3bd-42f1-b121-be4edc74e307.jpeg)


After
<img width="947" alt="Screenshot 2022-04-05 at 12 48 42" src="https://user-images.githubusercontent.com/11525717/161747456-8c65feff-210d-43a4-a214-41a3345a84c9.png">

Also adds the meet the team page to the navigation
