### PR TITLE
Add partytown to move scripts to web worker

### DIFF
--- a/.github/workflows/build-and-test-prs.yml
+++ b/.github/workflows/build-and-test-prs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use NodeJs
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '20.x'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --non-interactive

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use NodeJs
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '20.x'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --non-interactive

--- a/.gitignore
+++ b/.gitignore
@@ -5,16 +5,6 @@
 /.pnp
 .pnp.js
 
-# testing
-/coverage
-/cypress/screenshots
-/cypress/videos
-/cypress/example
-
-
-# cypress
-cypress.env.json
-
 # next.js
 /.next/
 /out/
@@ -53,3 +43,13 @@ yarn-error.log*
 /public/sw.js.map
 /public/workbox-*.js
 /public/workbox-*.js.map
+
+# Cypress testing
+/coverage
+/cypress/screenshots
+/cypress/videos
+/cypress/example
+cypress.env.json
+
+# Partytown
+/public/~partytown

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Happy coding! ⭐
 
 ## Prerequisites
 
-- NodeJS v16.x
+- NodeJS 20.x
 - Yarn v1.x
 
 ## Local Development:

--- a/components/crisp/CrispScript.tsx
+++ b/components/crisp/CrispScript.tsx
@@ -74,6 +74,7 @@ const CrispScript = () => {
   return (
     <Script
       id="crisp-widget"
+      type="text/partytown"
       strategy="afterInteractive"
       dangerouslySetInnerHTML={{
         __html: `

--- a/components/crisp/CrispScript.tsx
+++ b/components/crisp/CrispScript.tsx
@@ -74,7 +74,6 @@ const CrispScript = () => {
   return (
     <Script
       id="crisp-widget"
-      type="text/partytown"
       strategy="afterInteractive"
       dangerouslySetInnerHTML={{
         __html: `

--- a/components/head/GoogleTagManagerScript.tsx
+++ b/components/head/GoogleTagManagerScript.tsx
@@ -4,7 +4,7 @@ const GoogleTagManagerScript = () => {
   return (
     <Script
       id="gtag"
-      strategy="afterInteractive"
+      type="text/partytown"
       dangerouslySetInnerHTML={{
         __html: `
             window.dataLayer = window.dataLayer || [];

--- a/components/head/HotjarScript.tsx
+++ b/components/head/HotjarScript.tsx
@@ -1,0 +1,24 @@
+import Script from 'next/script';
+
+const HotjarScript = () => {
+  return (
+    <Script
+      id="hotjar"
+      type="text/partytown"
+      dangerouslySetInnerHTML={{
+        __html: `
+          (function(h,o,t,j,a,r){
+            h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+            h._hjSettings={hjid:${process.env.NEXT_PUBLIC_HOTJAR_ID},hjsv:6};
+            a=o.getElementsByTagName('head')[0];
+            r=o.createElement('script');r.async=1;
+            r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+            a.appendChild(r);
+          })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+        `,
+      }}
+    />
+  );
+};
+
+export default HotjarScript;

--- a/components/head/HotjarScript.tsx
+++ b/components/head/HotjarScript.tsx
@@ -1,6 +1,8 @@
 import Script from 'next/script';
 
 const HotjarScript = () => {
+  if (process.env.NEXT_PUBLIC_ENV === 'local') return <></>
+  
   return (
     <Script
       id="hotjar"

--- a/components/head/HotjarScript.tsx
+++ b/components/head/HotjarScript.tsx
@@ -1,8 +1,6 @@
 import Script from 'next/script';
 
-const HotjarScript = () => {
-  if (process.env.NEXT_PUBLIC_ENV === 'local') return <></>
-  
+const HotjarScript = () => {  
   return (
     <Script
       id="hotjar"

--- a/guards/authGuard.tsx
+++ b/guards/authGuard.tsx
@@ -1,7 +1,5 @@
-import Cookies from 'js-cookie';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { hotjar } from 'react-hotjar';
 import { api, useGetUserMutation } from '../app/api';
 import { clearCoursesSlice } from '../app/coursesSlice';
 import { clearPartnerAccessesSlice } from '../app/partnerAccessSlice';
@@ -58,10 +56,6 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
 
   // 2. Add ongoing event listener to check for token changes
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_ENV !== 'local') {
-      hotjar.initialize(Number(process.env.NEXT_PUBLIC_HOTJAR_ID), 6);
-    }
-
     // Add listener for new firebase auth token, updating it in state to be used in request headers
     // Required for restoring user state following app reload or revisiting site
 
@@ -129,10 +123,6 @@ export function AuthGuard({ children }: { children: JSX.Element }) {
 
     // If the User state has already been populated and ID from the backend has been given set verified as true
     if (user.id) {
-      // Check users analytics consent before sending user data
-      if (process.env.NEXT_PUBLIC_ENV !== 'local' && Cookies.get('analyticsConsent') === 'true') {
-        hotjar.identify('USER_ID', { userProperty: user.id });
-      }
       setVerified(true);
       setLoading(false);
       return;

--- a/guards/publicPageDataWrapper.tsx
+++ b/guards/publicPageDataWrapper.tsx
@@ -1,7 +1,5 @@
-import Cookies from 'js-cookie';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { hotjar } from 'react-hotjar';
 import { api, useGetUserMutation } from '../app/api';
 import { clearCoursesSlice } from '../app/coursesSlice';
 import { clearPartnerAccessesSlice } from '../app/partnerAccessSlice';
@@ -89,12 +87,6 @@ export function PublicPageDataWrapper({ children }: { children: JSX.Element }) {
     if (user.token && !user.id) {
       // User firebase token exists (i.e. user is logged in) but user data hasn't been loaded
       callGetUser();
-    }
-    if (user.id && process.env.NEXT_PUBLIC_ENV !== 'local') {
-      // Checking for analytics consent before sending userIdentifiers to hotjar
-      if (Cookies.get('analyticsConsent') === 'true') {
-        hotjar.identify('USER_ID', { userProperty: user.id });
-      }
     }
   }, [getUser, router, user]);
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react": "18.2.0",
     "react-cookie-consent": "^8.0.1",
     "react-dom": "18.0.0",
-    "react-hotjar": "^5.0.0",
     "react-player": "^2.13.0",
     "react-redux": "^8.0.5",
     "rollbar": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "npm run partytown && next build",
+    "build": "yarn run partytown && next build",
     "partytown": "partytown copylib public/~partytown",
     "start": "next start",
     "https:proxy": "local-ssl-proxy --source 3010 --target 3000 --cert localhost.pem --key localhost-key.pem",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "npm run partytown && next build",
+    "partytown": "partytown copylib public/~partytown",
     "start": "next start",
     "https:proxy": "local-ssl-proxy --source 3010 --target 3000 --cert localhost.pem --key localhost-key.pem",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cypress:headless": "cypress run --headless true --browser chrome"
   },
   "dependencies": {
+    "@builder.io/partytown": "^0.8.1",
     "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.4.1",
     "@emotion/server": "^11.4.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,14 +5,10 @@ import { ThemeProvider } from '@mui/material/styles';
 import { Analytics } from '@vercel/analytics/react';
 import { NextIntlClientProvider } from 'next-intl';
 import type { AppProps } from 'next/app';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
 import { wrapper } from '../app/store';
-import CrispScript from '../components/crisp/CrispScript';
-import GoogleTagManagerScript from '../components/head/GoogleTagManagerScript';
-import OpenGraphMetadata from '../components/head/OpenGraphMetadata';
 import { AppBarSpacer } from '../components/layout/AppBarSpacer';
 import Consent from '../components/layout/Consent';
 import Footer from '../components/layout/Footer';
@@ -104,13 +100,6 @@ function MyApp(props: MyAppProps) {
   return (
     <NextIntlClientProvider messages={pageProps.messages}>
       <CacheProvider value={emotionCache}>
-        <Head>
-          <title>Bloom</title>
-          <meta name="viewport" content="initial-scale=1, width=device-width" />
-        </Head>
-        <GoogleTagManagerScript />
-        <OpenGraphMetadata />
-        <CrispScript />
         <ThemeProvider theme={theme}>
           <CssBaseline />
           <TopBar />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { Analytics } from '@vercel/analytics/react';
 import { NextIntlClientProvider } from 'next-intl';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
@@ -101,6 +102,10 @@ function MyApp(props: MyAppProps) {
   return (
     <NextIntlClientProvider messages={pageProps.messages}>
       <CacheProvider value={emotionCache}>
+        <Head>
+          <title>Bloom</title>
+          <meta name="viewport" content="initial-scale=1, width=device-width" />
+        </Head>
         <CrispScript />
         <ThemeProvider theme={theme}>
           <CssBaseline />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
 import { wrapper } from '../app/store';
+import CrispScript from '../components/crisp/CrispScript';
 import { AppBarSpacer } from '../components/layout/AppBarSpacer';
 import Consent from '../components/layout/Consent';
 import Footer from '../components/layout/Footer';
@@ -100,6 +101,7 @@ function MyApp(props: MyAppProps) {
   return (
     <NextIntlClientProvider messages={pageProps.messages}>
       <CacheProvider value={emotionCache}>
+        <CrispScript />
         <ThemeProvider theme={theme}>
           <CssBaseline />
           <TopBar />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -2,7 +2,6 @@ import { Partytown } from '@builder.io/partytown/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 import * as React from 'react';
-import CrispScript from '../components/crisp/CrispScript';
 import GoogleTagManagerScript from '../components/head/GoogleTagManagerScript';
 import HotjarScript from '../components/head/HotjarScript';
 import OpenGraphMetadata from '../components/head/OpenGraphMetadata';
@@ -21,7 +20,6 @@ export default class MyDocument extends Document {
           <Partytown debug={true} forward={['dataLayer.push']} />
           <OpenGraphMetadata />
           <GoogleTagManagerScript />
-          <CrispScript />
           <HotjarScript />
         </Head>
         <body>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -19,7 +19,9 @@ export default class MyDocument extends Document {
           <Partytown debug={true} forward={['dataLayer.push']} />
           <OpenGraphMetadata />
           <GoogleTagManagerScript />
-          <HotjarScript />
+          {process.env.NEXT_PUBLIC_ENV === 'local' && (
+            <HotjarScript />
+          )}
         </Head>
         <body>
           <Main />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,10 @@
+import { Partytown } from '@builder.io/partytown/react';
 import createEmotionServer from '@emotion/server/create-instance';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 import * as React from 'react';
+import CrispScript from '../components/crisp/CrispScript';
+import GoogleTagManagerScript from '../components/head/GoogleTagManagerScript';
+import OpenGraphMetadata from '../components/head/OpenGraphMetadata';
 import createEmotionCache from '../config/emotionCache';
 
 export default class MyDocument extends Document {
@@ -12,6 +16,11 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Open+Sans:ital,wght@0,300;0,400;0,600;1,300;1,400;1,600&display=swap"
             rel="stylesheet"
           />
+          <meta name="viewport" content="initial-scale=1, width=device-width" />
+          <Partytown debug={true} forward={['dataLayer.push']} />
+          <OpenGraphMetadata />
+          <GoogleTagManagerScript />
+          <CrispScript />
         </Head>
         <body>
           <Main />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -16,7 +16,6 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Open+Sans:ital,wght@0,300;0,400;0,600;1,300;1,400;1,600&display=swap"
             rel="stylesheet"
           />
-          <meta name="viewport" content="initial-scale=1, width=device-width" />
           <Partytown debug={true} forward={['dataLayer.push']} />
           <OpenGraphMetadata />
           <GoogleTagManagerScript />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,6 +4,7 @@ import Document, { Head, Html, Main, NextScript } from 'next/document';
 import * as React from 'react';
 import CrispScript from '../components/crisp/CrispScript';
 import GoogleTagManagerScript from '../components/head/GoogleTagManagerScript';
+import HotjarScript from '../components/head/HotjarScript';
 import OpenGraphMetadata from '../components/head/OpenGraphMetadata';
 import createEmotionCache from '../config/emotionCache';
 
@@ -21,6 +22,7 @@ export default class MyDocument extends Document {
           <OpenGraphMetadata />
           <GoogleTagManagerScript />
           <CrispScript />
+          <HotjarScript />
         </Head>
         <body>
           <Main />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7553,11 +7553,6 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-hotjar@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/react-hotjar/-/react-hotjar-5.0.0.tgz#72beaa2e0067b407c4183dc3ace5020f68959cab"
-  integrity sha512-nEKDm+O5a77C9DlheuA9tz5rwhRjeIFPLhdvynGFxEYTT1qrYC3NU12Z9/tgvN2l9Tzyn7erUQ0C8fZHZBceTw==
-
 "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,6 +1234,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@builder.io/partytown@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.8.1.tgz#d50f2508b2e9b554ac890e8130c60b27cfb5958a"
+  integrity sha512-p4xhEtQCPe8YFJ8e7KT9RptnT+f4lvtbmXymbp1t0bLp+USkNMTxrRMNc3Dlr2w2fpxyX7uA0CyAeU3ju84O4A==
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"


### PR DESCRIPTION
### What changes did you make?
- Adds [partytown](https://partytown.builder.io/) package to move third-party scripts (GTM + hotjar) to a web worker
- partytown requires node v18+, updated app to use node v20+ as this caused no errors
- partytown can't work with `react-hotjar` as we don't have access to the `<script>` element - this change removes the package in favour of the standard script. Note this also removes the functionality to add the user id to hotjar users - we should discuss if this is a feature we're willing to, or even favour removing. Hotjar is the top 1/2 most expensive scripts, up to 1s

### Why did you make the changes?
Our third party scripts are blocking the main thread, and so blocking the page for 0.2-2+ seconds. Moving third-party scripts to a web worker, outside of the main thread, will massively increase performance.

### Notes on partytown
- the package is in Beta but has 250k downloads/week and is in active development (recent releases)
