### PR TITLE
Temporarily skip cypress-release-test action

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -1,9 +1,11 @@
 name: Cypress release tests
 
-on:
-  pull_request:
-    branches:
-      - main
+# TODO: FIX 401 issue on wait-for-vercel-preview and uncomment lines below
+
+# on:
+#   pull_request:
+#     branches:
+#       - main
 
 jobs:
   # vercel will redeploy the develop/staging app on creating a PR to main
@@ -11,9 +13,11 @@ jobs:
   wait-for-vercel-deployment:
     name: Wait for vercel deployment
     runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.waitForVercelDeployment.outputs.url }}
     steps:
       - name: Wait for Vercel preview deployment to be ready
-        uses: patrickedqvist/wait-for-vercel-preview@v1.2.0
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
         id: waitForVercelDeployment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +60,7 @@ jobs:
           NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID}}
           NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
           NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID }}
-          CYPRESS_BASE_URL: ${{ secrets.NEXT_PUBLIC_BASE_URL }}
+          CYPRESS_BASE_URL: ${{ needs.wait-for-vercel-deployment.outputs.preview_url }}
           CYPRESS_mail_slurp_api_key: ${{secrets.CYPRESS_MAIL_SLURP_API_KEY}}
           CYPRESS_inbox_id: ${{secrets.CYPRESS_INBOX_ID}}
           CYPRESS_reset_pwd_content_email: ${{secrets.CYPRESS_RESET_PWD_CONTENT_EMAIL}}


### PR DESCRIPTION
### What changes did you make?
The cypress-release-test action is failing due to a [401 error](https://github.com/patrickedqvist/wait-for-vercel-preview/issues/54) on [wait-for-vercel-preview](https://github.com/patrickedqvist/wait-for-vercel-preview) 
Until we have more time to work this out or get a response, the cypress test needs to be turned off as theres no other way to wait for the build to finish on vercel before testing.


