### PR TITLE
Update naming of cypress vars to match github secrets format

### DIFF
--- a/.github/workflows/merge-pr-develop.yml
+++ b/.github/workflows/merge-pr-develop.yml
@@ -43,9 +43,9 @@ jobs:
           NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
           NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID }}
           CYPRESS_BASE_URL: 'https://bloom-frontend-staging.herokuapp.com/' # runs cypress against staging
-          CYPRESS_mail-slurp-api-key: ${{secrets.MAIL_SLURP_API_KEY}}
-          CYPRESS_inbox-id: ${{secrets.MAILBOX_INBOX_ID}}
-          CYPRESS_reset-pwd-content-email: ${{secrets.RESET_PWD_CONTENT_EMAIL}}
+          CYPRESS_mail_slurp_api_key: ${{secrets.MAIL_SLURP_API_KEY}}
+          CYPRESS_inbox_id: ${{secrets.MAILBOX_INBOX_ID}}
+          CYPRESS_reset_pwd_content_email: ${{secrets.RESET_PWD_CONTENT_EMAIL}}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,9 +40,9 @@ jobs:
           NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
           NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN }}
           NEXT_PUBLIC_STORYBLOK_TOKEN: ${{ secrets.NEXT_PUBLIC_STORYBLOK_TOKEN }}
-          CYPRESS_mail-slurp-api-key: ${{secrets.MAIL_SLURP_API_KEY}}
-          CYPRESS_inbox-id: ${{secrets.MAILBOX_INBOX_ID}}
-          CYPRESS_reset-pwd-content-email: ${{secrets.RESET_PWD_CONTENT_EMAIL}}
+          CYPRESS_mail_slurp_api_key: ${{secrets.MAIL_SLURP_API_KEY}}
+          CYPRESS_inbox_id: ${{secrets.MAILBOX_INBOX_ID}}
+          CYPRESS_reset_pwd_content_email: ${{secrets.RESET_PWD_CONTENT_EMAIL}}
       - name: Test app
         run: yarn test
 
@@ -69,7 +69,7 @@ jobs:
   #         wait-on: 'http://localhost:3000'
   #         wait-on-timeout: 180
   #         config-file: cypress.config.ts
-  #         env: login_path="auth/login",reset-password-path="auth/reset-password", mail-slurp-api-key="bde69db8499813f157cfaba1d127a676e34a8a5228a12cc0d82ed62d64937073",inbox-id="f7ac78a8-71da-4a8d-ad10-aa565bd05a66",reset-pwd-content-email="f7ac78a8-71da-4a8d-ad10-aa565bd05a66@mailslurp.com",reset-pwd-confirm-email="test@test.com"
+  #         env: login_path="auth/login",reset_password_path="auth/reset-password", mail_slurp_api_key="bde69db8499813f157cfaba1d127a676e34a8a5228a12cc0d82ed62d64937073",inbox_id="f7ac78a8-71da-4a8d-ad10-aa565bd05a66",reset_pwd_content_email="f7ac78a8-71da-4a8d-ad10-aa565bd05a66@mailslurp.com",reset_pwd_confirm_email="test@test.com"
   #       env:
   #         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
   #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   fileServerFolder: 'cypress',
   env: {
     login_path: 'auth/login',
-    'reset-password-path': 'auth/reset-password',
-    'reset-pwd-confirm-email': 'test@test.com',
+    reset_password_path: 'auth/reset-password',
+    reset_pwd_confirm_email: 'test@test.com',
   },
   e2e: {
     // We've imported your old cypress plugins here.

--- a/cypress/integration/reset-password.cy.tsx
+++ b/cypress/integration/reset-password.cy.tsx
@@ -14,16 +14,16 @@ describe('Reset password', () => {
     // Find a link with an href attribute containing "reset-password" and click it
     cy.get('a[href*="reset-password"]').click();
 
-    cy.url().should('include', Cypress.env('reset-password-path'));
+    cy.url().should('include', Cypress.env('reset_password_path'));
 
     // The new page should contain an h2 with "Reset your password"
     cy.get('h2').contains('Reset your password');
   });
 
   it('should see resend-link button after typing known email', () => {
-    cy.visit(Cypress.env('reset-password-path'));
+    cy.visit(Cypress.env('reset_password_path'));
     cy.wait(1000); // Waiting for dom to rerender as the email input was detaching
-    cy.get('[qa-id=passwordResetEmailInput]').type(`${Cypress.env('reset-pwd-confirm-email')}`);
+    cy.get('[qa-id=passwordResetEmailInput]').type(`${Cypress.env('reset_pwd_confirm_email')}`);
     cy.get('[qa-id=passwordResetEmailButton]').click();
 
     cy.get('p', { timeout: 5000 }).should(
@@ -34,16 +34,16 @@ describe('Reset password', () => {
   });
 
   it('should receive email when known email submitted for password reset', async () => {
-    const mailslurp = new MailSlurp({ apiKey: Cypress.env('mail-slurp-api-key') });
+    const mailslurp = new MailSlurp({ apiKey: Cypress.env('mail_slurp_api_key') });
 
-    const inboxId = Cypress.env('inbox-id');
-    const email = Cypress.env('reset-pwd-content-email');
+    const inboxId = Cypress.env('inbox_id');
+    const email = Cypress.env('reset_pwd_content_email');
 
     // Retrieve inbox
     const inbox = await mailslurp.getInbox(inboxId);
 
     // Reset password
-    cy.visit(Cypress.env('reset-password-path'));
+    cy.visit(Cypress.env('reset_password_path'));
     cy.get('[qa-id=passwordResetEmailInput]').focus().type(`${email}{enter}`);
     cy.get('p', { timeout: 3000 })
       // check that front-end confirms an email has been sent


### PR DESCRIPTION
Dashes are not allowed but underscores are.

61d36d1c2f / Set up cypress run