### PR TITLE
Fix admin redirect

### DIFF
--- a/components/layout/NavigationMenu.tsx
+++ b/components/layout/NavigationMenu.tsx
@@ -72,10 +72,6 @@ const NavigationMenu = (props: NavigationMenuProps) => {
     let links: Array<NavigationItem> = [];
 
     if (!user.loading) {
-      if (user.token && router.pathname === '/auth/login') {
-        router.push('/courses');
-      }
-
       if (partnerAdmin && partnerAdmin.partner) {
         links.push({
           title: t('admin'),

--- a/guards/authGuard.tsx
+++ b/guards/authGuard.tsx
@@ -8,6 +8,7 @@ import { clearPartnerAdminSlice } from '../app/partnerAdminSlice';
 import { RootState } from '../app/store';
 import { clearUserSlice, setUserLoading } from '../app/userSlice';
 import LoadingContainer from '../components/common/LoadingContainer';
+import { auth } from '../config/firebase';
 import rollbar from '../config/rollbar';
 import {
   GET_AUTH_USER_ERROR,
@@ -30,6 +31,13 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
   const [verified, setVerified] = useState(false);
   const [loading, setLoading] = useState(false);
   const [getUser] = useGetUserMutation();
+  const [firebaseUserUpdated, setfirebaseUserUpdated] = useState(false);
+
+  useEffect(() => {
+    auth.onIdTokenChanged(async function (_) {
+      setfirebaseUserUpdated(true);
+    });
+  }, []);
 
   useEffect(() => {
     // Only called where a firebase token exist but user data not loaded, e.g. app reload
@@ -61,7 +69,7 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
       }
     }
 
-    if (loading || user.loading) {
+    if (loading || user.loading || !firebaseUserUpdated) {
       return;
     }
 
@@ -85,7 +93,7 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
     setLoading(true);
     callGetUser();
     setLoading(false);
-  }, [getUser, router, user, loading]);
+  }, [user, loading, firebaseUserUpdated]);
 
   if (!verified) {
     return <LoadingContainer />;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -66,6 +66,7 @@ function MyApp(props: MyAppProps) {
     // Add listener for new firebase auth token, updating it in state to be used in request headers
     // Required for restoring user state following app reload or revisiting site
     auth.onIdTokenChanged(async function (user) {
+      dispatch(setUserLoading(true));
       const token = await user?.getIdToken();
 
       if (token) {

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -10,6 +10,8 @@ import { GetStaticPropsContext } from 'next';
 import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { RootState } from '../../app/store';
 import Link from '../../components/common/Link';
 import LoginForm from '../../components/forms/LoginForm';
@@ -57,6 +59,7 @@ const Login: NextPage = () => {
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
   const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
   const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const router = useRouter();
 
   const headerProps = {
     partnerLogoSrc: welcomeToBloom,
@@ -66,6 +69,12 @@ const Login: NextPage = () => {
   };
 
   const allPartnersContent = getAllPartnersContent();
+
+  useEffect(() => {
+    if (user.token) {
+      router.push('/courses'); // Redirect if the user is on the login page but is alredy logged in
+    }
+  }, [user.token]);
 
   const ExtraContent = () => {
     return (


### PR DESCRIPTION
- fix issue where fresh reload of pages mean't a logged in user was redirected to login page and then courses
- tested that admin dashboard can be accessed via direct link
- tested that after logout the user cannot see the page 
- tested partner admin page can be accessed via direct link

- also adding here a change for a previous bug fix that Patricia did for us - the redirect for a logged in user away from the  login page. She did it correctly but when merging, I made a mistake and rebased to a previous version of her code. Just realised this when looking at the redirects for this bug. 