### PR TITLE
Add inspector to heroku start

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest --watch",
-    "start:heroku": "NODE_OPTIONS='--max_old_space_size=460' next start -p $PORT"
+    "start:heroku": "NODE_OPTIONS='--max_old_space_size=460 --inspect' next start -p $PORT"
   },
   "dependencies": {
     "@emotion/cache": "^11.4.0",


### PR DESCRIPTION
https://blog.sqreen.com/memory-leaks-nodejs-heroku/ 

I'm following the above tutorial to see if I can get an inspector running on staging so I can take heap snapshots. I couldn't reproduce the memory leak locally