### PR TITLE
Remove grid bonus content

### DIFF
--- a/components/session/GridBonusContent.tsx
+++ b/components/session/GridBonusContent.tsx
@@ -6,6 +6,7 @@ import { RichTextOptions } from '../../utils/richText';
 import SessionContentCard from '../cards/SessionContentCard';
 import { Dots } from '../common/Dots';
 
+// TODO add documentation on when this component is used i.e. which storyblok component it renders
 interface MultipleBonusContentProps {
   story: StoryData;
   eventData: { [index: string]: any };

--- a/components/session/GridBonusContent.tsx
+++ b/components/session/GridBonusContent.tsx
@@ -1,5 +1,4 @@
 import LinkIcon from '@mui/icons-material/Link';
-import Box from '@mui/material/Box';
 import { useTranslations } from 'next-intl';
 import { StoryData } from 'storyblok-js-client';
 import { render } from 'storyblok-rich-text-react-renderer';
@@ -30,70 +29,34 @@ interface GridBonusContentProps {
   eventData: { [index: string]: any };
 }
 
+// TODO rename this file to MultipleBonusContent
+// TODO rename this component and props to MultipleBonusContent...
 const GridBonusContent = (props: GridBonusContentProps) => {
   const { story, eventData } = props;
 
   const t = useTranslations('Courses');
 
+  // TODO remove log
+  console.log('>>> bonus', story);
+
+  // TODO remove index
   return (
     <>
-      {story.content.bonus &&
-        story.content.bonus.length === 1 &&
-        displayCentralBonusContent(story.content.bonus[0].content)}
-
-      {story.content.bonus &&
-        story.content.bonus.length > 1 &&
-        displayGridBonusContent(story.content.bonus)}
-    </>
-  );
-
-  function displayCentralBonusContent(bonusBlock: any, index?: number) {
-    return (
-      <>
-        <Dots />
-        {displayBonusContent(bonusBlock, index)}
-      </>
-    );
-  }
-
-  function displayGridBonusContent(bonusBlocks: any[]) {
-    return (
-      <>
-        <Dots />
-        <Box sx={bonusGridRowStyle}>
-          <Box sx={bonusGridColumnStyle}>
-            {bonusBlocks?.map((bonusBlock, index) => {
-              if (index % 2 === 1) return;
-
-              return displayBonusContent(bonusBlock.content, index);
-            })}
-          </Box>
-          <Box sx={bonusGridColumnStyle}>
-            {bonusBlocks?.map((bonusBlock, index) => {
-              if (index % 2 === 0) return;
-              return displayBonusContent(bonusBlock.content, index);
-            })}
-          </Box>
-        </Box>
-      </>
-    );
-  }
-
-  function displayBonusContent(bonusBlock: any, index?: number) {
-    return (
-      <>
+      <Dots />
+      {story.content.bonus.map((bonus: any, index: number) => (
         <SessionContentCard
+          key={bonus._uid}
           title={t('sessionDetail.bonusTitle') + index}
           titleIcon={LinkIcon}
           richtextContent
           eventPrefix="SESSION_BONUS_CONTENT"
           eventData={eventData}
         >
-          <>{render(bonusBlock, RichTextOptions)}</>
+          <>{render(bonus.content, RichTextOptions)}</>
         </SessionContentCard>
-      </>
-    );
-  }
+      ))}
+    </>
+  );
 };
 
 export default GridBonusContent;

--- a/components/session/GridBonusContent.tsx
+++ b/components/session/GridBonusContent.tsx
@@ -2,27 +2,9 @@ import LinkIcon from '@mui/icons-material/Link';
 import { useTranslations } from 'next-intl';
 import { StoryData } from 'storyblok-js-client';
 import { render } from 'storyblok-rich-text-react-renderer';
-import { columnStyle } from '../../styles/common';
 import { RichTextOptions } from '../../utils/richText';
 import SessionContentCard from '../cards/SessionContentCard';
 import { Dots } from '../common/Dots';
-
-const bonusGridColumnStyle = {
-  ...columnStyle,
-  alignItems: 'center',
-  justifyContent: 'flex-start',
-  gap: 2,
-  width: { xs: '100%', sm: '100%', md: 700 },
-} as const;
-
-export const bonusGridRowStyle = {
-  display: 'flex',
-  flexDirection: 'row',
-  justifyContent: 'center',
-  flexWrap: 'wrap',
-  gap: 2,
-  width: '100%',
-} as const;
 
 interface MultipleBonusContentProps {
   story: StoryData;
@@ -35,14 +17,13 @@ const MultipleBonusContent = (props: MultipleBonusContentProps) => {
 
   const t = useTranslations('Courses');
 
-
   return (
     <>
       <Dots />
       {story.content.bonus.map((bonus: any) => (
         <SessionContentCard
           key={bonus._uid}
-          title={t('sessionDetail.bonusTitle') }
+          title={t('sessionDetail.bonusTitle')}
           titleIcon={LinkIcon}
           richtextContent
           eventPrefix="SESSION_BONUS_CONTENT"

--- a/components/session/GridBonusContent.tsx
+++ b/components/session/GridBonusContent.tsx
@@ -24,14 +24,13 @@ export const bonusGridRowStyle = {
   width: '100%',
 } as const;
 
-interface GridBonusContentProps {
+interface MultipleBonusContentProps {
   story: StoryData;
   eventData: { [index: string]: any };
 }
 
 // TODO rename this file to MultipleBonusContent
-// TODO rename this component and props to MultipleBonusContent...
-const GridBonusContent = (props: GridBonusContentProps) => {
+const MultipleBonusContent = (props: MultipleBonusContentProps) => {
   const { story, eventData } = props;
 
   const t = useTranslations('Courses');
@@ -59,4 +58,4 @@ const GridBonusContent = (props: GridBonusContentProps) => {
   );
 };
 
-export default GridBonusContent;
+export default MultipleBonusContent;

--- a/components/session/GridBonusContent.tsx
+++ b/components/session/GridBonusContent.tsx
@@ -35,17 +35,14 @@ const MultipleBonusContent = (props: MultipleBonusContentProps) => {
 
   const t = useTranslations('Courses');
 
-  // TODO remove log
-  console.log('>>> bonus', story);
 
-  // TODO remove index
   return (
     <>
       <Dots />
-      {story.content.bonus.map((bonus: any, index: number) => (
+      {story.content.bonus.map((bonus: any) => (
         <SessionContentCard
           key={bonus._uid}
-          title={t('sessionDetail.bonusTitle') + index}
+          title={t('sessionDetail.bonusTitle') }
           titleIcon={LinkIcon}
           richtextContent
           eventPrefix="SESSION_BONUS_CONTENT"

--- a/components/session/MultipleBonusContent.tsx
+++ b/components/session/MultipleBonusContent.tsx
@@ -12,7 +12,6 @@ interface MultipleBonusContentProps {
   eventData: { [index: string]: any };
 }
 
-// TODO rename this file to MultipleBonusContent
 const MultipleBonusContent = (props: MultipleBonusContentProps) => {
   const { story, eventData } = props;
 

--- a/components/session/MultipleBonusContent.tsx
+++ b/components/session/MultipleBonusContent.tsx
@@ -2,11 +2,15 @@ import LinkIcon from '@mui/icons-material/Link';
 import { useTranslations } from 'next-intl';
 import { StoryData } from 'storyblok-js-client';
 import { render } from 'storyblok-rich-text-react-renderer';
+import SessionDetail from '../../pages/courses/image-based-abuse/[sessionSlug]';
 import { RichTextOptions } from '../../utils/richText';
 import SessionContentCard from '../cards/SessionContentCard';
 import { Dots } from '../common/Dots';
 
-// TODO add documentation on when this component is used i.e. which storyblok component it renders
+/**
+ * This React component is used to render storyblok component "Bonus Block".
+ * This is currently used in the following session page: {@link SessionDetail}
+ */
 interface MultipleBonusContentProps {
   story: StoryData;
   eventData: { [index: string]: any };

--- a/pages/courses/image-based-abuse/[sessionSlug].tsx
+++ b/pages/courses/image-based-abuse/[sessionSlug].tsx
@@ -19,7 +19,7 @@ import { Dots } from '../../../components/common/Dots';
 import Link from '../../../components/common/Link';
 import CrispButton from '../../../components/crisp/CrispButton';
 import Header from '../../../components/layout/Header';
-import GridBonusContent from '../../../components/session/GridBonusContent';
+import MultipleBonusContent from '../../../components/session/GridBonusContent';
 import { SessionCompleteButton } from '../../../components/session/SessionCompleteButton';
 import Video from '../../../components/video/Video';
 import VideoTranscriptModal from '../../../components/video/VideoTranscriptModal';
@@ -301,7 +301,7 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
                     </SessionContentCard>
                   </>
                 )}
-              {story.content.bonus && <GridBonusContent story={story} eventData={eventData} />}
+              {story.content.bonus && <MultipleBonusContent story={story} eventData={eventData} />}
               {liveChatAccess && (
                 <>
                   <Dots />

--- a/pages/courses/image-based-abuse/[sessionSlug].tsx
+++ b/pages/courses/image-based-abuse/[sessionSlug].tsx
@@ -19,7 +19,7 @@ import { Dots } from '../../../components/common/Dots';
 import Link from '../../../components/common/Link';
 import CrispButton from '../../../components/crisp/CrispButton';
 import Header from '../../../components/layout/Header';
-import MultipleBonusContent from '../../../components/session/GridBonusContent';
+import MultipleBonusContent from '../../../components/session/MultipleBonusContent';
 import { SessionCompleteButton } from '../../../components/session/SessionCompleteButton';
 import Video from '../../../components/video/Video';
 import VideoTranscriptModal from '../../../components/video/VideoTranscriptModal';


### PR DESCRIPTION
Changed the view of Bonus Content for Image Based Abuse course to display as a column rather than a grid. 

c25b293655 / IBA: Change bonus content layout from grid to column