### PR TITLE
Fix cypress-release-test - downgrade action

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for Vercel preview deployment to be ready
-        uses: patrickedqvist/wait-for-vercel-preview@v1.1.1
+        uses: patrickedqvist/wait-for-vercel-preview@v1.2.0
         id: waitForVercelDeployment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for Vercel preview deployment to be ready
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
+        uses: patrickedqvist/wait-for-vercel-preview@v1.1.1
         id: waitForVercelDeployment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What changes did you make?
Downgrade wait-for-vercel-preview due to 401 error and [issue](https://github.com/patrickedqvist/wait-for-vercel-preview/issues/54) suggesting this isnt the case on 1.2.0
