### PR TITLE
Use router.asPath not router.pathName for language change

### DIFF
--- a/components/layout/LanguageMenu.tsx
+++ b/components/layout/LanguageMenu.tsx
@@ -46,6 +46,8 @@ export default function LanguageMenu() {
   const handleClose = () => {
     setAnchorEl(null);
   };
+  console.log(router.asPath);
+  console.log(router.pathname);
 
   return (
     <Box>
@@ -77,7 +79,7 @@ export default function LanguageMenu() {
             const languageUppercase = language.toUpperCase();
             return (
               <MenuItem key={language} sx={menuItemStyle}>
-                <Button component={Link} href={router.pathname} locale={language}>
+                <Button component={Link} href={router.asPath} locale={language}>
                   {languageUppercase}
                 </Button>
               </MenuItem>

--- a/components/layout/LanguageMenu.tsx
+++ b/components/layout/LanguageMenu.tsx
@@ -46,8 +46,6 @@ export default function LanguageMenu() {
   const handleClose = () => {
     setAnchorEl(null);
   };
-  console.log(router.asPath);
-  console.log(router.pathname);
 
   return (
     <Box>


### PR DESCRIPTION
Currently when you language change, it gets the path name from router.pathname and sets the locale to the selected language. However, router.pathname uses variables like /courses/[slug] rather than courses/healing sexual trauma. Instead I have used, asPath to fix this issue. 