### PR TITLE
Fix production testing workflow - run tests on main PRs

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -6,57 +6,6 @@ on:
       - develop
 
 jobs:
-  cypress-run:
-    name: Cypress E2E tests
-    runs-on: ubuntu-latest
-    strategy:
-      # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
-      # leaving Cypress Cloud hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
-      fail-fast: false
-      matrix:
-        # run 3 copies of the current job in parallel
-        # this will automatically load balance
-        containers: [1, 2, 3]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Run cypress
-        uses: cypress-io/github-action@v6
-        with:
-          browser: chrome
-          spec: cypress/**/*.cy.tsx
-          headed: false
-          record: true # send results to cypress dashboard
-          parallel: true
-        env:
-          NEXT_PUBLIC_ROLLBAR_ENV: CI
-          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
-          NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN }}
-          NEXT_PUBLIC_STORYBLOK_TOKEN: ${{ secrets.NEXT_PUBLIC_STORYBLOK_TOKEN }}
-          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
-          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
-          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET }}
-          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID}}
-          NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
-          NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID }}
-          CYPRESS_BASE_URL: ${{ secrets.NEXT_PUBLIC_BASE_URL }}
-          CYPRESS_mail_slurp_api_key: ${{secrets.CYPRESS_MAIL_SLURP_API_KEY}}
-          CYPRESS_inbox_id: ${{secrets.CYPRESS_INBOX_ID}}
-          CYPRESS_reset_pwd_content_email: ${{secrets.CYPRESS_RESET_PWD_CONTENT_EMAIL}}
-          CYPRESS_bumble_partner_admin_email: ${{secrets.CYPRESS_BUMBLE_ADMIN_EMAIL}}
-          CYPRESS_bumble_partner_admin_password: ${{secrets.CYPRESS_TEST_ACCOUNT_PASSWORD}}
-          CYPRESS_badoo_partner_admin_email: ${{secrets.CYPRESS_BADOO_ADMIN_EMAIL}}
-          CYPRESS_badoo_partner_admin_password: ${{secrets.CYPRESS_TEST_ACCOUNT_PASSWORD}}
-          CYPRESS_super_admin_email: ${{secrets.CYPRESS_SUPER_ADMIN_EMAIL}}
-          CYPRESS_super_admin_password: ${{secrets.CYPRESS_TEST_ACCOUNT_PASSWORD}}
-          CYPRESS_public_email: ${{secrets.CYPRESS_PUBLIC_EMAIL}}
-          CYPRESS_public_password: ${{secrets.CYPRESS_PUBLIC_PASSWORD}}
-          CYPRESS_api_url: ${{secrets.CYPRESS_BLOOM_BACKEND_API_URL}}
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   create-pr-to-main:
     name: Create release PR to main
     needs: cypress-run

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -1,49 +1,25 @@
-name: Cypress tests # on both PRs and push to develop/main
+name: Cypress release tests
 
-# Trigger is like this because I want a way to select which branches to run cypress tests.
-# Can change to something better in the future
 on:
-  push:
-    branches:
-      - 'run-cypress-tests/**'
-      - 'dependabot/**'
-  workflow_dispatch:
+  pull_request:
+    branches: [main]
 
 jobs:
-  build:
-    name: Build
+  # vercel will redeploy the develop/staging app on creating a PR to main
+  # wait for new deployment to complete before running tests
+  wait-for-vercel-deployment:
+    name: Wait for vercel deployment
     runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache node_modules
-        uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - name: Wait for Vercel preview deployment to be ready
+        uses: patrickedqvist/wait-for-vercel-preview@master
+        id: waitForVercelPreviewDeployment
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Use NodeJs
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16.x'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 120
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile --non-interactive
-
-      - name: Run linting
-        run: yarn lint
-
-      - name: Build app
-        run: yarn build
-        env:
-          NEXT_PUBLIC_ROLLBAR_ENV: CI
-          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
-          NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN: ${{ secrets.NEXT_PUBLIC_ROLLBAR_CLIENT_TOKEN }}
-          NEXT_PUBLIC_STORYBLOK_TOKEN: ${{ secrets.NEXT_PUBLIC_STORYBLOK_TOKEN }}
   cypress-run:
     name: Cypress e2e tests
     needs: build

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - 'run-cypress-tests/**'
       - 'dependabot/**'
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -80,7 +82,7 @@ jobs:
           NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID}}
           NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
           NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID }}
-          CYPRESS_BASE_URL: 'https://bloom-frontend-git-develop-chaynhq.vercel.app/' # runs cypress against staging
+          CYPRESS_BASE_URL: ${{ secrets.NEXT_PUBLIC_BASE_URL }}
           CYPRESS_mail_slurp_api_key: ${{secrets.CYPRESS_MAIL_SLURP_API_KEY}}
           CYPRESS_inbox_id: ${{secrets.CYPRESS_INBOX_ID}}
           CYPRESS_reset_pwd_content_email: ${{secrets.CYPRESS_RESET_PWD_CONTENT_EMAIL}}


### PR DESCRIPTION
### What changes did you make?
Delays running tests on main until the new preview/staging deployment is complete. Uses [wait-for-vercel-preview](https://github.com/patrickedqvist/wait-for-vercel-preview) action to prevent tests running until the preview app is redeployed.

### Why did you make the changes?
The vercel deployment for preview (now https://bloom-frontend-git-develop-chaynhq.vercel.app/) would not have completed before the tests were run.

