### PR TITLE
Fix cypress-release-tests - rearrange if

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cypress-run:
     name: Cypress e2e tests
-    if: github.ref == 'refs/heads/main' && github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       # when one test fails, DO NOT cancel the other


### PR DESCRIPTION
### What changes did you make?
Changed order of if statement on github action step, to prevent the step skipping too early.

