### PR TITLE
Fix cypress-release-tests - increase timeout

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 1000
+          check_interval: 5
 
   cypress-run:
     name: Cypress e2e tests

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -17,7 +17,7 @@ jobs:
         id: waitForVercelDeployment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 120
+          max_timeout: 1000
 
   cypress-run:
     name: Cypress e2e tests


### PR DESCRIPTION
### What changes did you make?
wait-for-vercel was [responding](https://github.com/chaynHQ/bloom-frontend/actions/runs/7046448434/job/19178267842?pr=725) with `Could not find any deployments for actor vercel[bot], retrying (attempt 1 / 30)` and timed out at 120 seconds before the deployment was ready 
