### PR TITLE
Disable PWA temporarily

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -27,7 +27,7 @@ module.exports = withPWA({
   pwa: {
     dest: 'public',
     skipWaiting: true,
-    disable: process.env.NEXT_PUBLIC_ENV === 'local' ? true : false,
+    disable: true,
   },
   async redirects() {
     return [


### PR DESCRIPTION
PWA is causing errors and this change is to prevent these errors. As this feature does not seem to be used significantly, it will be removed at a future date.

ee18f0711a / Disable PWA