### PR TITLE
user id field added to the simply book widget config

### DIFF
--- a/config/simplybook.ts
+++ b/config/simplybook.ts
@@ -33,6 +33,9 @@ export const getSimplybookWidgetConfig = (user?: User) => {
             name: user.name,
             email: user.email,
           },
+          fields: {
+            b3b2455c79e69e6baf6e8c1fcf34b691: user.id,
+          }
         },
       }),
     },


### PR DESCRIPTION
Paasing in the user id to the simply book widget so we can use it to link the user based on their id rather than their email address. This will need to be merged into develop so that it can be tested on staging with the zapier / simplybook integrations. May need code changes after testing!