### PR TITLE
NPS styles - more specific selectors 7

### DIFF
--- a/styles/hotjarNPS.css
+++ b/styles/hotjarNPS.css
@@ -198,3 +198,8 @@
   color: #000000 !important;
   box-shadow: none !important;
 }
+
+._hj-widget-container ._hj-s3UIi__styles__globalStyles ._hj-B\+0X3__styles__consentButton i, ._hj_feedback_container ._hj-B\+0X3__styles__consentButton i {
+  font-size: 15px !important;
+  height: 17px !important;
+}


### PR DESCRIPTION
### What changes did you make?
Adjusted the CSS to attempt to override the hotjar CSS by using more specific selectors and more `!important`

### Why did you make the changes?
CSS is being overridden by hotjar styles loaded after our css import
