### PR TITLE
Replace cypress-run job

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,4 +1,4 @@
-name: Deploy to staging
+name: Create release PR
 
 on:
   push:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,4 +1,4 @@
-name: Create release PR
+name: Deploy to staging
 
 on:
   push:
@@ -6,8 +6,60 @@ on:
       - develop
 
 jobs:
+  cypress-run:
+    name: Cypress E2E tests
+    runs-on: ubuntu-latest
+    strategy:
+      # when one test fails, DO NOT cancel the other
+      # containers, because this will kill Cypress processes
+      # leaving Cypress Cloud hanging ...
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # run 3 copies of the current job in parallel
+        # this will automatically load balance
+        containers: [1, 2, 3]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run cypress
+        uses: cypress-io/github-action@v6
+        with:
+          browser: chrome
+          spec: cypress/**/*.cy.tsx
+          headed: false
+          record: true # send results to cypress dashboard
+          parallel: true
+        env:
+          NEXT_PUBLIC_ROLLBAR_ENV: CI
+          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+          NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN }}
+          NEXT_PUBLIC_STORYBLOK_TOKEN: ${{ secrets.NEXT_PUBLIC_STORYBLOK_TOKEN }}
+          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
+          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET }}
+          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID}}
+          NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
+          NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID }}
+          CYPRESS_BASE_URL: ${{ secrets.NEXT_PUBLIC_BASE_URL }}
+          CYPRESS_mail_slurp_api_key: ${{secrets.CYPRESS_MAIL_SLURP_API_KEY}}
+          CYPRESS_inbox_id: ${{secrets.CYPRESS_INBOX_ID}}
+          CYPRESS_reset_pwd_content_email: ${{secrets.CYPRESS_RESET_PWD_CONTENT_EMAIL}}
+          CYPRESS_bumble_partner_admin_email: ${{secrets.CYPRESS_BUMBLE_ADMIN_EMAIL}}
+          CYPRESS_bumble_partner_admin_password: ${{secrets.CYPRESS_TEST_ACCOUNT_PASSWORD}}
+          CYPRESS_badoo_partner_admin_email: ${{secrets.CYPRESS_BADOO_ADMIN_EMAIL}}
+          CYPRESS_badoo_partner_admin_password: ${{secrets.CYPRESS_TEST_ACCOUNT_PASSWORD}}
+          CYPRESS_super_admin_email: ${{secrets.CYPRESS_SUPER_ADMIN_EMAIL}}
+          CYPRESS_super_admin_password: ${{secrets.CYPRESS_TEST_ACCOUNT_PASSWORD}}
+          CYPRESS_public_email: ${{secrets.CYPRESS_PUBLIC_EMAIL}}
+          CYPRESS_public_password: ${{secrets.CYPRESS_PUBLIC_PASSWORD}}
+          CYPRESS_api_url: ${{secrets.CYPRESS_BLOOM_BACKEND_API_URL}}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   create-pr-to-main:
-    name: Create release PR
+    name: Create release PR to main
+    needs: cypress-run
     runs-on: ubuntu-latest
     steps:
       - name: Create Pull Request


### PR DESCRIPTION
### What changes did you make?
Replaced cypress-run job on the `create-release-pr` action

### Why did you make the changes?
This was removed in the previous migration to Vercel. Adding back now as realised it's the only place that tests are run (rather than being run on each branch)
