### PR TITLE
Auth session redirects bug

### DIFF
--- a/app/userSlice.tsx
+++ b/app/userSlice.tsx
@@ -18,7 +18,7 @@ export interface User {
   signUpLanguage: LANGUAGES | null;
   isSuperAdmin: boolean;
   activeSubscriptions: ActiveSubscription[];
-  firebaseTokenLoading: boolean;
+  authStateLoading: boolean;
 }
 
 export interface Subscription {
@@ -51,7 +51,7 @@ const initialState: User = {
   signUpLanguage: null,
   isSuperAdmin: false,
   activeSubscriptions: [],
-  firebaseTokenLoading: false,
+  authStateLoading: true,
 };
 
 const slice = createSlice({
@@ -67,8 +67,8 @@ const slice = createSlice({
     setUserLoading(state, action: PayloadAction<boolean>) {
       state.loading = action.payload;
     },
-    setUserFirebaseTokenLoading(state, action: PayloadAction<boolean>) {
-      state.firebaseTokenLoading = action.payload;
+    setAuthStateLoading(state, action: PayloadAction<boolean>) {
+      state.authStateLoading = action.payload;
     },
   },
 
@@ -114,7 +114,6 @@ const isSubscriptionActive = (subscription: Subscription): subscription is Activ
 };
 
 const { actions, reducer } = slice;
-export const { clearUserSlice, setUserToken, setUserLoading, setUserFirebaseTokenLoading } =
-  actions;
+export const { clearUserSlice, setUserToken, setUserLoading, setAuthStateLoading } = actions;
 export const selectCurrentUser = (state: RootState) => state.user;
 export default reducer;

--- a/cypress/integration/auth-redirect.cy.tsx
+++ b/cypress/integration/auth-redirect.cy.tsx
@@ -2,10 +2,21 @@ describe('Auth redirect', () => {
   before(() => {
     cy.cleanUpTestState();
   });
-  it('User visits a page with an auth guard and should be redirected', () => {
+  it('User visits the courses page and should be redirected with correct url', () => {
     cy.visit('/courses');
     cy.wait(2000);
     cy.get('h2', { timeout: 5000 }).should('contain', 'Welcome back');
     cy.url().should('include', 'return_url=%2Fcourses');
+  });
+  it('User visits a session page with an auth guard and should be redirected', () => {
+    cy.visit(
+      '/courses/image-based-abuse-and-rebuilding-ourselves/the-social-context-of-image-based-abuse-and-victim-blaming',
+    );
+    cy.wait(2000);
+    cy.get('h2', { timeout: 5000 }).should('contain', 'Welcome back');
+    cy.url().should(
+      'include',
+      'return_url=%2Fcourses%2Fimage-based-abuse-and-rebuilding-ourselves%2Fthe-social-context-of-image-based-abuse-and-victim-blaming',
+    );
   });
 });

--- a/guards/authGuard.tsx
+++ b/guards/authGuard.tsx
@@ -6,9 +6,15 @@ import { clearCoursesSlice } from '../app/coursesSlice';
 import { clearPartnerAccessesSlice } from '../app/partnerAccessSlice';
 import { clearPartnerAdminSlice } from '../app/partnerAdminSlice';
 import { RootState } from '../app/store';
-import { clearUserSlice, setUserLoading } from '../app/userSlice';
+import {
+  clearUserSlice,
+  setAuthStateLoading,
+  setUserLoading,
+  setUserToken,
+} from '../app/userSlice';
 import LoadingContainer from '../components/common/LoadingContainer';
 
+import { auth } from '../config/firebase';
 import rollbar from '../config/rollbar';
 import {
   GET_AUTH_USER_ERROR,
@@ -29,8 +35,42 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
 
   const { user } = useTypedSelector((state: RootState) => state);
   const [verified, setVerified] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [getUser] = useGetUserMutation();
+
+  // 1. Auth state loads and we check whether there is a user that exists and listen for a token change
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged(async (authState) => {
+      if (!authState) {
+        dispatch(setAuthStateLoading(false));
+        setLoading(false);
+        return;
+      }
+      // authState.getIdToken Returns a JSON Web Token (JWT) used to identify the user to a Firebase service.
+      // Returns the current token if it has not expired. Otherwise, this will refresh the token and return a new one.
+      const authToken = await authState.getIdToken();
+      dispatch(setUserToken(authToken));
+      dispatch(setAuthStateLoading(false));
+    });
+    return () => unsubscribe();
+  }, []);
+
+  // 2. Add ongoing event listener to check for token changes
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ENV !== 'local') {
+      hotjar.initialize(Number(process.env.NEXT_PUBLIC_HOTJAR_ID), 6);
+    }
+
+    // Add listener for new firebase auth token, updating it in state to be used in request headers
+    // Required for restoring user state following app reload or revisiting site
+
+    auth.onIdTokenChanged(async function (user) {
+      const token = await user?.getIdToken();
+      if (token) {
+        await dispatch(setUserToken(token));
+      }
+    });
+  }, []);
 
   // Function to get User details from the backend api
   async function callGetUser() {
@@ -65,13 +105,14 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
     }
   }
 
+  // 3. get user information from the backend
   useEffect(() => {
     // Only called where a firebase token exist but user data not loaded, e.g. app reload
 
     // If auth guard loading state is true, i.e. it has checked
     // or the getUser request has started but not finished
     // or the firebase token is being fetched
-    if (loading || user.loading || user.firebaseTokenLoading) {
+    if (user.loading || user.authStateLoading) {
       return;
     }
 
@@ -90,19 +131,20 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
         hotjar.identify('USER_ID', { userProperty: user.id });
       }
       setVerified(true);
+      setLoading(false);
       return;
     }
 
     // If the user state does not have a token at all (i.e. is null) and the page is not been set a loading
     // redirect to the log in page
-    if (!user.token) {
+    if (!user.token && !user.authStateLoading) {
+      setLoading(false);
       router.replace(`/auth/login${generateReturnQuery(router.asPath)}`);
       return;
     }
 
     // User firebase token exists but user data doesn't, so reload user data
     // Handles restoring user data on app reload or revisiting the site
-    setLoading(true);
     callGetUser();
     setLoading(false);
   }, [user, loading]);

--- a/guards/publicPageDataWrapper.tsx
+++ b/guards/publicPageDataWrapper.tsx
@@ -5,7 +5,13 @@ import { clearCoursesSlice } from '../app/coursesSlice';
 import { clearPartnerAccessesSlice } from '../app/partnerAccessSlice';
 import { clearPartnerAdminSlice } from '../app/partnerAdminSlice';
 import { RootState } from '../app/store';
-import { clearUserSlice, setUserLoading } from '../app/userSlice';
+import {
+  clearUserSlice,
+  setAuthStateLoading,
+  setUserLoading,
+  setUserToken,
+} from '../app/userSlice';
+import { auth } from '../config/firebase';
 import rollbar from '../config/rollbar';
 import { GET_AUTH_USER_ERROR, GET_AUTH_USER_SUCCESS } from '../constants/events';
 import { useAppDispatch, useTypedSelector } from '../hooks/store';
@@ -33,6 +39,23 @@ export function PublicPageDataWrapper({ children }: { children: JSX.Element }) {
   const [loading, setLoading] = useState(false);
 
   const [getUser] = useGetUserMutation();
+
+  // 1. Auth state loads and we check whether there is a user that exists and listen for a token change
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged(async (authState) => {
+      if (!authState) {
+        dispatch(setAuthStateLoading(false));
+        setLoading(false);
+        return;
+      }
+      // authState.getIdToken Returns a JSON Web Token (JWT) used to identify the user to a Firebase service.
+      // Returns the current token if it has not expired. Otherwise, this will refresh the token and return a new one.
+      const authToken = await authState.getIdToken();
+      dispatch(setUserToken(authToken));
+      dispatch(setAuthStateLoading(false));
+    });
+    return () => unsubscribe();
+  }, []);
 
   useEffect(() => {
     async function callGetUser() {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,10 +7,8 @@ import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { hotjar } from 'react-hotjar';
 import { Provider } from 'react-redux';
 import { wrapper } from '../app/store';
-import { setUserFirebaseTokenLoading, setUserToken } from '../app/userSlice';
 import CrispScript from '../components/crisp/CrispScript';
 import GoogleTagManagerScript from '../components/head/GoogleTagManagerScript';
 import OpenGraphMetadata from '../components/head/OpenGraphMetadata';
@@ -20,13 +18,11 @@ import Footer from '../components/layout/Footer';
 import LeaveSiteButton from '../components/layout/LeaveSiteButton';
 import TopBar from '../components/layout/TopBar';
 import createEmotionCache from '../config/emotionCache';
-import { auth } from '../config/firebase';
 import { AuthGuard } from '../guards/authGuard';
 import { PartnerAdminGuard } from '../guards/partnerAdminGuard';
 import { PublicPageDataWrapper } from '../guards/publicPageDataWrapper';
 import { SuperAdminGuard } from '../guards/superAdminGuard';
 import { TherapyAccessGuard } from '../guards/therapyAccessGuard';
-import { useAppDispatch } from '../hooks/store';
 import '../styles/globals.css';
 import theme from '../styles/theme';
 
@@ -49,7 +45,6 @@ function MyApp(props: MyAppProps) {
     pageProps: any;
   } = props;
 
-  const dispatch: any = useAppDispatch();
   const router = useRouter();
 
   // Example:
@@ -57,24 +52,6 @@ function MyApp(props: MyAppProps) {
   // This pathname split with a '/' separator will produce the array ['', 'auth', 'register']
   // The second array entry is pulled out as the pathHead and will be 'auth'
   const pathHead = router.pathname.split('/')[1]; // e.g. courses | therapy | partner-admin
-
-  useEffect(() => {
-    if (process.env.NEXT_PUBLIC_ENV !== 'local') {
-      hotjar.initialize(Number(process.env.NEXT_PUBLIC_HOTJAR_ID), 6);
-    }
-
-    // Add listener for new firebase auth token, updating it in state to be used in request headers
-    // Required for restoring user state following app reload or revisiting site
-    auth.onIdTokenChanged(async function (user) {
-      dispatch(setUserFirebaseTokenLoading(true));
-      const token = await user?.getIdToken();
-
-      if (token) {
-        await dispatch(setUserToken(token));
-      }
-      dispatch(setUserFirebaseTokenLoading(false));
-    });
-  }, [dispatch]);
 
   // Adds required permissions guard to pages, redirecting where required permissions are missing
   // New pages will default to requiring authenticated and public pages must be added to the array below

--- a/utils/generateReturnQuery.ts
+++ b/utils/generateReturnQuery.ts
@@ -1,7 +1,5 @@
 export default function generateReturnUrlQuery(pathname: string) {
-  return pathname.indexOf('/courses/') > -1
-    ? `?${generateReturnUrlParam('/courses')}`
-    : `?${generateReturnUrlParam(pathname)}`;
+  return `?${generateReturnUrlParam(pathname)}`;
 }
 
 export const generateReturnUrlParam = (path: string) => `return_url=${encodeURIComponent(path)}`;


### PR DESCRIPTION
- I've tried to add better documentation of the auth guard although it might still be confusing.
- I've Added a onAuthStateChanged listener to both public page wrapper and auth guard in the aim to just keep auth contained to each for readibilities sake, although I am sacrificing duplication. I was looking at this[ implementation](https://blog.logrocket.com/implementing-authentication-in-next-js-with-firebase/) for inspiration. It is interesting that they use contexts. Perhaps this might be a better direction to go in the future
- Another thing I learnt is that children useEffects run before parent useEffects. Previously the checking for the token in app.tsx happened after the useEffects in the authguard ran, hence we experience the redirect issues. 
- I've set user.authStateLoading as true by default because on every page, firebase auth is always checked. We have two loading flags, user.authUserLoading and user.loading. This differentiates between user.loading (waiting for the request from the backend to return) and user.authUserLoading. 
- I've added a cypress test for the bug in the auth redirects