### PR TITLE
NPS styles - more specific selectors 5

### DIFF
--- a/styles/hotjarNPS.css
+++ b/styles/hotjarNPS.css
@@ -176,9 +176,7 @@
   font-size: 0.875rem !important;
 }
 
-._hj-widget-container
-  ._hj-s3UIi__styles__globalStyles
-  ._hj-B\+0x3__styles__consentButton._hj-oxtSd__styles__declineButton,
+._hj-widget-container ._hj-B\+0x3__styles__consentButton._hj-oxtSd__styles__declineButton,
 ._hj_feedback_container ._hj-B\+0x3__styles__consentButton._hj-oxtSd__styles__declineButton {
   background-color: transparent !important;
   color: #000000 !important;


### PR DESCRIPTION
### What changes did you make?
Adjusted the CSS to attempt to override the hotjar CSS by using more specific selectors and more `!important`

### Why did you make the changes?
CSS is being overridden by hotjar styles loaded after our css import
