### PR TITLE
Fix cypress-release-tests with deployment_status

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -2,13 +2,11 @@ name: Cypress release tests
 
 on:
   deployment_status:
-    branches:
-      - main
 
 jobs:
   cypress-run:
     name: Cypress e2e tests
-    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     strategy:
       # when one test fails, DO NOT cancel the other


### PR DESCRIPTION
### What changes did you make?
Removes wait-for-vercel-preview action and uses `deployment_status` functionality as documented [here](https://vercel.com/guides/how-can-i-run-end-to-end-tests-after-my-vercel-preview-deployment)
