### PR TITLE
Gender multiple choice bug fix

### DIFF
--- a/components/forms/AboutYouDemographicForm.tsx
+++ b/components/forms/AboutYouDemographicForm.tsx
@@ -145,7 +145,7 @@ const AboutYouDemographicForm = () => {
               sx={staticFieldLabelStyle}
               variant="standard"
               label={t('genderLabel')}
-              required
+              required={genderInput.length === 0} // required doesn't play nicely with an array value. It is expecting a string
             />
           )}
         />


### PR DESCRIPTION
### Issue link / number:
N/A - ticket in notion

### What changes did you make?
- Changed when the required field runs in material UI as it is expecting a string in a textfield. 

### Why did you make the changes?
- fix an issue in submitting about-you form as required autocomplete was failing. 

