### PR TITLE
Remove unused sharp and storyblok-editable deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@mui/lab": "^5.0.0-alpha.73",
     "@mui/material": "^5.0.2",
     "@reduxjs/toolkit": "^1.6.1",
-    "@storyblok/storyblok-editable": "^1.0.0",
     "@vercel/analytics": "^1.1.1",
     "axios": "^0.24.0",
     "firebase": "^9.9.2",
@@ -42,7 +41,6 @@
     "react-player": "^2.13.0",
     "react-redux": "^8.0.5",
     "rollbar": "^2.24.0",
-    "sharp": "^0.30.5",
     "storyblok-js-client": "^4.2.0",
     "storyblok-rich-text-react-renderer": "^2.9.0"
   },
@@ -62,7 +60,6 @@
     "eslint-config-prettier": "^8.3.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.2.4",
-    "lodash": "^4.17.21",
     "mailslurp-client": "^15.7.5",
     "prettier": "^2.4.1",
     "puppeteer": "^21.5.2",


### PR DESCRIPTION
### What changes did you make?
Removed unused packages `sharp` and `storyblok-editable`

### Why did you make the changes?
As part of wider epic to improve Bloom performance, including reducing JS loaded/bundle size.