### PR TITLE
Fix dep on create-release-pr

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   create-pr-to-main:
     name: Create release PR to main
-    needs: cypress-run
     runs-on: ubuntu-latest
     steps:
       - name: Create Pull Request


### PR DESCRIPTION
### What changes did you make?
Fixes error on create-release-pr deps as the previous job was removed/moved to `cypress-release-tests`