### PR TITLE
check partner admin id exists in GA events

### DIFF
--- a/utils/getAccountType.test.ts
+++ b/utils/getAccountType.test.ts
@@ -1,7 +1,9 @@
 import { PartnerAccess, PartnerAccesses } from '../app/partnerAccessSlice';
 import { PartnerAdmin } from '../app/partnerAdminSlice';
 import { AccountType, getAccountType } from './getAccountType';
-const partnerAdmin = {} as PartnerAdmin;
+const partnerAdminEmpty = { id: null } as PartnerAdmin;
+const partnerAdmin = { id: 'id' } as PartnerAdmin;
+
 const partnerAccesses = [{} as PartnerAccess] as PartnerAccesses;
 
 describe('getAccountType', () => {
@@ -16,5 +18,8 @@ describe('getAccountType', () => {
   });
   it('should return partnerAdmin  if both partnerAdmin and connected to partner', () => {
     expect(getAccountType(partnerAdmin, partnerAccesses)).toBe(AccountType.partnerAdmin);
+  });
+  it('should return publicUser if partnerAdmi id = null', () => {
+    expect(getAccountType(partnerAdminEmpty, undefined)).toBe(AccountType.publicUser);
   });
 });

--- a/utils/getAccountType.ts
+++ b/utils/getAccountType.ts
@@ -13,7 +13,7 @@ export const getAccountType = (
 ): AccountType => {
   // TODO We do not have the data for whether someone is a super admin yet
   // this would be great to implement
-  if (partnerAdmin) {
+  if (partnerAdmin?.id) {
     return AccountType.partnerAdmin;
   }
   if (partnerAccesses && partnerAccesses.length > 0) {


### PR DESCRIPTION
I'm passing through partnerAdmin which is meaning everyone is a partner admin everywhere as I'm not checking if id is null  😱 