### PR TITLE
feat: enable signup banner on partially public pages

### DIFF
--- a/components/banner/SignUpBanner.tsx
+++ b/components/banner/SignUpBanner.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import { useTranslations } from 'next-intl';
+import { STORYBLOK_COLORS } from '../../constants/enums';
+import Column from '../common/Column';
+import Link from '../common/Link';
+import PageSection from '../common/PageSection';
+import Row from '../common/Row';
+
+interface SignUpBannerProps {}
+
+export const SignUpBanner = ({}: SignUpBannerProps) => {
+  const t = useTranslations('Shared');
+
+  return (
+    <PageSection color={STORYBLOK_COLORS.BLOOM_GRADIENT} alignment="center">
+      <Row numberOfColumns={1} horizontalAlignment={'center'} verticalAlignment={'center'}>
+        <Column>
+          <Typography variant="h2" component="h2" mb={2}>
+            {t('signUpTodayPromo.title')}
+          </Typography>
+          <Typography mb={2}>{t('signUpTodayPromo.description1')}</Typography>
+          <Typography
+            sx={{
+              mb: '2rem !important',
+            }}
+          >
+            {t('signUpTodayPromo.description2')}
+          </Typography>
+          <Button component={Link} variant="contained" color="secondary" href={'/auth/register'}>
+            {t('signUpTodayPromo.button')}
+          </Button>
+        </Column>
+      </Row>
+    </PageSection>
+  );
+};

--- a/components/common/Column.tsx
+++ b/components/common/Column.tsx
@@ -1,0 +1,32 @@
+import { Box } from '@mui/system';
+
+interface ColumnProps {
+  children: any;
+  width?: string;
+}
+
+const Column = (props: ColumnProps) => {
+  const { width, children } = props;
+
+  const columnStyles = {
+    width:
+      width === 'extra-small'
+        ? {
+            xs: `20%`,
+            md: '5%',
+          }
+        : width === 'small'
+        ? { xs: '100%', md: '20%' }
+        : width === 'medium'
+        ? { xs: '100%', md: '40%' }
+        : width === 'large'
+        ? { xs: '100%', md: '60%' }
+        : width === 'extra-large'
+        ? { xs: '100%', md: '80%' }
+        : { xs: `100%`, md: 'auto' },
+    ...(!width ? { flex: { md: 1 } } : {}),
+  };
+  return <Box sx={columnStyles}>{children}</Box>;
+};
+
+export default Column;

--- a/components/common/PageSection.tsx
+++ b/components/common/PageSection.tsx
@@ -1,0 +1,35 @@
+import { Container } from '@mui/material';
+import { STORYBLOK_COLORS } from '../../constants/enums';
+import { columnStyle } from '../../styles/common';
+import theme from '../../styles/theme';
+
+interface PageSectionProps {
+  children: any;
+  color: STORYBLOK_COLORS;
+  alignment: string;
+}
+
+const PageSection = (props: PageSectionProps) => {
+  const { children, color, alignment } = props;
+  const containerStyle = {
+    ...columnStyle,
+    ...(color && {
+      backgroundColor: color,
+      ...(color === STORYBLOK_COLORS.BLOOM_GRADIENT
+        ? { backgroundImage: theme.palette.bloomGradient }
+        : {}),
+    }),
+    ...(alignment && {
+      alignItems:
+        alignment === 'center' ? 'center' : alignment === 'right' ? 'flex-end' : 'flex-start',
+    }),
+    textAlign: alignment === 'center' ? 'center' : alignment === 'right' ? 'right' : 'left',
+    ...(alignment === 'center' && {
+      ' p': { marginX: 'auto' },
+    }),
+  } as const;
+
+  return <Container sx={containerStyle}>{children}</Container>;
+};
+
+export default PageSection;

--- a/components/common/Row.tsx
+++ b/components/common/Row.tsx
@@ -1,0 +1,46 @@
+import { Box } from '@mui/system';
+import { richtextContentStyle, rowStyle } from '../../styles/common';
+
+interface RowProps {
+  children: any;
+  numberOfColumns: number;
+  horizontalAlignment: string;
+  verticalAlignment: string;
+}
+
+const Row = (props: RowProps) => {
+  const { children, horizontalAlignment, verticalAlignment, numberOfColumns } = props;
+
+  const rowStyles = {
+    width: '100%',
+    gap: { xs: 3, sm: 8 / numberOfColumns, md: 10 / numberOfColumns, lg: 16 / numberOfColumns },
+    ...rowStyle,
+    textAlign:
+      horizontalAlignment === 'center'
+        ? 'center'
+        : horizontalAlignment === 'right'
+        ? 'right'
+        : 'left',
+    ...(horizontalAlignment && {
+      justifyContent:
+        horizontalAlignment === 'center'
+          ? 'center'
+          : horizontalAlignment === 'right'
+          ? 'flex-end'
+          : 'flex-start',
+    }),
+    ...(verticalAlignment && {
+      alignItems:
+        verticalAlignment === 'center'
+          ? 'center'
+          : verticalAlignment === 'bottom'
+          ? 'flex-end'
+          : 'flex-start',
+    }),
+    ...richtextContentStyle,
+  } as const;
+
+  return <Box sx={rowStyles}>{children}</Box>;
+};
+
+export default Row;

--- a/components/layout/AppBarSpacer.tsx
+++ b/components/layout/AppBarSpacer.tsx
@@ -4,12 +4,9 @@ import { RootState } from '../../app/store';
 import { useTypedSelector } from '../../hooks/store';
 import theme from '../../styles/theme';
 
-const singleNavSpacing = { xs: '3rem', sm: '4rem', md: '3.75rem' };
-const doubleNavSpacing = { md: '8rem' };
 export const AppBarSpacer = () => {
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
   const { user } = useTypedSelector((state: RootState) => state);
-  const spacing = user.token && !isSmallScreen ? doubleNavSpacing : singleNavSpacing;
-  return <Box height={spacing} marginTop={0}></Box>;
+  return <Box height={{ xs: '3rem', sm: '4rem', md: '8rem' }} marginTop={0}></Box>;
 };

--- a/components/layout/LeaveSiteButton.tsx
+++ b/components/layout/LeaveSiteButton.tsx
@@ -1,35 +1,19 @@
-import { Button, useMediaQuery } from '@mui/material';
+import { Button } from '@mui/material';
 import { Box } from '@mui/system';
 import { useTranslations } from 'next-intl';
-import { RootState } from '../../app/store';
 import { LEAVE_SITE_BUTTON_CLICKED } from '../../constants/events';
-import { useTypedSelector } from '../../hooks/store';
-import theme from '../../styles/theme';
 import logEvent from '../../utils/logEvent';
 
-const baseStyles = {
+const leaveThisSiteStyles = {
   position: 'fixed',
   textAlign: 'right',
   right: { xs: 16, lg: 80 },
   zIndex: 100,
-} as const;
-
-const singleNavSpacing = {
-  ...baseStyles,
-  top: { xs: 60, sm: 80, lg: 90 },
-} as const;
-
-const doubleNavSpacing = {
-  ...baseStyles,
-  top: { md: 150, lg: 160 },
+  top: { xs: 60, sm: 80, md: 150, lg: 160 },
 } as const;
 
 const LeaveSiteButton = () => {
   const tS = useTranslations('Shared');
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-
-  const { user } = useTypedSelector((state: RootState) => state);
-  const spacing = user.token && !isSmallScreen ? doubleNavSpacing : singleNavSpacing;
 
   const hideSite = () => {
     logEvent(LEAVE_SITE_BUTTON_CLICKED);
@@ -40,7 +24,7 @@ const LeaveSiteButton = () => {
   };
 
   return (
-    <Box sx={spacing}>
+    <Box sx={leaveThisSiteStyles}>
       <Button onClick={hideSite} variant="contained" color="error">
         {tS('leaveSiteButton')}
       </Button>

--- a/components/storyblok/StoryblokPageSection.tsx
+++ b/components/storyblok/StoryblokPageSection.tsx
@@ -1,8 +1,7 @@
-import { Container } from '@mui/material';
 import { render } from 'storyblok-rich-text-react-renderer';
 import { STORYBLOK_COLORS } from '../../constants/enums';
-import { columnStyle } from '../../styles/common';
 import { RichTextOptions } from '../../utils/richText';
+import PageSection from '../common/PageSection';
 
 interface StoryblokPageSectionProps {
   content: AnalyserNode;
@@ -15,22 +14,11 @@ const StoryblokPageSection = (props: StoryblokPageSectionProps) => {
 
   if (!content) return <></>;
 
-  const containerStyle = {
-    ...columnStyle,
-    ...(color && {
-      backgroundColor: color,
-    }),
-    ...(alignment && {
-      alignItems:
-        alignment === 'center' ? 'center' : alignment === 'right' ? 'flex-end' : 'flex-start',
-    }),
-    textAlign: alignment === 'center' ? 'center' : alignment === 'right' ? 'right' : 'left',
-    ...(alignment === 'center' && {
-      ' p': { marginX: 'auto' },
-    }),
-  } as const;
-
-  return <Container sx={containerStyle}>{render(content, RichTextOptions)}</Container>;
+  return (
+    <PageSection color={color} alignment={alignment}>
+      {render(content, RichTextOptions)}
+    </PageSection>
+  );
 };
 
 export default StoryblokPageSection;

--- a/components/storyblok/StoryblokRow.tsx
+++ b/components/storyblok/StoryblokRow.tsx
@@ -1,8 +1,8 @@
-import { Box } from '@mui/system';
 import { Richtext } from 'storyblok-js-client';
 import { render } from 'storyblok-rich-text-react-renderer';
-import { richtextContentStyle, rowStyle } from '../../styles/common';
 import { RichTextOptions } from '../../utils/richText';
+import Column from '../common/Column';
+import Row from '../common/Row';
 import { StoryblokBlok, StoryblokColumn } from './StoryblokTypes';
 
 interface StoryblokRowProps {
@@ -11,70 +11,12 @@ interface StoryblokRowProps {
   vertical_alignment: string;
 }
 
-const columnStyles = (width: string | undefined) => ({
-  width:
-    width === 'extra-small'
-      ? {
-          xs: `20%`,
-          md: '5%',
-        }
-      : width === 'small'
-      ? { xs: '100%', md: '20%' }
-      : width === 'medium'
-      ? { xs: '100%', md: '40%' }
-      : width === 'large'
-      ? { xs: '100%', md: '60%' }
-      : width === 'extra-large'
-      ? { xs: '100%', md: '80%' }
-      : { xs: `100%`, md: 'auto' },
-  ...(!width && { flex: { md: 1 } }),
-});
-
-const getGap = (noColumns: number) => {
-  return {
-    gap: {
-      xs: 3,
-      sm: 8 / noColumns,
-      md: 10 / noColumns,
-      lg: 16 / noColumns,
-    },
-  };
-};
-
 const StoryblokRow = (props: StoryblokRowProps) => {
   const { columns, horizontal_alignment, vertical_alignment } = props;
 
   const columnArray = Array.isArray(columns) ? columns : [columns];
 
   if (!columnArray) return <></>;
-
-  const rowStyles = {
-    width: '100%',
-    ...rowStyle,
-    textAlign:
-      horizontal_alignment === 'center'
-        ? 'center'
-        : horizontal_alignment === 'right'
-        ? 'right'
-        : 'left',
-    ...(horizontal_alignment && {
-      justifyContent:
-        horizontal_alignment === 'center'
-          ? 'center'
-          : horizontal_alignment === 'right'
-          ? 'flex-end'
-          : 'flex-start',
-    }),
-    ...(vertical_alignment && {
-      alignItems:
-        vertical_alignment === 'center'
-          ? 'center'
-          : vertical_alignment === 'bottom'
-          ? 'flex-end'
-          : 'flex-start',
-    }),
-    ...richtextContentStyle,
-  } as const;
 
   let numberOfColumns = 0;
   const renderedColumns = columnArray.map((col, index) => {
@@ -83,7 +25,7 @@ const StoryblokRow = (props: StoryblokRowProps) => {
     if (contentIsObject) {
       const storyblokColumn = col as StoryblokColumn;
       numberOfColumns++;
-      return renderColumn(storyblokColumn.content, storyblokColumn.width.toString(), index);
+      return renderColumn(storyblokColumn.content, index, storyblokColumn.width.toString());
     }
     return col.content.map((richTextContent: StoryblokBlok | StoryblokColumn, index2: number) => {
       // The render function from  storyblok-rich-text-react-renderer' expects an object that has a .type and .content
@@ -94,28 +36,42 @@ const StoryblokRow = (props: StoryblokRowProps) => {
 
         const renderedBlokColumns = richTextContent.attrs.body.map((el: StoryblokColumn) => {
           numberColumnsInBlock++;
-          return renderColumn(el.content, el.width.toString(), index2);
+          return renderColumn(el.content, index2, el.width.toString());
         });
         return (
-          <Box sx={{ ...rowStyles, ...getGap(numberColumnsInBlock) }}>{renderedBlokColumns}</Box>
+          <Row
+            numberOfColumns={numberColumnsInBlock}
+            verticalAlignment={vertical_alignment}
+            horizontalAlignment={horizontal_alignment}
+          >
+            {renderedBlokColumns}
+          </Row>
         );
       }
       numberOfColumns++;
       return 'width' in richTextContent ? (
-        renderColumn(richTextContent, richTextContent.width.toString(), index2)
+        renderColumn(richTextContent, index2, richTextContent.width.toString())
       ) : (
         <></>
       );
     });
   });
-  return <Box sx={{ ...rowStyles, ...getGap(numberOfColumns) }}>{renderedColumns}</Box>;
+  return (
+    <Row
+      numberOfColumns={numberOfColumns}
+      horizontalAlignment={horizontal_alignment}
+      verticalAlignment={vertical_alignment}
+    >
+      {renderedColumns}
+    </Row>
+  );
 };
 
-const renderColumn = (content: any, width: string, index: number) => {
+const renderColumn = (content: any, index: number, width?: string) => {
   return (
-    <Box sx={columnStyles(width)} key={`row_column_${index}_${Math.random()*100}`}>
+    <Column width={width} key={`row_column_${index}_${Math.random() * 100}`}>
       {render(content, RichTextOptions)}
-    </Box>
+    </Column>
   );
 };
 

--- a/components/storyblok/StoryblokRowColumnBlock.tsx
+++ b/components/storyblok/StoryblokRowColumnBlock.tsx
@@ -1,7 +1,7 @@
-import { Box } from '@mui/system';
 import { render } from 'storyblok-rich-text-react-renderer';
-import { richtextContentStyle, rowStyle } from '../../styles/common';
 import { RichTextOptions } from '../../utils/richText';
+import Column from '../common/Column';
+import Row from '../common/Row';
 import { StoryblokColumn } from './StoryblokTypes';
 
 /**
@@ -27,63 +27,20 @@ const StoryblokRowColumnBlock = (props: StoryblokRowColumnBlockProps) => {
 
   if (!columns) return <></>;
 
-  const rowStyles = {
-    width: '100%',
-    gap: { xs: 3, sm: 8 / columns.length, md: 10 / columns.length, lg: 16 / columns.length },
-    ...rowStyle,
-    textAlign:
-      horizontal_alignment === 'center'
-        ? 'center'
-        : horizontal_alignment === 'right'
-        ? 'right'
-        : 'left',
-    ...(horizontal_alignment && {
-      justifyContent:
-        horizontal_alignment === 'center'
-          ? 'center'
-          : horizontal_alignment === 'right'
-          ? 'flex-end'
-          : 'flex-start',
-    }),
-    ...(vertical_alignment && {
-      alignItems:
-        vertical_alignment === 'center'
-          ? 'center'
-          : vertical_alignment === 'bottom'
-          ? 'flex-end'
-          : 'flex-start',
-    }),
-    ...richtextContentStyle,
-  } as const;
-
   return (
-    <Box sx={rowStyles}>
+    <Row
+      numberOfColumns={columns.length}
+      verticalAlignment={vertical_alignment}
+      horizontalAlignment={horizontal_alignment}
+    >
       {columns.map((column: any, index: number) => {
-        const columnStyles = {
-          width:
-            column.width === 'extra-small'
-              ? {
-                  xs: `20%`,
-                  md: '5%',
-                }
-              : column.width === 'small'
-              ? { xs: '100%', md: '20%' }
-              : column.width === 'medium'
-              ? { xs: '100%', md: '40%' }
-              : column.width === 'large'
-              ? { xs: '100%', md: '60%' }
-              : column.width === 'extra-large'
-              ? { xs: '100%', md: '80%' }
-              : { xs: `100%`, md: 'auto' },
-          ...(!column.width && { flex: { md: 1 } }),
-        };
         return (
-          <Box sx={columnStyles} key={`row_column_${index}_${Math.random()*100}`}>
+          <Column width={column.width} key={`row_column_${index}_${Math.random() * 100}`}>
             {render(column.content, RichTextOptions)}
-          </Box>
+          </Column>
         );
       })}
-    </Box>
+    </Row>
   );
 };
 

--- a/constants/enums.ts
+++ b/constants/enums.ts
@@ -47,6 +47,7 @@ export enum STORYBLOK_COLORS {
   SECONDARY_DARK = 'secondary.dark',
   COMMON_WHITE = 'common.white',
   BACKGROUND_DEFAULT = 'background.default',
+  BLOOM_GRADIENT = 'bloomGradient',
 }
 
 export enum SURVEY_FORMS {

--- a/cypress/integration/auth-redirect.cy.tsx
+++ b/cypress/integration/auth-redirect.cy.tsx
@@ -2,17 +2,11 @@ describe('Auth redirect', () => {
   before(() => {
     cy.cleanUpTestState();
   });
-  it('User visits the courses page and should be redirected with correct url', () => {
-    cy.visit('/courses');
-    cy.wait(2000);
-    cy.get('h2', { timeout: 8000 }).should('contain', 'Welcome back');
-    cy.url().should('include', 'return_url=%2Fcourses');
-  });
   it('User visits a session page with an auth guard and should be redirected', () => {
     cy.visit(
       '/courses/image-based-abuse-and-rebuilding-ourselves/the-social-context-of-image-based-abuse-and-victim-blaming',
     );
-    cy.wait(2000);
+
     cy.get('h2', { timeout: 8000 }).should('contain', 'Welcome back');
     cy.url().should(
       'include',

--- a/cypress/integration/home.cy.tsx
+++ b/cypress/integration/home.cy.tsx
@@ -1,8 +1,0 @@
-describe('Home page', () => {
-  it('should render', () => {
-    cy.visit('/');
-    cy.get('p', { timeout: 8000 }).contains(
-      'Learn and heal from trauma in a private, supportive space.',
-    );
-  });
-});

--- a/cypress/integration/initial-exploration.cy.tsx
+++ b/cypress/integration/initial-exploration.cy.tsx
@@ -1,0 +1,18 @@
+describe('Initial exploration', () => {
+  it('should be able to explore all pages', () => {
+    cy.visit('/');
+    cy.get('p', { timeout: 8000 }).contains(
+      'Learn and heal from trauma in a private, supportive space.',
+    );
+    cy.get(`[qa-id=secondary-nav-chat-button]`).click();
+    cy.get('a', { timeout: 8000 }).contains('Sign up today');
+    cy.get(`[qa-id=secondary-nav-grounding-button]`).click();
+    cy.get('a', { timeout: 8000 }).contains('Sign up today');
+    cy.get(`[qa-id=secondary-nav-activities-button]`).click();
+    cy.get('a', { timeout: 8000 }).contains('Sign up today');
+    cy.get(`[qa-id=secondary-nav-notes-button]`).click();
+    cy.get('a', { timeout: 8000 }).contains('Sign up today');
+    cy.get(`[qa-id=secondary-nav-courses-button]`).click();
+    cy.get('a', { timeout: 8000 }).contains('Sign up today');
+  });
+});

--- a/cypress/integration/navigation.cy.tsx
+++ b/cypress/integration/navigation.cy.tsx
@@ -11,8 +11,11 @@ describe('Navigation', () => {
       cy.get(`[qa-id=language-menu-button]`).should('exist');
       cy.get(`[qa-id=meet-team-menu-button]`).should('exist');
       cy.get(`[qa-id=partner-admin-menu-button]`).should('not.exist');
-      cy.get(`[qa-id=secondary-nav]`).should('not.exist');
+      cy.get(`[qa-id=secondary-nav]`).should('exist');
       cy.get(`[qa-id=login-menu-button]`).should('exist');
+      cy.get(`[qa-id=secondary-nav-therapy-button]`).should('not.exist');
+      cy.get(`[qa-id=secondary-nav-notes-button]`).should('exist');
+      cy.get(`[qa-id=secondary-nav-courses-button]`).should('exist');
     });
   });
   describe('A logged in public user', () => {

--- a/guards/publicPageDataWrapper.tsx
+++ b/guards/publicPageDataWrapper.tsx
@@ -18,7 +18,6 @@ import rollbar from '../config/rollbar';
 import { GET_AUTH_USER_ERROR, GET_AUTH_USER_SUCCESS } from '../constants/events';
 import { useAppDispatch, useTypedSelector } from '../hooks/store';
 import { getErrorMessage } from '../utils/errorMessage';
-import generateReturnQuery from '../utils/generateReturnQuery';
 import logEvent, { getEventUserData } from '../utils/logEvent';
 
 /**
@@ -79,8 +78,6 @@ export function PublicPageDataWrapper({ children }: { children: JSX.Element }) {
         await dispatch(clearCoursesSlice());
         await dispatch(clearUserSlice());
         await dispatch(api.util.resetApiState());
-
-        router.replace(`/auth/login${generateReturnQuery(router.asPath)}`);
       }
       setLoading(false);
     }

--- a/messages/shared/de.json
+++ b/messages/shared/de.json
@@ -70,6 +70,12 @@
       "cookieConsentPolicy": "Cookie-Richtlinie",
       "acceptLabel": "Cookies akzeptieren",
       "declineLabel": "Cookies ablehnen"
+    },
+    "signUpTodayPromo": {
+      "title": "Sign up for a free account today",
+      "description1": "We provide free services to support you to heal from trauma. From our video courses and reflective activities to our 1-1 chat and WhatsApp subscription service, there's lots of different ways to engage with Bloom.",
+      "description2": "Sign up today to get access to all of our content and explore everything Bloom has to offer!",
+      "button": "Sign up today"
     }
   }
 }

--- a/messages/shared/en.json
+++ b/messages/shared/en.json
@@ -70,6 +70,12 @@
       "cookieConsentPolicy": "cookie policy",
       "acceptLabel": "Accept Cookies",
       "declineLabel": "Reject Cookies"
+    },
+    "signUpTodayPromo": {
+      "title": "Sign up for a free account today",
+      "description1": "We provide free services to support you to heal from trauma. From our video courses and reflective activities to our 1-1 chat and WhatsApp subscription service, there's lots of different ways to engage with Bloom.",
+      "description2": "Sign up today to get access to all of our content and explore everything Bloom has to offer!",
+      "button": "Sign up today"
     }
   }
 }

--- a/messages/shared/es.json
+++ b/messages/shared/es.json
@@ -68,6 +68,12 @@
       "cookieConsentPolicy": "política de cookies",
       "acceptLabel": "Aceptar Cookies",
       "declineLabel": "Reject Cookies"
+    },
+    "signUpTodayPromo": {
+      "title": "Sign up for a free account today",
+      "description1": "We provide free services to support you to heal from trauma. From our video courses and reflective activities to our 1-1 chat and WhatsApp subscription service, there's lots of different ways to engage with Bloom.",
+      "description2": "Sign up today to get access to all of our content and explore everything Bloom has to offer!",
+      "button": "Sign up today"
     }
   }
 }

--- a/messages/shared/fr.json
+++ b/messages/shared/fr.json
@@ -70,6 +70,12 @@
       "cookieConsentPolicy": "politique relative aux cookies",
       "acceptLabel": "Accepter les Cookies",
       "declineLabel": "Reject Cookies"
+    },
+    "signUpTodayPromo": {
+      "title": "Sign up for a free account today",
+      "description1": "We provide free services to support you to heal from trauma. From our video courses and reflective activities to our 1-1 chat and WhatsApp subscription service, there's lots of different ways to engage with Bloom.",
+      "description2": "Sign up today to get access to all of our content and explore everything Bloom has to offer!",
+      "button": "Sign up today"
     }
   }
 }

--- a/messages/shared/hi.json
+++ b/messages/shared/hi.json
@@ -70,6 +70,12 @@
       "cookieConsentPolicy": "Cookies neeti",
       "acceptLabel": "Cookies sweekaar kariye",
       "declineLabel": "Cookies asweekar karein"
+    },
+    "signUpTodayPromo": {
+      "title": "Sign up for a free account today",
+      "description1": "We provide free services to support you to heal from trauma. From our video courses and reflective activities to our 1-1 chat and WhatsApp subscription service, there's lots of different ways to engage with Bloom.",
+      "description2": "Sign up today to get access to all of our content and explore everything Bloom has to offer!",
+      "button": "Sign up today"
     }
   }
 }

--- a/messages/shared/pt.json
+++ b/messages/shared/pt.json
@@ -70,6 +70,12 @@
       "cookieConsentPolicy": "Política de cookies",
       "acceptLabel": "Aceitar Cookies",
       "declineLabel": "Rejeitar Cookies"
+    },
+    "signUpTodayPromo": {
+      "title": "Sign up for a free account today",
+      "description1": "We provide free services to support you to heal from trauma. From our video courses and reflective activities to our 1-1 chat and WhatsApp subscription service, there's lots of different ways to engage with Bloom.",
+      "description2": "Sign up today to get access to all of our content and explore everything Bloom has to offer!",
+      "button": "Sign up today"
     }
   }
 }

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -1,11 +1,15 @@
 import { Box } from '@mui/system';
 import { GetStaticPathsContext, GetStaticPropsContext, NextPage } from 'next';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
+import { RootState } from '../app/store';
+import { SignUpBanner } from '../components/banner/SignUpBanner';
 import Header from '../components/layout/Header';
 import StoryblokPageSection from '../components/storyblok/StoryblokPageSection';
 import Storyblok, { useStoryblok } from '../config/storyblok';
 import { LANGUAGES } from '../constants/enums';
+import { useTypedSelector } from '../hooks/store';
 
 interface Props {
   story: StoryData;
@@ -16,6 +20,8 @@ interface Props {
 
 const Page: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
   story = useStoryblok(story, preview, sbParams, locale);
+  const { user } = useTypedSelector((state: RootState) => state);
+  const router = useRouter();
 
   const headerProps = {
     title: story.content.title,
@@ -23,18 +29,21 @@ const Page: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
     imageSrc: story.content.header_image?.filename,
     translatedImageAlt: story.content.header_image?.alt,
   };
+  const partiallyPublicPages = ['/activities', '/grounding'];
+  const isPartiallyPublicPage = partiallyPublicPages.includes(router.asPath);
 
   return (
     <Box>
       <Head>{story.content.title}</Head>
-
       <Header
         title={headerProps.title}
         introduction={headerProps.introduction}
         imageSrc={headerProps.imageSrc}
         translatedImageAlt={headerProps.translatedImageAlt}
       />
-      {story.content.page_sections?.length > 0 &&
+      {!user.token && isPartiallyPublicPage && <SignUpBanner />}
+      {user.token &&
+        story.content.page_sections?.length > 0 &&
         story.content.page_sections.map((section: any, index: number) => (
           <StoryblokPageSection
             key={`page_section_${index}`}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -71,10 +71,21 @@ function MyApp(props: MyAppProps) {
       'partnership',
       'about-our-courses',
     ];
+
+    // As the subpages of courses are not public and these pages are only partially public,
+    // they are treated differently as they are not public path heads
+    const partiallyPublicPages = [
+      '/courses',
+      '/activities',
+      '/grounding',
+      '/subscription/whatsapp',
+      '/chat',
+    ];
+
     const component = <Component {...pageProps} />;
     let children = null;
 
-    if (publicPathHeads.includes(pathHead)) {
+    if (publicPathHeads.includes(pathHead) || partiallyPublicPages.includes(router.asPath)) {
       return <PublicPageDataWrapper>{component}</PublicPageDataWrapper>;
     }
     if (pathHead === 'therapy') {
@@ -109,7 +120,7 @@ function MyApp(props: MyAppProps) {
           <Footer />
           <Consent />
           {/* Vercel analytics */}
-          <Analytics /> 
+          <Analytics />
         </ThemeProvider>
       </CacheProvider>
     </NextIntlClientProvider>

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -4,13 +4,13 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
 import { RootState } from '../app/store';
+import { SignUpBanner } from '../components/banner/SignUpBanner';
 import CrispButton from '../components/crisp/CrispButton';
 import Header, { HeaderProps } from '../components/layout/Header';
 import StoryblokPageSection from '../components/storyblok/StoryblokPageSection';
 import Storyblok, { useStoryblok } from '../config/storyblok';
 import { LANGUAGES } from '../constants/enums';
 import { useTypedSelector } from '../hooks/store';
-import { rowStyle } from '../styles/common';
 import { getEventUserData } from '../utils/logEvent';
 
 interface Props {
@@ -19,18 +19,6 @@ interface Props {
   sbParams: StoriesParams;
   locale: LANGUAGES;
 }
-
-const containerStyle = {
-  backgroundColor: 'primary.light',
-  textAlign: 'center',
-  ...rowStyle,
-} as const;
-
-const crispButtonContainerStyle = {
-  paddingTop: 4,
-  paddingBottom: 1,
-  display: 'flex',
-} as const;
 
 const Chat: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
   let configuredStory = useStoryblok(story, preview, sbParams, locale);
@@ -51,14 +39,17 @@ const Chat: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
         <Header
           {...headerProps}
           cta={
-            <CrispButton
-              email={user.email}
-              eventData={eventUserData}
-              buttonText={t('sessionDetail.chat.startButton')}
-            />
+            user.token && (
+              <CrispButton
+                email={user.email}
+                eventData={eventUserData}
+                buttonText={t('sessionDetail.chat.startButton')}
+              />
+            )
           }
         />
-        {configuredStory.content.page_sections?.length > 0 &&
+        {user.token ? (
+          configuredStory.content.page_sections?.length > 0 &&
           configuredStory.content.page_sections.map((section: any, index: number) => (
             <StoryblokPageSection
               key={`page_section_${index}`}
@@ -66,7 +57,10 @@ const Chat: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
               alignment={section.alignment}
               color={section.color}
             />
-          ))}
+          ))
+        ) : (
+          <SignUpBanner />
+        )}
       </Box>
     </>
   );

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -7,6 +7,7 @@ import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import { StoryData, StoryParams } from 'storyblok-js-client';
 import { RootState } from '../../app/store';
+import { SignUpBanner } from '../../components/banner/SignUpBanner';
 import CourseCard from '../../components/cards/CourseCard';
 import LoadingContainer from '../../components/common/LoadingContainer';
 import Header from '../../components/layout/Header';
@@ -105,6 +106,23 @@ const CourseList: NextPage<Props> = ({ stories, preview, sbParams, locale }) => 
       setCoursesCompleted(courseCoursesCompleted);
     }
   }, [partnerAccesses, partnerAdmin, stories, courses]);
+  // Show sign up banner if user is logged out
+  if (!user.token) {
+    return (
+      <Box>
+        <Head>
+          <title>{t('title')}</title>
+        </Head>
+        <Header
+          title={headerProps.title}
+          introduction={headerProps.introduction}
+          imageSrc={headerProps.imageSrc}
+          imageAlt={headerProps.imageAlt}
+        />
+        <SignUpBanner />
+      </Box>
+    );
+  }
 
   const getCourseProgress = (courseId: number) => {
     return coursesStarted.includes(courseId)

--- a/pages/subscription/whatsapp.tsx
+++ b/pages/subscription/whatsapp.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
 import { RootState } from '../../app/store';
+import { SignUpBanner } from '../../components/banner/SignUpBanner';
 import ImageTextColumn from '../../components/common/ImageTextColumn';
 import { ImageTextItem } from '../../components/common/ImageTextGrid';
 import WhatsappSubscribeForm from '../../components/forms/WhatsappSubscribeForm';
@@ -85,15 +86,19 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story, preview, sbParams,
       <Head>{configuredStory.content.title}</Head>
       <Box>
         <Header {...headerProps} />
-        <Container sx={containerStyle}>
-          <Box sx={infoBoxStyle}>
-            <ImageTextColumn items={steps} translations="Whatsapp.steps" />
-          </Box>
-          <Box sx={formContainerStyle}>
-            {hasActiveWhatsappSub ? <WhatsappUnsubscribeForm /> : <WhatsappSubscribeForm />}
-          </Box>
-        </Container>
-        {configuredStory.content.page_sections?.length > 0 &&
+        {!user.token && <SignUpBanner />}
+        {user.token && (
+          <Container sx={containerStyle}>
+            <Box sx={infoBoxStyle}>
+              <ImageTextColumn items={steps} translations="Whatsapp.steps" />
+            </Box>
+            <Box sx={formContainerStyle}>
+              {hasActiveWhatsappSub ? <WhatsappUnsubscribeForm /> : <WhatsappSubscribeForm />}
+            </Box>
+          </Container>
+        )}
+        {user.token &&
+          configuredStory.content.page_sections?.length > 0 &&
           configuredStory.content.page_sections.map((section: any, index: number) => (
             <StoryblokPageSection
               key={`page_section_${index}`}

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -4,10 +4,12 @@ import { createTheme, lighten, responsiveFontSizes } from '@mui/material/styles'
 declare module '@mui/material/styles' {
   interface Palette {
     palePrimaryLight: string;
+    bloomGradient: string;
   }
   interface PaletteOptions {
     palePrimaryLight?: string;
     paleSecondaryLight?: string;
+    bloomGradient?: string;
   }
 }
 // Create a theme instance.
@@ -31,6 +33,7 @@ let theme = createTheme({
     },
     palePrimaryLight: '#F9eded',
     paleSecondaryLight: '#FFF8F4',
+    bloomGradient: 'linear-gradient(#F3D6D8, #FFEAE1)',
   },
   shape: {
     borderRadius: 20,


### PR DESCRIPTION
### Issue link / number:
N/A in notion

### What changes did you make?
- refactor row and column and page section components
- create a banner for sign ups 
- Add banner to grounding, whatsapp, activities, courses and chat pages
<img width="1438" alt="Screenshot 2023-12-05 at 08 49 34" src="https://github.com/chaynHQ/bloom-frontend/assets/16049515/7a86c37c-50f6-41ed-a0d8-47b35a6b8ce4">

### Why did you make the changes?
To better expose our resources to users who are about to sign up
