### PR TITLE
Increase lighthouse desktop budgets

### DIFF
--- a/lighthouse_desktop_budget.json
+++ b/lighthouse_desktop_budget.json
@@ -18,7 +18,7 @@
     "timings": [
       {
         "metric": "first-meaningful-paint",
-        "budget": 8500
+        "budget": 9000
       },
       {
         "metric": "first-contentful-paint",
@@ -38,7 +38,7 @@
       },
       {
         "metric": "speed-index",
-        "budget": 5000
+        "budget": 5500
       }
     ]
   }


### PR DESCRIPTION
### What changes did you make?
Increased lighthouse budget values (See #738) for desktop, as the `develop -> main` PR was failing.
Lighthouse scores vary slightly per run - we've set the lighthouse budget values close to our current scores, with the aim to decrease them as we improve performance. For now (until Jan) if a build fails due to lighthouse scores, we can increase the score to pass the build; the exception would be a drastically higher value, in which case assess if the changes have degraded performance.