### PR TITLE
Address issue #624 link the /docs to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ LinkedIn - [@chayn](https://www.linkedin.com/company/chayn)
 
 # Bloom Frontend
 
+[For a more detailed explanation of this project's key concepts and architecture, please visit the /docs directory](https://github.com/chaynHQ/bloom-frontend/tree/develop/docs)
+
 [![Bloom CI Pipeline](https://github.com/chaynHQ/bloom-frontend/actions/workflows/deploy-to-staging.yml/badge.svg)](https://github.com/chaynHQ/bloom-frontend/actions/workflows/deploy-to-staging.yml)
 
 **Currently in active development**


### PR DESCRIPTION
### Issue ref: #624 

#### Issue description:
I have appended the following statement to the README below the header one, 'Bloom Frontend': 'To delve into a comprehensive exposition of this project's fundamental principles and structural framework, kindly peruse the contents of the /docs directory