### PR TITLE
Fix cypress release tests - develop branch

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cypress-run:
     name: Cypress e2e tests
-    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     strategy:
       # when one test fails, DO NOT cancel the other


### PR DESCRIPTION
### What changes did you make?
Cypress release tests action is still not being triggered. Test using `github.ref == 'refs/heads/develop'` as the ref