### PR TITLE
Add account type to analytics meta data

### DIFF
--- a/utils/getAccountType.test.ts
+++ b/utils/getAccountType.test.ts
@@ -5,16 +5,16 @@ const partnerAdmin = {} as PartnerAdmin;
 const partnerAccesses = [{} as PartnerAccess] as PartnerAccesses;
 
 describe('getAccountType', () => {
-  it('getAccountType should return publicUser if neither is partnerAdmin nor partner user', () => {
+  it('should return publicUser if neither is partnerAdmin nor partner user', () => {
     expect(getAccountType(undefined, undefined)).toBe(AccountType.publicUser);
   });
-  it('getAccountType should return partnerAdmin if is partnerAdmin', () => {
+  it('should return partnerAdmin if is partnerAdmin', () => {
     expect(getAccountType(partnerAdmin, undefined)).toBe(AccountType.partnerAdmin);
   });
-  it('getAccountType should return partnerUser if not partnerAdmin and connected to partner', () => {
+  it('should return partnerUser if not partnerAdmin and connected to partner', () => {
     expect(getAccountType(undefined, partnerAccesses)).toBe(AccountType.partnerUser);
   });
-  it('getAccountType should return partnerAdmin  if both partnerAdmin and connected to partner', () => {
+  it('should return partnerAdmin  if both partnerAdmin and connected to partner', () => {
     expect(getAccountType(partnerAdmin, partnerAccesses)).toBe(AccountType.partnerAdmin);
   });
 });

--- a/utils/getAccountType.test.ts
+++ b/utils/getAccountType.test.ts
@@ -1,0 +1,20 @@
+import { PartnerAccess, PartnerAccesses } from '../app/partnerAccessSlice';
+import { PartnerAdmin } from '../app/partnerAdminSlice';
+import { AccountType, getAccountType } from './getAccountType';
+const partnerAdmin = {} as PartnerAdmin;
+const partnerAccesses = [{} as PartnerAccess] as PartnerAccesses;
+
+describe('getAccountType', () => {
+  it('getAccountType should return publicUser if neither is partnerAdmin nor partner user', () => {
+    expect(getAccountType(undefined, undefined)).toBe(AccountType.publicUser);
+  });
+  it('getAccountType should return partnerAdmin if is partnerAdmin', () => {
+    expect(getAccountType(partnerAdmin, undefined)).toBe(AccountType.partnerAdmin);
+  });
+  it('getAccountType should return partnerUser if not partnerAdmin and connected to partner', () => {
+    expect(getAccountType(undefined, partnerAccesses)).toBe(AccountType.partnerUser);
+  });
+  it('getAccountType should return partnerAdmin  if both partnerAdmin and connected to partner', () => {
+    expect(getAccountType(partnerAdmin, partnerAccesses)).toBe(AccountType.partnerAdmin);
+  });
+});

--- a/utils/getAccountType.ts
+++ b/utils/getAccountType.ts
@@ -1,0 +1,23 @@
+import { PartnerAccesses } from '../app/partnerAccessSlice';
+import { PartnerAdmin } from '../app/partnerAdminSlice';
+
+export enum AccountType {
+  partnerAdmin = 'PARTNER_ADMIN',
+  superAdmin = 'SUPER_ADMIN',
+  publicUser = 'PUBLIC_USER',
+  partnerUser = 'PARTNER_USER',
+}
+export const getAccountType = (
+  partnerAdmin: PartnerAdmin | undefined,
+  partnerAccesses: PartnerAccesses | undefined,
+): AccountType => {
+  // TODO We do not have the data for whether someone is a super admin yet
+  // this would be great to implement
+  if (partnerAdmin) {
+    return AccountType.partnerAdmin;
+  }
+  if (partnerAccesses && partnerAccesses.length > 0) {
+    return AccountType.partnerUser;
+  }
+  return AccountType.publicUser;
+};

--- a/utils/logEvent.ts
+++ b/utils/logEvent.ts
@@ -6,6 +6,7 @@ import {
   joinedPartners,
   totalTherapyRemaining,
 } from './formatPartnerAccesses';
+import { getAccountType } from './getAccountType';
 
 export const logEvent = (event: string, params?: {}) => {
   analytics?.logEvent(event, params!);
@@ -13,6 +14,7 @@ export const logEvent = (event: string, params?: {}) => {
 
 export const getEventUserData = (data: Partial<GetUserResponse>) => {
   return {
+    account_type: getAccountType(data.partnerAdmin, data.partnerAccesses),
     registered_at: data.user?.createdAt,
     partner: joinedPartners(data.partnerAccesses),
     partner_live_chat: joinedFeatureLiveChat(data.partnerAccesses),


### PR DESCRIPTION
- add account meta data for tracking purposes