### PR TITLE
[HIGH LEVEL] Enable emojis in richtext

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@storyblok/storyblok-editable": "^1.0.0",
     "axios": "^0.24.0",
     "firebase": "^9.9.2",
+    "gemoji": "^8.1.0",
     "js-cookie": "^3.0.1",
     "material-ui-phone-number": "^3.0.0",
     "next": "^12.2.5",
@@ -41,7 +42,7 @@
     "rollbar": "^2.24.0",
     "sharp": "^0.30.5",
     "storyblok-js-client": "^4.2.0",
-    "storyblok-rich-text-react-renderer": "^2.5.2"
+    "storyblok-rich-text-react-renderer": "^2.9.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/utils/richText.tsx
+++ b/utils/richText.tsx
@@ -49,11 +49,12 @@ export const RichTextOptions: RenderOptions = {
         </Typography>
       );
     },
-    [NODE_EMOJI]: (children: ReactNode | null, { name }) => (
-      <span className="emoji" role="img" aria-label={name} aria-hidden={name ? 'false' : 'true'}>
-        {name && nameToEmoji[name]}
-      </span>
-    ),
+    [NODE_EMOJI]: (children: ReactNode | null, { name }) =>
+      name && nameToEmoji[name] ? (
+        <span className="emoji" role="img" aria-label={name} aria-hidden={false}>
+          {name && nameToEmoji[name]}
+        </span>
+      ) : null, // The return value is Element | null
   },
   markResolvers: {
     [MARK_LINK]: (children: any, props: any) => {

--- a/utils/richText.tsx
+++ b/utils/richText.tsx
@@ -1,7 +1,9 @@
 import { Typography } from '@mui/material';
+import { nameToEmoji } from 'gemoji';
 import { ReactNode } from 'react';
 import {
   MARK_LINK,
+  NODE_EMOJI,
   NODE_HEADING,
   NODE_PARAGRAPH,
   RenderOptions,
@@ -47,6 +49,11 @@ export const RichTextOptions: RenderOptions = {
         </Typography>
       );
     },
+    [NODE_EMOJI]: (children: ReactNode | null, { name }) => (
+      <span className="emoji" role="img" aria-label={name} aria-hidden={name ? 'false' : 'true'}>
+        {name && nameToEmoji[name]}
+      </span>
+    ),
   },
   markResolvers: {
     [MARK_LINK]: (children: any, props: any) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3466,6 +3466,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+gemoji@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/gemoji/-/gemoji-8.1.0.tgz#3d47a26e569c51efa95198822a6f483d7a7ae600"
+  integrity sha512-HA4Gx59dw2+tn+UAa7XEV4ufUKI4fH1KgcbenVA9YKSj1QJTT0xh5Mwv5HMFNN3l2OtUe3ZIfuRwSyZS5pLIWw==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -6054,10 +6059,10 @@ storyblok-js-client@^4.2.0:
   resolved "https://registry.yarnpkg.com/storyblok-js-client/-/storyblok-js-client-4.2.0.tgz#f1b64b256b071aef14d915e326210a73f18a0259"
   integrity sha512-dAeZfqFrHdxyvGFEVv0glOTxLx1Y2faGN39qeLZLOGCoeK49Xg53hOl8BddxqrjTqTp93GzbqLx04r/hzXrfxA==
 
-storyblok-rich-text-react-renderer@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/storyblok-rich-text-react-renderer/-/storyblok-rich-text-react-renderer-2.5.2.tgz#20001a4e7d88405568af130d9db50fde98f6418d"
-  integrity sha512-JgTPUJsPmxhmkKpP6nNivaGiIP0Te0+HXNSDm4df6CWSCi+LSrfrYGh9OFx+Bla1UujWhdxCj9OpY3dXzbdv3w==
+storyblok-rich-text-react-renderer@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/storyblok-rich-text-react-renderer/-/storyblok-rich-text-react-renderer-2.9.0.tgz#a3e77541c6803b8b5a897a6b798e8756ea9de8c1"
+  integrity sha512-AEcWGVrs7Y5O3cFn5kbhy+Odesk5Rf5JTXAhJrFPgIXybrAfVpzZeOUYuIjjPgGvQ3M/f7PieZg/SHUQVq34QA==
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
- update storyblok-renderer package to enable NODE_EMOJI resolver
- install gemoji to get Name to Emoji mapping 
- Storyblok sense us only the emoji name as a string and we have to map that to an emoji hence the installation of a mapping library