### PR TITLE
Improve react player performance

### DIFF
--- a/components/storyblok/StoryblokAudio.tsx
+++ b/components/storyblok/StoryblokAudio.tsx
@@ -2,7 +2,7 @@ import { Box } from '@mui/system';
 import dynamic from 'next/dynamic';
 import { richtextContentStyle } from '../../styles/common';
 // See React Player Hydration issue https://github.com/cookpete/react-player/issues/1474
-const ReactPlayer = dynamic(() => import('react-player/lazy'), { ssr: false });
+const ReactPlayer = dynamic(() => import('react-player/file'), { ssr: false });
 
 const audioContainerStyle = {
   position: 'relative',

--- a/components/storyblok/StoryblokVideo.tsx
+++ b/components/storyblok/StoryblokVideo.tsx
@@ -1,8 +1,9 @@
 import { Box } from '@mui/system';
 import dynamic from 'next/dynamic';
+import { YouTubeConfig } from 'react-player/youtube';
 import { richtextContentStyle } from '../../styles/common';
 // See React Player Hydration issue https://github.com/cookpete/react-player/issues/1474
-const ReactPlayer = dynamic(() => import('react-player/lazy'), { ssr: false });
+const ReactPlayer = dynamic(() => import('react-player/youtube'), { ssr: false });
 
 const videoContainerStyle = {
   position: 'relative',
@@ -53,18 +54,16 @@ const StoryblokVideo = (props: StoryblokVideoProps) => {
 
     ...richtextContentStyle,
   } as const;
-  const extraConfig =
+
+  const extraConfig: YouTubeConfig =
     video.url.indexOf('youtu.be') > -1 || video.url.indexOf('youtube') > -1
       ? {
-          config: {
-            youtube: {
-              embedOptions: {
-                host: 'https://www.youtube-nocookie.com',
-              },
-            },
+          embedOptions: {
+            host: 'https://www.youtube-nocookie.com',
           },
         }
       : {};
+
   return (
     <Box sx={containerStyle}>
       <Box sx={videoContainerStyle}>

--- a/components/video/Video.tsx
+++ b/components/video/Video.tsx
@@ -6,7 +6,7 @@ import { Dispatch, SetStateAction, useRef, useState } from 'react';
 import { OnProgressProps } from 'react-player/base';
 import logEvent from '../../utils/logEvent';
 // See React Player Hydration issue https://github.com/cookpete/react-player/issues/1474
-const ReactPlayer = dynamic(() => import('react-player/lazy'), { ssr: false });
+const ReactPlayer = dynamic(() => import('react-player/youtube'), { ssr: false });
 
 const videoContainerStyle = {
   position: 'relative',


### PR DESCRIPTION
### What changes did you make?
Swapped the `react-player` import from `/lazy` to `/youtube` (for video) or `/file` (for audio). 
As we're using next.js [dynamic lazy loading](https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#with-external-libraries) already, the lower bundle size should be a greater win than using the lazy loading in `react-player` however we can retest performance scores for this.

### Why did you make the changes?
As part of a larger epic to improve Bloom performance, this reduces loaded JS/bundle size by ensuring only the youtube player module is loaded, instead of all available players (vimeo, soundcloud etc)

Reduces bundle size of `react-player` by 44%

**Before**
![Group 9](https://github.com/chaynHQ/bloom-frontend/assets/11525717/5459334a-19d4-4e52-b4e6-850c26f33223)
**After**
<img width="488" alt="Screenshot 2023-12-11 at 18 02 07" src="https://github.com/chaynHQ/bloom-frontend/assets/11525717/b9de6cd3-a782-4ccf-9780-4ef71bc1c5f7">

