### PR TITLE
Fix Auth redirect bug when callGetUser fails and improve racy cypress tests 

### DIFF
--- a/cypress/integration/activities.cy.tsx
+++ b/cypress/integration/activities.cy.tsx
@@ -6,8 +6,8 @@ describe('A logged in user should be able to navigate to activities and do an ex
 
   it('Should go to the activities page and click on an exercise', () => {
     cy.get(`[qa-id=secondary-nav-activities-button]`).should('exist').click(); //navigate to activities
-
-    cy.get('h3').contains('Thought diaries').should('exist').click(); //check click first  exercise exists and open it
+    // Default timeout is 4 seconds so extended to 8 to avoid racy tests
+    cy.get('h3', { timeout: 8000 }).contains('Thought diaries').should('exist').click(); //check click first  exercise exists and open it
 
     cy.get('.MuiCollapse-root.MuiCollapse-entered') //check the audio file exists in accordian
       .should('exist')

--- a/cypress/integration/grounding-exercises.cy.tsx
+++ b/cypress/integration/grounding-exercises.cy.tsx
@@ -6,10 +6,10 @@ describe('A logged in user should be able to navigate to grounding and do an exe
 
   it('Should go to the grounding page and click on an exercise', () => {
     cy.get(`[qa-id=secondary-nav-grounding-button]`).should('exist').click(); //navigate to grounding
+    // Extending timeout to ensure tests don't fail because of lazy loading
+    cy.get('h3', { timeout: 8000 }).contains('Visual breathing').should('exist').click(); //check visual breathing exercise exists and open it
 
-    cy.get('h3').contains('Visual breathing').should('exist').click(); //check visual breathing exercise exists and open it
-
-    cy.get('audio[src="https://a.storyblok.com/f/142459/x/add3c95f3c/visual-breathing-gif.m4a"]') //check the audio file exists in accordian
+    cy.get('audio') //check the audio file exists in accordian
       .should('exist')
       .invoke('attr', 'src')
       .then((audiofile) => {

--- a/guards/authGuard.tsx
+++ b/guards/authGuard.tsx
@@ -94,6 +94,8 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
         logEvent(GET_USER_ERROR, { message: getErrorMessage(userResponse.error) }); // deprecated event
         logEvent(GET_AUTH_USER_ERROR, { message: getErrorMessage(userResponse.error) });
       }
+
+      auth.signOut();
       await dispatch(clearPartnerAccessesSlice());
       await dispatch(clearPartnerAdminSlice());
       await dispatch(clearCoursesSlice());

--- a/guards/publicPageDataWrapper.tsx
+++ b/guards/publicPageDataWrapper.tsx
@@ -70,6 +70,8 @@ export function PublicPageDataWrapper({ children }: { children: JSX.Element }) {
           rollbar.error('LoadUserDataIfAvailable: get user error', userResponse.error);
           logEvent(GET_AUTH_USER_ERROR, { message: getErrorMessage(userResponse.error) });
         }
+
+        auth.signOut();
         await dispatch(clearPartnerAccessesSlice());
         await dispatch(clearPartnerAdminSlice());
         await dispatch(clearCoursesSlice());

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -71,8 +71,9 @@ const Login: NextPage = () => {
   const allPartnersContent = getAllPartnersContent();
 
   useEffect(() => {
-    if (user.token) {
-      router.push('/courses'); // Redirect if the user is on the login page but is alredy logged in
+    // Redirect if the user is on the login page but is already logged in and their data has been retrieved from the backend
+    if (user.token && user.id) {
+      router.push('/courses');
     }
   }, [user.token]);
 


### PR DESCRIPTION
- Add cypress test timeouts to improve raciness 
- Fetch just audio component in grounding to allow for file changes on the content side 
- Sign out of firebase auth if callGetUser fails to avoid eternal redirects