### PR TITLE
Fix issue with password-reset flow

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -43,7 +43,12 @@ function MyApp(props: MyAppProps) {
 
   const dispatch: any = useAppDispatch();
   const router = useRouter();
-  const pathname = router.asPath.split('/')[1]; // e.g. courses | therapy | partner-admin
+
+  // Example:
+  // The url http://bloom.chayn.co/auth/register?example=true will have a pathname of /auth/register
+  // This pathname split with a '/' separator will produce the array ['', 'auth', 'register']
+  // The second array entry is pulled out as the pathHead and will be 'auth'
+  const pathHead = router.pathname.split('/')[1]; // e.g. courses | therapy | partner-admin
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_ENV === 'staging') {
@@ -65,7 +70,7 @@ function MyApp(props: MyAppProps) {
   // Adds required permissions guard to pages, redirecting where required permissions are missing
   // New pages will default to requiring authenticated and public pages must be added to the array below
   const ComponentWithGuard = () => {
-    const publicPaths = [
+    const publicPathHeads = [
       '',
       'index',
       'welcome',
@@ -79,13 +84,13 @@ function MyApp(props: MyAppProps) {
     const component = <Component {...pageProps} />;
     let children = null;
 
-    if (publicPaths.includes(pathname)) {
+    if (publicPathHeads.includes(pathHead)) {
       return component;
     }
-    if (pathname === 'therapy') {
+    if (pathHead === 'therapy') {
       children = <TherapyAccessGuard>{component}</TherapyAccessGuard>;
     }
-    if (pathname === 'partner-admin') {
+    if (pathHead === 'partner-admin') {
       children = <PartnerAdminGuard>{component}</PartnerAdminGuard>;
     }
 
@@ -102,7 +107,7 @@ function MyApp(props: MyAppProps) {
         <ThemeProvider theme={theme}>
           <CssBaseline />
           <TopBar />
-          {pathname !== 'partner-admin' && <LeaveSiteButton />}
+          {pathHead !== 'partner-admin' && <LeaveSiteButton />}
           <ComponentWithGuard />
           <Footer />
         </ThemeProvider>


### PR DESCRIPTION
This commit fixes bug which redirects users to the login page if they click on a reset password link in their email.

This bug occured because the redirect link from firebase was not identified by the app as pointing to a public page. Instead, an auth-guarded component was served which then triggered the app to show the login page.

Going deeper in the code, the issue occured because the mechanism to identify public paths did not work when the path contained query params. Since the reset-password email links did contain query params, it
was incorrectly classes as needing an auth guard.

The variables which hold the public paths and the current path have been renamed to contain 'head' as this makes it clear to the reader which part of the path is referred to in the code.

050422-1958 / Fix password reset flow