### PR TITLE
Extract build-&-test action into deploy actions

### DIFF
--- a/.github/workflows/build-and-test-prs.yml
+++ b/.github/workflows/build-and-test-prs.yml
@@ -1,8 +1,6 @@
 name: Build & test # on both PRs and push to develop/main
 
 on:
-  push:
-    branches: [develop, main]
   pull_request:
     branches: [develop, main]
 

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -6,6 +6,42 @@ on:
       - main
 
 jobs:
+  build-and-test:
+    name: Build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Use NodeJs
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: Run linting
+        run: yarn lint
+
+      - name: Build app
+        run: yarn build
+        env:
+          NEXT_PUBLIC_ROLLBAR_ENV: CI
+          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+          NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN }}
+          NEXT_PUBLIC_STORYBLOK_TOKEN: ${{ secrets.NEXT_PUBLIC_STORYBLOK_TOKEN }}
+      - name: Test app
+        run: yarn test
   deploy-to-prod:
     needs: build-and-test
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -6,6 +6,42 @@ on:
       - develop
 
 jobs:
+  build-and-test:
+    name: Build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Use NodeJs
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: Run linting
+        run: yarn lint
+
+      - name: Build app
+        run: yarn build
+        env:
+          NEXT_PUBLIC_ROLLBAR_ENV: CI
+          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+          NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN }}
+          NEXT_PUBLIC_STORYBLOK_TOKEN: ${{ secrets.NEXT_PUBLIC_STORYBLOK_TOKEN }}
+      - name: Test app
+        run: yarn test
   deploy-to-staging:
     needs: build-and-test
     runs-on: ubuntu-latest
@@ -17,7 +53,6 @@ jobs:
           heroku_app_name: ${{secrets.HEROKU_STAGING_APP}} # Must be unique in Heroku
           heroku_email: ${{secrets.HEROKU_EMAIL}}
           branch: 'develop'
-
   cypress-run:
     name: Cypress e2e tests
     needs: deploy-to-staging


### PR DESCRIPTION
This allows deploys to be prevented by failing builds. The previous commit aiming to do the same did not work.

2d638a6cc1 / Restructure github actions