### PR TITLE
Fix PWA with buildExcludes + runtimeCaching

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,15 @@
 /** @type {import('next').NextConfig} */
 
-const withPWA = require('next-pwa')({
-  dest: 'public',
-});
+const withPWA = require('next-pwa');
+const runtimeCaching = require('next-pwa/cache');
 
 module.exports = withPWA({
   reactStrictMode: true,
+  pwa: {
+    dest: 'public',
+    runtimeCaching,
+    buildExcludes: [/middleware-manifest.json$/],
+  },
   publicRuntimeConfig: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
     NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,15 @@
 /** @type {import('next').NextConfig} */
 
-const withPWA = require('next-pwa');
 const runtimeCaching = require('next-pwa/cache');
+
+const withPWA = require('next-pwa')({
+  dest: 'public',
+  runtimeCaching,
+  buildExcludes: [/middleware-manifest.json$/],
+});
 
 module.exports = withPWA({
   reactStrictMode: true,
-  pwa: {
-    dest: 'public',
-    runtimeCaching,
-    buildExcludes: [/middleware-manifest.json$/],
-  },
   publicRuntimeConfig: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
     NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,

--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const runtimeCaching = require('next-pwa/cache');
 const withPWA = require('next-pwa')({
   dest: 'public',
   runtimeCaching,
-  buildExcludes: [/middleware-manifest.json$/],
+  buildExcludes: [/middleware-manifest\.json$/],
 });
 
 module.exports = withPWA({


### PR DESCRIPTION
### What changes did you make?
Add patch/fix for PWA `bad-precaching-response` error - see [issue](https://github.com/shadowwalker/next-pwa/issues/288) and suggested [fix](https://github.com/shadowwalker/next-pwa/issues/288#issuecomment-953799577)

```
Uncaught (in promise) bad-precaching-response: bad-precaching-response :: [{"url":"https://bloom.chayn.co/_next/app-build-manifest.json","status":404}]
    at Z.S (https://bloom.chayn.co/workbox-9b4d2a02.js:1:16900)
    at async Z.U (https://bloom.chayn.co/workbox-9b4d2a02.js:1:16452)
    at async Z.q (https://bloom.chayn.co/workbox-9b4d2a02.js:1:7597)
```