### PR TITLE
Linked /doc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ LinkedIn - [@chayn](https://www.linkedin.com/company/chayn)
 
 # Bloom Frontend
 
+For a more detailed explanation of this project's key concepts and architecture, please visit the [/docs](https://github.com/chaynHQ/bloom-frontend/tree/develop/docs) directory.
+
 [![Bloom CI Pipeline](https://github.com/chaynHQ/bloom-frontend/actions/workflows/deploy-to-staging.yml/badge.svg)](https://github.com/chaynHQ/bloom-frontend/actions/workflows/deploy-to-staging.yml)
 
 **Currently in active development**


### PR DESCRIPTION
Fixes #624 

- [X] Added the desired sentence.
- [X] Linked the /doc folder.

Happy Hacktoberfest! :)

Result:
![image](https://github.com/chaynHQ/bloom-frontend/assets/66525499/d0fb4d82-f754-4391-a0f4-9ad8147d8a0a)
