### PR TITLE
Add vercel analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@mui/material": "^5.0.2",
     "@reduxjs/toolkit": "^1.6.1",
     "@storyblok/storyblok-editable": "^1.0.0",
+    "@vercel/analytics": "^1.1.1",
     "axios": "^0.24.0",
     "firebase": "^9.9.2",
     "gemoji": "^8.1.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import { CacheProvider, EmotionCache } from '@emotion/react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 // Import the functions you need from the SDKs you need
+import { Analytics } from '@vercel/analytics/react';
 import { NextIntlClientProvider } from 'next-intl';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
@@ -107,6 +108,8 @@ function MyApp(props: MyAppProps) {
           <ComponentWithGuard />
           <Footer />
           <Consent />
+          {/* Vercel analytics */}
+          <Analytics /> 
         </ThemeProvider>
       </CacheProvider>
     </NextIntlClientProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1954,6 +1954,13 @@
     "@typescript-eslint/types" "4.32.0"
     eslint-visitor-keys "^2.0.0"
 
+"@vercel/analytics@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-1.1.1.tgz#2a712378a95014a548b4f9d2ae1ea0721433908d"
+  integrity sha512-+NqgNmSabg3IFfxYhrWCfB/H+RCUOCR5ExRudNG2+pcRehq628DJB5e1u1xqwpLtn4pAYii4D98w7kofORAGQA==
+  dependencies:
+    server-only "^0.0.1"
+
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -6014,6 +6021,11 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
 
 setimmediate@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
### What changes did you make?
Add [vercel analytics](https://vercel.com/docs/analytics). Currently doesn't use custom events and just stores basic activity

### Why did you make the changes?
To test the vercel integrations and serve as an extra source of data primarly for developers, but also as a backup to google analytics
Note vercel analytics are [compliant with GDPR ](https://posthog.com/blog/best-gdpr-compliant-analytics-tools#6-vercel-web-analytics)
