### PR TITLE
NPS styles - more specific selectors 7

### DIFF
--- a/styles/hotjarNPS.css
+++ b/styles/hotjarNPS.css
@@ -101,7 +101,7 @@
   ._hj-s3UIi__styles__globalStyles
   ._hj-XpAaA__styles__surveyFooter
   button[disabled]:hover {
-  background: #f1f2f6 !important;
+  background: rgb(255, 203, 182) !important;
 }
 
 /* Input styles */


### PR DESCRIPTION
### What changes did you make?
Adjusted the CSS to attempt to override the hotjar CSS by using more specific selectors and more `!important`

### Why did you make the changes?
CSS is being overridden by hotjar styles loaded after our css import