### PR TITLE
Fix mobile topbar spacing

### DIFF
--- a/components/layout/LanguageMenu.tsx
+++ b/components/layout/LanguageMenu.tsx
@@ -16,8 +16,10 @@ const menuItemStyle = {
 } as const;
 
 const buttonStyle = {
-  gap: 1,
-  paddingX: 1.5,
+  height: 40,
+  minWidth: { xs: 40, md: 64 },
+  paddingX: 1,
+  gap: 0.75,
   fontWeight: 400,
 
   ':hover': { backgroundColor: 'background.default' },
@@ -26,7 +28,7 @@ const buttonStyle = {
     backgroundColor: 'primary.main',
     opacity: 0.2,
   },
-  '& .MuiButton-startIcon': { mx: 0 },
+  '& .MuiButton-startIcon': { display: { xs: 'none', md: 'inline-flex' }, mx: 0 },
 } as const;
 
 export default function LanguageMenu() {

--- a/components/layout/NavigationMenu.tsx
+++ b/components/layout/NavigationMenu.tsx
@@ -13,8 +13,8 @@ const listStyle = {
   flexDirection: { xs: 'column', md: 'row' },
   height: '100%',
   marginLeft: { xs: 0, md: 'auto' },
-  marginRight: { xs: 0, md: 2 },
-  gap: { xs: 2, md: 1 },
+  marginRight: { xs: 0, md: 0.5 },
+  gap: { xs: 2, md: 0 },
 } as const;
 
 const listItemStyle = {

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -1,10 +1,10 @@
+import { Box } from '@mui/material';
 import AppBar from '@mui/material/AppBar';
 import Container from '@mui/material/Container';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { RootState } from '../../app/store';
 import { useTypedSelector } from '../../hooks/store';
@@ -32,6 +32,7 @@ const appBarContainerStyles = {
 const logoContainerStyle = {
   position: 'relative',
   width: { xs: 80, sm: 120 },
+  marginLeft: { xs: 4, md: 0 },
   height: 48,
 } as const;
 
@@ -39,7 +40,6 @@ const TopBar = () => {
   const t = useTranslations('Navigation');
   const tS = useTranslations('Shared');
   const theme = useTheme();
-  const router = useRouter();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
   const [welcomeUrl, setWelcomeUrl] = useState<string>('/');
 
@@ -62,8 +62,10 @@ const TopBar = () => {
           <Image alt={tS('alt.bloomLogo')} src={bloomLogo} layout="fill" objectFit="contain" />
         </Link>
         {!isSmallScreen && <NavigationMenu />}
-        {user.token && <UserMenu />}
-        <LanguageMenu />
+        <Box sx={rowStyle}>
+          {user.token && <UserMenu />}
+          <LanguageMenu />
+        </Box>
       </Container>
     </AppBar>
   );

--- a/components/layout/UserMenu.tsx
+++ b/components/layout/UserMenu.tsx
@@ -23,7 +23,8 @@ const menuItemStyle = {
 } as const;
 
 const buttonStyle = {
-  paddingX: 1.5,
+  paddingX: 1,
+  minWidth: { xs: 40, md: 64 },
   height: 40,
   fontWeight: 400,
 


### PR DESCRIPTION
Fixes spacing/flex issues on mobile, introduced when adding back the language menu

before
<img width="413" alt="Screenshot 2022-04-06 at 14 59 48" src="https://user-images.githubusercontent.com/11525717/161992204-a7f10f14-1db3-4e87-afcc-58b41b21e324.png">

after
<img width="401" alt="Screenshot 2022-04-06 at 14 59 20" src="https://user-images.githubusercontent.com/11525717/161992221-6847c105-87c4-435c-ab1f-68fd7e5e1bdf.png">

Also made the desktop nav a bit tighter, as it was overflowing at 900px

before
<img width="1111" alt="Screenshot 2022-04-06 at 14 59 40" src="https://user-images.githubusercontent.com/11525717/161992327-0026c69f-edad-41f2-849e-799f34759d3e.png">

after
<img width="1037" alt="Screenshot 2022-04-06 at 14 59 31" src="https://user-images.githubusercontent.com/11525717/161992343-776616b0-b6f3-4313-99a2-6675142c0944.png">


