### PR TITLE
fix: stop superadmins updating inactive therapy codes

### DIFF
--- a/components/forms/UpdateTherapyAdminForm.tsx
+++ b/components/forms/UpdateTherapyAdminForm.tsx
@@ -53,7 +53,7 @@ const UpdateTherapyAdminForm = () => {
       setAutocompleteSearchQueryIsLoading(true);
       const searchCritiera = {
         email: autocompleteSearchQuery,
-        partnerAccess: { featureTherapy: true },
+        partnerAccess: { featureTherapy: true, active: true },
         include: ['partnerAccess'],
         fields: ['partnerAccess'],
         limit: '10',


### PR DESCRIPTION
### Issue link / number:
In notion, N/A

### What changes did you make?
- filter partner access codes by active so admins don't update inactive partner access codes

### Why did you make the changes?
- fix bug where super admins acciddentaly could add therapy sessions to inactive access codes 

