### PR TITLE
Split redux state performance

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -1,9 +1,8 @@
 name: Cypress release tests
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    branches: [main]
 
 jobs:
   # vercel will redeploy the develop/staging app on creating a PR to main

--- a/components/banner/UserResearchBanner.tsx
+++ b/components/banner/UserResearchBanner.tsx
@@ -2,7 +2,6 @@ import { Alert, AlertTitle, Button, Collapse, Stack } from '@mui/material';
 import Cookies from 'js-cookie';
 import { useRouter } from 'next/router';
 import React from 'react';
-import { RootState } from '../../app/store';
 import { FeatureFlag } from '../../config/featureFlag';
 import { USER_BANNER_DISMISSED, USER_BANNER_INTERESTED } from '../../constants/events';
 import { useTypedSelector } from '../../hooks/store';
@@ -24,8 +23,10 @@ const USER_RESEARCH_FORM_LINK =
 export default function UserResearchBanner() {
   const [open, setOpen] = React.useState(true);
 
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const router = useRouter();
   const isBannerNotInteracted = !Boolean(Cookies.get(USER_RESEARCH_BANNER_INTERACTED));
@@ -53,7 +54,7 @@ export default function UserResearchBanner() {
                 size="medium"
                 onClick={() => {
                   Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
-                  logEvent(USER_BANNER_INTERESTED, eventData);
+                  logEvent(USER_BANNER_INTERESTED, eventUserData);
 
                   setOpen(false);
 
@@ -67,7 +68,7 @@ export default function UserResearchBanner() {
                 size="medium"
                 onClick={() => {
                   Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
-                  logEvent(USER_BANNER_DISMISSED, eventData);
+                  logEvent(USER_BANNER_DISMISSED, eventUserData);
 
                   setOpen(false);
                 }}

--- a/components/course/CourseHeader.tsx
+++ b/components/course/CourseHeader.tsx
@@ -18,7 +18,7 @@ const CourseHeader = (props: CourseHeaderProps) => {
 
   useEffect(() => {
     logEvent(COURSE_OVERVIEW_VIEWED, eventData);
-  }, []);
+  });
 
   const headerProps = {
     title: story.content.name,

--- a/components/crisp/CrispScript.tsx
+++ b/components/crisp/CrispScript.tsx
@@ -1,20 +1,22 @@
 import { useRouter } from 'next/router';
 import Script from 'next/script';
 import { useEffect } from 'react';
-import { RootState } from '../../app/store';
 import { CHAT_MESSAGE_SENT, CHAT_STARTED, FIRST_CHAT_STARTED } from '../../constants/events';
 import { useTypedSelector } from '../../hooks/store';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 import { createCrispProfileData } from './utils/createCrispProfileData';
 
 const CrispScript = () => {
-  const { user, partnerAccesses, partnerAdmin, courses } = useTypedSelector(
-    (state: RootState) => state,
-  );
-  const router = useRouter();
-  const locale = router.locale;
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const userEmail = useTypedSelector((state) => state.user.email);
+  const userCrispTokenId = useTypedSelector((state) => state.user.crispTokenId);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const courses = useTypedSelector((state) => state.courses);
 
-  const eventData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const router = useRouter();
+
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_ENV === 'production') {
@@ -24,34 +26,34 @@ const CrispScript = () => {
       'on',
       'chat:initiated',
       () => {
-        logEvent(FIRST_CHAT_STARTED, eventData);
+        logEvent(FIRST_CHAT_STARTED, eventUserData);
       },
     ]);
     (window as any).$crisp.push([
       'on',
       'message:sent',
       () => {
-        logEvent(CHAT_MESSAGE_SENT, eventData);
+        logEvent(CHAT_MESSAGE_SENT, eventUserData);
       },
     ]);
     (window as any).$crisp.push([
       'on',
       'chat:opened',
       () => {
-        logEvent(CHAT_STARTED, eventData);
+        logEvent(CHAT_STARTED, eventUserData);
       },
     ]);
-  }, []);
+  });
 
   useEffect(() => {
     const hasLiveAccess =
       partnerAccesses.length === 0
         ? true
         : partnerAccesses.find((partnerAccess) => partnerAccess.featureLiveChat === true);
-    if (user.email && hasLiveAccess) {
-      (window as any).CRISP_TOKEN_ID = user.crispTokenId;
+    if (userEmail && hasLiveAccess) {
+      (window as any).CRISP_TOKEN_ID = userCrispTokenId;
       (window as any).$crisp.push(['do', 'session:reset']);
-      (window as any).$crisp.push(['set', 'user:email', [user.email]]);
+      (window as any).$crisp.push(['set', 'user:email', [userEmail]]);
       const segments =
         partnerAccesses.length > 0
           ? partnerAccesses.map((pa) => pa.partner.name.toLowerCase())
@@ -67,7 +69,7 @@ const CrispScript = () => {
     } else {
       (window as any).$crisp.push(['do', 'chat:hide']);
     }
-  }, [user, partnerAccesses]);
+  });
 
   const crispScriptUrl = 'https://client.crisp.chat/l.js';
 

--- a/components/crisp/CrispScript.tsx
+++ b/components/crisp/CrispScript.tsx
@@ -69,7 +69,7 @@ const CrispScript = () => {
     } else {
       (window as any).$crisp.push(['do', 'chat:hide']);
     }
-  });
+  }, [userEmail, partnerAccesses, userCrispTokenId, courses]);
 
   const crispScriptUrl = 'https://client.crisp.chat/l.js';
 

--- a/components/forms/AboutYouDemographicForm.tsx
+++ b/components/forms/AboutYouDemographicForm.tsx
@@ -16,8 +16,7 @@ import {
 import axios from 'axios';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
-import { RootState } from '../../app/store';
+import { useEffect, useState } from 'react';
 import { enCountries, esCountries } from '../../constants/countries';
 import { LANGUAGES } from '../../constants/enums';
 import {
@@ -62,7 +61,10 @@ const AboutYouDemographicForm = () => {
     | React.ReactNodeArray
     | React.ReactElement<any, string | React.JSXElementConstructor<any>>
   >();
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
+  const userId = useTypedSelector((state) => state.user.id);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
 
   useEffect(() => {
     if (router.locale === LANGUAGES.es) {
@@ -73,8 +75,8 @@ const AboutYouDemographicForm = () => {
   }, [router.locale]);
 
   useEffect(() => {
-    setEventUserData(getEventUserData({ user, partnerAccesses, partnerAdmin }));
-  }, [user, partnerAccesses, partnerAdmin]);
+    setEventUserData(getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin));
+  }, [userCreatedAt, partnerAccesses, partnerAdmin]);
 
   const submitHandler = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -84,7 +86,7 @@ const AboutYouDemographicForm = () => {
 
     const formData = {
       date: new Date().toISOString(),
-      user_id: user.id && hashString(user.id),
+      user_id: userId && hashString(userId),
       // Sort alphabetically the gender inputs and the make it into a string for the form
       gender: genderInput
         .map((gender) => gender.toLowerCase())
@@ -127,7 +129,8 @@ const AboutYouDemographicForm = () => {
     }
   };
 
-  const genderOptions = useMemo(() => t('genderOptions').split(';'), []);
+  const genderOptions = t('genderOptions').split(';');
+
   return (
     <Box mt={3}>
       <form autoComplete="off" onSubmit={submitHandler}>

--- a/components/forms/AboutYouSetAForm.tsx
+++ b/components/forms/AboutYouSetAForm.tsx
@@ -4,7 +4,6 @@ import axios from 'axios';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { RootState } from '../../app/store';
 import {
   ABOUT_YOU_SETA_ERROR,
   ABOUT_YOU_SETA_REQUEST,
@@ -47,7 +46,9 @@ const AboutYouSetAForm = () => {
     | React.ReactNodeArray
     | React.ReactElement<any, string | React.JSXElementConstructor<any>>
   >();
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
+  const user = useTypedSelector((state) => state.user);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
 
   const scaleQuestions: ScaleFieldItem[] = [
     { name: 'Q1', inputState: scale1Input, inputStateSetter: setScale1Input },
@@ -61,8 +62,8 @@ const AboutYouSetAForm = () => {
   ];
 
   useEffect(() => {
-    setEventUserData(getEventUserData({ user, partnerAccesses, partnerAdmin }));
-  }, [user, partnerAccesses, partnerAdmin]);
+    setEventUserData(getEventUserData(user.createdAt, partnerAccesses, partnerAdmin));
+  }, [user.createdAt, partnerAccesses, partnerAdmin]);
 
   const submitHandler = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/components/forms/ApplyCodeForm.tsx
+++ b/components/forms/ApplyCodeForm.tsx
@@ -4,7 +4,6 @@ import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 import { useAssignPartnerAccessMutation } from '../../app/api';
 import { PartnerAccess } from '../../app/partnerAccessSlice';
-import { RootState } from '../../app/store';
 import { PARTNER_ACCESS_CODE_STATUS } from '../../constants/enums';
 import {
   ASSIGN_NEW_PARTNER_ACCESS_ERROR,
@@ -32,14 +31,16 @@ const ApplyCodeForm = () => {
     | React.ReactNodeArray
     | React.ReactElement<any, string | React.JSXElementConstructor<any>>
   >();
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
 
   const [assignPartnerAccess, { isLoading: assignPartnerAccessIsLoading }] =
     useAssignPartnerAccessMutation();
 
   useEffect(() => {
-    setEventUserData(getEventUserData({ user, partnerAccesses, partnerAdmin }));
-  }, [user, partnerAccesses, partnerAdmin]);
+    setEventUserData(getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin));
+  }, [userCreatedAt, partnerAccesses, partnerAdmin]);
 
   const submitHandler = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/components/forms/CreateAccessCodeForm.tsx
+++ b/components/forms/CreateAccessCodeForm.tsx
@@ -13,7 +13,6 @@ import { useTranslations } from 'next-intl';
 import * as React from 'react';
 import { useState } from 'react';
 import { useAddPartnerAccessMutation } from '../../app/api';
-import { RootState } from '../../app/store';
 import { BASE_URL } from '../../constants/common';
 import { PARTNER_ACCESS_FEATURES } from '../../constants/enums';
 import {
@@ -27,8 +26,10 @@ import logEvent, { getEventUserData } from '../../utils/logEvent';
 import Link from '../common/Link';
 
 const CreateAccessCodeForm = () => {
-  const { partnerAdmin, user, partnerAccesses } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const t = useTranslations('PartnerAdmin.createAccessCode');
   const [loading, setLoading] = useState<boolean>(false);

--- a/components/forms/CreatePartnerAdminForm.tsx
+++ b/components/forms/CreatePartnerAdminForm.tsx
@@ -4,7 +4,6 @@ import { useTranslations } from 'next-intl';
 import * as React from 'react';
 import { useState } from 'react';
 import { useAddPartnerAdminMutation, useGetPartnersQuery } from '../../app/api';
-import { RootState } from '../../app/store';
 import {
   CREATE_PARTNER_ADMIN_ERROR,
   CREATE_PARTNER_ADMIN_REQUEST,
@@ -15,10 +14,12 @@ import { getErrorMessage } from '../../utils/errorMessage';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 
 const CreatePartnerAdminForm = () => {
-  const { partnerAdmin, user, partnerAccesses, partners } = useTypedSelector(
-    (state: RootState) => state,
-  );
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const partners = useTypedSelector((state) => state.partners);
+
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
   useGetPartnersQuery(undefined);
 
   const t = useTranslations('Admin.createPartnerAdmin');

--- a/components/forms/LoginForm.tsx
+++ b/components/forms/LoginForm.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../constants/events';
 import { useAppDispatch } from '../../hooks/store';
 import { getErrorMessage } from '../../utils/errorMessage';
-import logEvent, { getEventUserData } from '../../utils/logEvent';
+import logEvent, { getEventUserResponseData } from '../../utils/logEvent';
 import Link from '../common/Link';
 
 const containerStyle = {
@@ -67,8 +67,9 @@ const LoginForm = () => {
         const userResponse = await getUser('');
 
         if ('data' in userResponse) {
-          logEvent(GET_USER_SUCCESS, { ...getEventUserData(userResponse.data) }); // deprecated event
-          logEvent(GET_LOGIN_USER_SUCCESS, { ...getEventUserData(userResponse.data) });
+          const eventUserData = getEventUserResponseData(userResponse.data);
+          logEvent(GET_USER_SUCCESS, eventUserData); // deprecated event
+          logEvent(GET_LOGIN_USER_SUCCESS, eventUserData);
 
           // Checking if the query type is a string to keep typescript happy
           // because a query value can be an array

--- a/components/forms/RegisterForm.tsx
+++ b/components/forms/RegisterForm.tsx
@@ -10,7 +10,6 @@ import {
   useGetAutomaticAccessCodeFeatureForPartnerQuery,
   useValidateCodeMutation,
 } from '../../app/api';
-import { RootState } from '../../app/store';
 import { setUserLoading, setUserToken } from '../../app/userSlice';
 import { LANGUAGES, PARTNER_ACCESS_CODE_STATUS } from '../../constants/enums';
 import {
@@ -32,7 +31,7 @@ import {
 import { useAppDispatch, useTypedSelector } from '../../hooks/store';
 import { getErrorMessage } from '../../utils/errorMessage';
 import hasAutomaticAccessFeature from '../../utils/hasAutomaticAccessCodeFeature';
-import logEvent, { getEventUserData } from '../../utils/logEvent';
+import logEvent, { getEventUserResponseData } from '../../utils/logEvent';
 import Link from '../common/Link';
 
 const containerStyle = {
@@ -122,13 +121,16 @@ const RegisterForm = (props: RegisterFormProps) => {
     });
 
     if ('data' in userResponse && userResponse.data.user.id) {
-      logEvent(REGISTER_SUCCESS, { ...getEventUserData(userResponse.data) });
+      const eventUserData = getEventUserResponseData(userResponse.data);
+
+      logEvent(REGISTER_SUCCESS, eventUserData);
       try {
         const auth = getAuth();
         const userCredential = await signInWithEmailAndPassword(auth, emailInput, passwordInput);
-        logEvent(LOGIN_SUCCESS);
-        logEvent(GET_USER_REQUEST); // deprecated event
-        logEvent(GET_LOGIN_USER_REQUEST);
+        logEvent(LOGIN_SUCCESS, eventUserData);
+        logEvent(GET_USER_REQUEST, eventUserData); // deprecated event
+        logEvent(GET_LOGIN_USER_REQUEST, eventUserData);
+
         const token = await userCredential.user?.getIdToken();
         if (token) {
           await dispatch(setUserToken(token));
@@ -273,7 +275,7 @@ interface PartnerRegisterFormProps {
 }
 
 export const PartnerRegisterForm = ({ partnerName, codeParam }: PartnerRegisterFormProps) => {
-  const { partners } = useTypedSelector((state: RootState) => state);
+  const partners = useTypedSelector((state) => state.partners);
   const [accessCodeRequired, setAccessCodeRequired] = useState<boolean>(true);
   const [partnerId, setPartnerId] = useState<string | undefined>(undefined);
 

--- a/components/forms/UpdateTherapyAdminForm.tsx
+++ b/components/forms/UpdateTherapyAdminForm.tsx
@@ -15,7 +15,6 @@ import {
 import { useTranslations } from 'next-intl';
 import { SyntheticEvent, useEffect, useState } from 'react';
 import { api, useUpdatePartnerAccessMutation } from '../../app/api';
-import { RootState } from '../../app/store';
 import { GetUserDto } from '../../app/userSlice';
 import { UPDATE_THERAPY_SESSIONS, UPDATE_THERAPY_SESSIONS_ERROR } from '../../constants/events';
 import { useAppDispatch, useTypedSelector } from '../../hooks/store';
@@ -23,9 +22,11 @@ import { getErrorMessage } from '../../utils/errorMessage';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 
 const UpdateTherapyAdminForm = () => {
-  const { user } = useTypedSelector((state: RootState) => state);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
 
-  const eventUserData = getEventUserData({ user });
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const t = useTranslations('Admin.updateTherapy');
   const dispatch: any = useAppDispatch();

--- a/components/forms/WelcomeCodeForm.tsx
+++ b/components/forms/WelcomeCodeForm.tsx
@@ -3,7 +3,6 @@ import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import { RootState } from '../../app/store';
 import { generatePartnerPromoGetStartedEvent } from '../../constants/events';
 import { useTypedSelector } from '../../hooks/store';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
@@ -20,10 +19,12 @@ interface WelcomeCodeFormProps {
 const WelcomeCodeForm = (props: WelcomeCodeFormProps) => {
   const { codeParam, partnerParam } = props;
   const t = useTranslations('Welcome');
-  const { user, partnerAccesses, partnerAdmin, partners } = useTypedSelector(
-    (state: RootState) => state,
-  );
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const [codeInput, setCodeInput] = useState<string>('');
   const router = useRouter();

--- a/components/forms/WhatsappSubscribeForm.tsx
+++ b/components/forms/WhatsappSubscribeForm.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import { useState } from 'react';
 import 'react-international-phone/style.css';
 import { useSubscribeToWhatsappMutation } from '../../app/api';
-import { RootState } from '../../app/store';
 import { WHATSAPP_SUBSCRIPTION_STATUS } from '../../constants/enums';
 import {
   WHATSAPP_SUBSCRIBE_ERROR,
@@ -27,8 +26,10 @@ const WhatsappSubscribeForm = () => {
   const t = useTranslations('Whatsapp.form');
   const tS = useTranslations('Shared');
 
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const [phoneNumber, setPhoneNumber] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
@@ -40,7 +41,7 @@ const WhatsappSubscribeForm = () => {
     event.preventDefault();
     setFormError('');
     setLoading(true);
-    logEvent(WHATSAPP_SUBSCRIBE_REQUEST, eventData);
+    logEvent(WHATSAPP_SUBSCRIBE_REQUEST, eventUserData);
 
     const validatedNumber = validateNumber(phoneNumber);
 
@@ -55,7 +56,7 @@ const WhatsappSubscribeForm = () => {
 
       if ('data' in subscribeResponse) {
         setLoading(false);
-        logEvent(WHATSAPP_SUBSCRIBE_SUCCESS, eventData);
+        logEvent(WHATSAPP_SUBSCRIBE_SUCCESS, eventUserData);
       }
 
       if ('error' in subscribeResponse) {

--- a/components/layout/AppBarSpacer.tsx
+++ b/components/layout/AppBarSpacer.tsx
@@ -1,11 +1,5 @@
-import { Box, useMediaQuery } from '@mui/material';
-import { RootState } from '../../app/store';
-import { useTypedSelector } from '../../hooks/store';
-import theme from '../../styles/theme';
+import { Box } from '@mui/material';
 
 export const AppBarSpacer = () => {
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-
-  const { user } = useTypedSelector((state: RootState) => state);
   return <Box height={{ xs: '3rem', sm: '4rem', md: '8rem' }} marginTop={0}></Box>;
 };

--- a/components/layout/Consent.tsx
+++ b/components/layout/Consent.tsx
@@ -3,7 +3,6 @@ import { useTranslations } from 'next-intl';
 import Image from 'next/legacy/image';
 import React from 'react';
 import CookieConsent from 'react-cookie-consent';
-import { RootState } from '../../app/store';
 import { COOKIES_ACCEPTED, COOKIES_REJECTED } from '../../constants/events';
 import { useTypedSelector } from '../../hooks/store';
 import IllustrationCookieCat from '../../public/illustration_cookie_cat.svg';
@@ -12,8 +11,10 @@ import Link from '../common/Link';
 
 const Consent = (props: {}) => {
   const theme = useTheme();
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
   const tS = useTranslations('Shared');
   const isMobileScreen = useMediaQuery(theme.breakpoints.down('sm'));
 

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -7,7 +7,6 @@ import { useTranslations } from 'next-intl';
 import Image from 'next/legacy/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { RootState } from '../../app/store';
 import { PARTNER_SOCIAL_LINK_CLICKED, SOCIAL_LINK_CLICKED } from '../../constants/events';
 import { PartnerContent, getPartnerContent } from '../../constants/partners';
 import { useTypedSelector } from '../../hooks/store';
@@ -58,7 +57,9 @@ const Footer = () => {
   const [partners, setPartners] = useState<PartnerContent[] | null>(null);
   const router = useRouter();
 
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
 
   const addUniquePartner = (partnersList: PartnerContent[], partnerName: string) => {
     if (!partnersList.find((p) => p.name.toLowerCase() === partnerName.toLowerCase())) {
@@ -68,7 +69,7 @@ const Footer = () => {
   };
 
   useEffect(() => {
-    setEventUserData(getEventUserData({ user, partnerAccesses, partnerAdmin }));
+    setEventUserData(getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin));
     let partnersList: PartnerContent[] = [getPartnerContent('public')];
 
     if (partnerAdmin && partnerAdmin.partner) {
@@ -91,7 +92,7 @@ const Footer = () => {
     }
 
     setPartners(partnersList);
-  }, [partnerAccesses, user, router, partnerAdmin]);
+  }, [partnerAccesses, userCreatedAt, router, partnerAdmin]);
 
   return (
     <Container sx={footerContainerStyle}>

--- a/components/layout/LanguageMenu.tsx
+++ b/components/layout/LanguageMenu.tsx
@@ -3,7 +3,6 @@ import { Box, Button, Menu, MenuItem } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import * as React from 'react';
-import { RootState } from '../../app/store';
 import { HEADER_LANGUAGE_MENU_CLICKED, generateLanguageMenuEvent } from '../../constants/events';
 import { useTypedSelector } from '../../hooks/store';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
@@ -46,8 +45,10 @@ export default function LanguageMenu() {
   const locale = router.locale;
   const locales = router.locales;
   const t = useTranslations('Navigation');
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);

--- a/components/layout/NavigationDrawer.tsx
+++ b/components/layout/NavigationDrawer.tsx
@@ -3,7 +3,6 @@ import MenuIcon from '@mui/icons-material/Menu';
 import { Box, Button, Drawer } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import * as React from 'react';
-import { RootState } from '../../app/store';
 import {
   HEADER_NAVIGATION_MENU_CLOSED,
   HEADER_NAVIGATION_MENU_OPENED,
@@ -41,8 +40,10 @@ const NavigationDrawer = () => {
   const open = Boolean(anchorEl);
   const t = useTranslations('Navigation');
   const tS = useTranslations('Shared');
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);

--- a/components/layout/NavigationMenu.tsx
+++ b/components/layout/NavigationMenu.tsx
@@ -2,7 +2,6 @@ import { List, ListItem, ListItemButton, ListItemText } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { RootState } from '../../app/store';
 import {
   HEADER_ADMIN_CLICKED,
   HEADER_IMMEDIATE_HELP_CLICKED,
@@ -62,15 +61,20 @@ interface NavigationMenuProps {
 const NavigationMenu = (props: NavigationMenuProps) => {
   const { setAnchorEl } = props;
   const t = useTranslations('Navigation');
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const userLoading = useTypedSelector((state) => state.user.loading);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
+
   const [navigationLinks, setNavigationLinks] = useState<Array<NavigationItem>>([]);
   const router = useRouter();
 
   useEffect(() => {
     let links: Array<NavigationItem> = [];
 
-    if (!user.loading) {
+    if (!userLoading) {
       if (partnerAdmin && partnerAdmin.partner) {
         links.push({
           title: t('admin'),
@@ -100,7 +104,7 @@ const NavigationMenu = (props: NavigationMenuProps) => {
 
     setNavigationLinks(links);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [partnerAccesses, t, user, partnerAdmin]);
+  }, [t, userLoading, partnerAccesses, partnerAdmin]);
 
   return (
     <List sx={listStyle} onClick={() => setAnchorEl && setAnchorEl(null)}>

--- a/components/layout/PrimaryNavigationDrawerLinks.tsx
+++ b/components/layout/PrimaryNavigationDrawerLinks.tsx
@@ -2,7 +2,6 @@ import { Button, List, ListItem, ListItemButton, ListItemText } from '@mui/mater
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { RootState } from '../../app/store';
 import {
   DRAWER_ADMIN_CLICKED,
   DRAWER_IMMEDIATE_HELP_CLICKED,
@@ -66,16 +65,22 @@ interface NavigationMenuProps {
 const PrimaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
   const { setAnchorEl } = props;
   const t = useTranslations('Navigation');
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+
+  const userLoading = useTypedSelector((state) => state.user.loading);
+  const userToken = useTypedSelector((state) => state.user.token);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
+
   const [navigationLinks, setNavigationLinks] = useState<Array<NavigationItem>>([]);
   const router = useRouter();
 
   useEffect(() => {
     let links: Array<NavigationItem> = [];
 
-    if (!user.loading) {
-      if (user.token && router.pathname === '/auth/login') {
+    if (!userLoading) {
+      if (userToken && router.pathname === '/auth/login') {
         router.push('/courses');
       }
 
@@ -105,7 +110,7 @@ const PrimaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
 
     setNavigationLinks(links);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [partnerAccesses, t, user, partnerAdmin]);
+  }, [t, userToken, userLoading, partnerAccesses, partnerAdmin]);
 
   return (
     <List sx={listStyle} onClick={() => setAnchorEl && setAnchorEl(null)}>
@@ -122,7 +127,7 @@ const PrimaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
           </ListItemButton>
         </ListItem>
       ))}
-      {!user.loading && !user.token && (
+      {!userLoading && !userToken && (
         <li>
           <Button
             variant="contained"

--- a/components/layout/SecondaryNav.tsx
+++ b/components/layout/SecondaryNav.tsx
@@ -5,7 +5,6 @@ import notesFromBloomIcon from '../../public/notes_from_bloom_icon.svg';
 import therapyIcon from '../../public/therapy_icon.svg';
 
 import { useTranslations } from 'next-intl';
-import { RootState } from '../../app/store';
 import {
   SECONDARY_HEADER_ACTIVITIES_CLICKED,
   SECONDARY_HEADER_CHAT_CLICKED,
@@ -52,8 +51,10 @@ export const SecondaryNavIcon = ({ alt, src }: SecondaryNavIconType) => (
 
 const SecondaryNav = ({ currentPage }: { currentPage: string }) => {
   const router = useRouter();
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
   const t = useTranslations('Navigation');
 
   const therapyAccess = partnerAccesses.find(

--- a/components/layout/SecondaryNavigationDrawerLinks.tsx
+++ b/components/layout/SecondaryNavigationDrawerLinks.tsx
@@ -1,7 +1,6 @@
 import { List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { RootState } from '../../app/store';
 import {
   DRAWER_ACTIVITIES_CLICKED,
   DRAWER_CHAT_CLICKED,
@@ -75,8 +74,14 @@ interface NavigationMenuProps {
 const SecondaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
   const { setAnchorEl } = props;
   const t = useTranslations('Navigation');
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const userLoading = useTypedSelector((state) => state.user.loading);
+  const userToken = useTypedSelector((state) => state.user.token);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
+
   const [navigationLinks, setNavigationLinks] = useState<Array<SecondaryNavigationItem>>([]);
 
   useEffect(() => {
@@ -113,8 +118,8 @@ const SecondaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
       },
     ];
 
-    if (!user.loading) {
-      if (user.token) {
+    if (!userLoading) {
+      if (userToken) {
         const therapyAccess = partnerAccesses.find(
           (partnerAccess) => partnerAccess.featureTherapy === true,
         );
@@ -132,7 +137,7 @@ const SecondaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
 
     setNavigationLinks(links);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [partnerAccesses, t, user, partnerAdmin]);
+  }, [t, userLoading, userToken, partnerAccesses, partnerAdmin]);
 
   return (
     <List sx={listStyle} onClick={() => setAnchorEl && setAnchorEl(null)}>

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -3,7 +3,6 @@ import { useTranslations } from 'next-intl';
 import Image from 'next/legacy/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { RootState } from '../../app/store';
 import { HEADER_HOME_LOGO_CLICKED, HEADER_LOGIN_CLICKED } from '../../constants/events';
 import { useTypedSelector } from '../../hooks/store';
 import bloomLogo from '../../public/bloom_logo_white.svg';
@@ -44,8 +43,11 @@ const TopBar = () => {
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
   const [welcomeUrl, setWelcomeUrl] = useState<string>('/');
 
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userToken = useTypedSelector((state) => state.user.token);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   useEffect(() => {
     if (partnerAdmin && partnerAdmin.partner) {
@@ -73,9 +75,9 @@ const TopBar = () => {
           </Link>
           <Box sx={{ ...rowStyle, alignItems: 'center', alignContent: 'center' }}>
             {!isSmallScreen && <NavigationMenu />}
-            {user.token && <UserMenu />}
+            {userToken && <UserMenu />}
             <LanguageMenu />
-            {!isSmallScreen && !user.token && (
+            {!isSmallScreen && !userToken && (
               <Button
                 variant="contained"
                 size="medium"

--- a/components/layout/UserMenu.tsx
+++ b/components/layout/UserMenu.tsx
@@ -10,7 +10,6 @@ import { api } from '../../app/api';
 import { clearCoursesSlice } from '../../app/coursesSlice';
 import { clearPartnerAccessesSlice } from '../../app/partnerAccessSlice';
 import { clearPartnerAdminSlice } from '../../app/partnerAdminSlice';
-import { RootState } from '../../app/store';
 import { clearUserSlice } from '../../app/userSlice';
 import { HEADER_ACCOUNT_ICON_CLICKED, HEADER_APPLY_A_CODE_CLICKED } from '../../constants/events';
 import { useAppDispatch, useTypedSelector } from '../../hooks/store';
@@ -42,8 +41,10 @@ export default function UserMenu() {
   const router = useRouter();
   const t = useTranslations('Navigation');
   const dispatch: any = useAppDispatch();
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 

--- a/components/session/SessionProgressDisplay.tsx
+++ b/components/session/SessionProgressDisplay.tsx
@@ -3,7 +3,6 @@ import DonutLargeIcon from '@mui/icons-material/DonutLarge';
 import { Box } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { Course } from '../../app/coursesSlice';
-import { RootState } from '../../app/store';
 import { PROGRESS_STATUS } from '../../constants/enums';
 import { useTypedSelector } from '../../hooks/store';
 import { StoryblokSessionJson } from '../../utils/helper-types/storyblok';
@@ -20,7 +19,7 @@ export const SessionProgressDisplay = (props: SessionProgressDisplayProps) => {
     PROGRESS_STATUS.NOT_STARTED,
   );
 
-  const { courses } = useTypedSelector((state: RootState) => state);
+  const courses = useTypedSelector((state) => state.courses);
 
   useEffect(() => {
     const userCourse = courses.find((course: Course) => course.storyblokId === storyblokCourseId);

--- a/config/storyblok.ts
+++ b/config/storyblok.ts
@@ -86,7 +86,7 @@ export function useStoryblok(
       // first load the bridge, then initialize the event listeners
       addBridge(initEventListeners);
     }
-  }, []);
+  });
 
   useEffect(() => {
     setStory(originalStory);

--- a/guards/partnerAdminGuard.tsx
+++ b/guards/partnerAdminGuard.tsx
@@ -3,7 +3,6 @@ import { Box } from '@mui/system';
 import Head from 'next/head';
 import Image from 'next/legacy/image';
 import { useTranslations } from 'use-intl';
-import { RootState } from '../app/store';
 import Link from '../components/common/Link';
 import { useTypedSelector } from '../hooks/store';
 import illustrationPerson4Peach from '../public/illustration_person4_peach.svg';
@@ -22,11 +21,12 @@ const imageContainerStyle = {
 } as const;
 
 export function PartnerAdminGuard({ children }: { children: JSX.Element }) {
-  const { partnerAdmin } = useTypedSelector((state: RootState) => state);
+  const partnerAdminId = useTypedSelector((state) => state.partnerAdmin.id);
+
   const t = useTranslations('PartnerAdmin.accessGuard');
   const tS = useTranslations('Shared');
 
-  if (!partnerAdmin) {
+  if (!partnerAdminId) {
     return (
       <Container sx={containerStyle}>
         <Head>{t('title')}</Head>

--- a/guards/superAdminGuard.tsx
+++ b/guards/superAdminGuard.tsx
@@ -3,7 +3,6 @@ import { Box } from '@mui/system';
 import Head from 'next/head';
 import Image from 'next/legacy/image';
 import { useTranslations } from 'use-intl';
-import { RootState } from '../app/store';
 import Link from '../components/common/Link';
 import { useTypedSelector } from '../hooks/store';
 import illustrationPerson4Peach from '../public/illustration_person4_peach.svg';
@@ -22,11 +21,11 @@ const imageContainerStyle = {
 } as const;
 
 export function SuperAdminGuard({ children }: { children: JSX.Element }) {
-  const { user } = useTypedSelector((state: RootState) => state);
+  const userIsSuperAdmin = useTypedSelector((state) => state.user.isSuperAdmin);
   const t = useTranslations('Admin.accessGuard');
   const tS = useTranslations('Shared');
 
-  if (!user.isSuperAdmin) {
+  if (!userIsSuperAdmin) {
     return (
       <Container sx={containerStyle}>
         <Head>{t('title')}</Head>

--- a/guards/therapyAccessGuard.tsx
+++ b/guards/therapyAccessGuard.tsx
@@ -3,7 +3,6 @@ import { Box } from '@mui/system';
 import Head from 'next/head';
 import Image from 'next/legacy/image';
 import { useTranslations } from 'use-intl';
-import { RootState } from '../app/store';
 import Link from '../components/common/Link';
 import { useTypedSelector } from '../hooks/store';
 import illustrationPerson4Peach from '../public/illustration_person4_peach.svg';
@@ -22,7 +21,7 @@ const imageContainerStyle = {
 } as const;
 
 export function TherapyAccessGuard({ children }: { children: JSX.Element }) {
-  const { partnerAccesses } = useTypedSelector((state: RootState) => state);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const t = useTranslations('Therapy.accessGuard');
   const tS = useTranslations('Shared');
 

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -4,7 +4,6 @@ import { GetStaticPropsContext, NextPage } from 'next';
 import Head from 'next/head';
 import Image from 'next/legacy/image';
 import { useTranslations } from 'use-intl';
-import { RootState } from '../app/store';
 import Link from '../components/common/Link';
 import LoadingContainer from '../components/common/LoadingContainer';
 import { useTypedSelector } from '../hooks/store';
@@ -27,9 +26,10 @@ const imageContainerStyle = {
 
 const Custom404: NextPage = () => {
   const t = useTranslations('Shared');
-  const { user } = useTypedSelector((state: RootState) => state);
+  const userToken = useTypedSelector((state) => state.user.token);
+  const userLoading = useTypedSelector((state) => state.user.loading);
 
-  if (user.loading) {
+  if (userLoading) {
     return <LoadingContainer />;
   }
 
@@ -45,16 +45,16 @@ const Custom404: NextPage = () => {
         {t('404.title')}
       </Typography>
       <Typography>
-        {user.token ? t('404.authenticatedDescription') : t('404.unauthenticatedDescription')}
+        {userToken ? t('404.authenticatedDescription') : t('404.unauthenticatedDescription')}
       </Typography>
       <Button
         sx={{ mt: 3 }}
         variant="contained"
         color="secondary"
         component={Link}
-        href={user.token ? '/courses' : '/login'}
+        href={userToken ? '/courses' : '/login'}
       >
-        {user.token ? t('404.authenticatedRedirectButton') : t('404.unauthenticatedRedirectButton')}
+        {userToken ? t('404.authenticatedRedirectButton') : t('404.unauthenticatedRedirectButton')}
       </Button>
     </Container>
   );

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -4,7 +4,6 @@ import { GetStaticPropsContext, NextPage } from 'next';
 import Head from 'next/head';
 import Image from 'next/legacy/image';
 import { useTranslations } from 'use-intl';
-import { RootState } from '../app/store';
 import Link from '../components/common/Link';
 import LoadingContainer from '../components/common/LoadingContainer';
 import { useTypedSelector } from '../hooks/store';
@@ -13,7 +12,8 @@ import { columnStyle } from '../styles/common';
 
 const Custom500: NextPage = () => {
   const t = useTranslations('Shared');
-  const { user } = useTypedSelector((state: RootState) => state);
+  const userToken = useTypedSelector((state) => state.user.token);
+  const userLoading = useTypedSelector((state) => state.user.loading);
 
   const containerStyle = {
     ...columnStyle,
@@ -29,7 +29,7 @@ const Custom500: NextPage = () => {
     marginBottom: 2,
   } as const;
 
-  if (user.loading) {
+  if (userLoading) {
     return <LoadingContainer />;
   }
 
@@ -50,9 +50,9 @@ const Custom500: NextPage = () => {
         variant="contained"
         color="secondary"
         component={Link}
-        href={user.token ? '/courses' : '/login'}
+        href={userToken ? '/courses' : '/login'}
       >
-        {user.token ? t('500.authenticatedRedirectButton') : t('500.unauthenticatedRedirectButton')}
+        {userToken ? t('500.authenticatedRedirectButton') : t('500.unauthenticatedRedirectButton')}
       </Button>
     </Container>
   );

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -3,7 +3,6 @@ import { GetStaticPathsContext, GetStaticPropsContext, NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
-import { RootState } from '../app/store';
 import { SignUpBanner } from '../components/banner/SignUpBanner';
 import Header from '../components/layout/Header';
 import StoryblokPageSection from '../components/storyblok/StoryblokPageSection';
@@ -20,7 +19,7 @@ interface Props {
 
 const Page: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
   story = useStoryblok(story, preview, sbParams, locale);
-  const { user } = useTypedSelector((state: RootState) => state);
+  const userToken = useTypedSelector((state) => state.user.token);
   const router = useRouter();
 
   const headerProps = {
@@ -41,8 +40,8 @@ const Page: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
         imageSrc={headerProps.imageSrc}
         translatedImageAlt={headerProps.translatedImageAlt}
       />
-      {!user.token && isPartiallyPublicPage && <SignUpBanner />}
-      {user.token &&
+      {!userToken && isPartiallyPublicPage && <SignUpBanner />}
+      {userToken &&
         story.content.page_sections?.length > 0 &&
         story.content.page_sections.map((section: any, index: number) => (
           <StoryblokPageSection

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -105,7 +105,11 @@ function MyApp(props: MyAppProps) {
 
   return (
     <ErrorBoundary>
-      <NextIntlClientProvider messages={pageProps.messages} locale={router.locale}>
+      <NextIntlClientProvider
+        messages={pageProps.messages}
+        locale={router.locale}
+        timeZone="Europe/London"
+      >
         <Head>
           <title>Bloom</title>
           <meta name="viewport" content="initial-scale=1, width=device-width" />
@@ -140,7 +144,7 @@ function AppReduxWrapper({ Component, ...rest }: MyAppProps) {
         (window as any).store = store;
       }
     }
-  }, []);
+  });
 
   return (
     <Provider store={store}>

--- a/pages/about-our-courses.tsx
+++ b/pages/about-our-courses.tsx
@@ -3,7 +3,6 @@ import { GetStaticPropsContext, NextPage } from 'next';
 import Head from 'next/head';
 import { useEffect } from 'react';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
-import { RootState } from '../app/store';
 import Header from '../components/layout/Header';
 import StoryblokPageSection from '../components/storyblok/StoryblokPageSection';
 import Storyblok, { useStoryblok } from '../config/storyblok';
@@ -21,8 +20,10 @@ interface Props {
 
 const CourseAbout: NextPage<Props> = ({ storyData, preview, sbParams, locale }) => {
   const story = useStoryblok(storyData, preview, sbParams, locale);
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const headerProps = {
     title: story.content.title,
@@ -33,7 +34,7 @@ const CourseAbout: NextPage<Props> = ({ storyData, preview, sbParams, locale }) 
 
   useEffect(() => {
     logEvent(ABOUT_COURSES_VIEWED, eventUserData);
-  }, []);
+  });
 
   return (
     <Box>

--- a/pages/account/about-you.tsx
+++ b/pages/account/about-you.tsx
@@ -4,7 +4,6 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { RootState } from '../../app/store';
 import Link from '../../components/common/Link';
 import AboutYouDemographicForm from '../../components/forms/AboutYouDemographicForm';
 import AboutYouSetAForm from '../../components/forms/AboutYouSetAForm';
@@ -48,9 +47,11 @@ const AboutYou: NextPage = () => {
 
   const t = useTranslations('Account.aboutYou');
 
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const { q, return_url } = router.query;
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   useEffect(() => {
     if (q) {
@@ -62,7 +63,7 @@ const AboutYou: NextPage = () => {
 
   useEffect(() => {
     logEvent(ABOUT_YOU_VIEWED, eventUserData);
-  }, []);
+  });
 
   const headerProps = {
     partnerLogoSrc: welcomeToBloom,

--- a/pages/account/apply-a-code.tsx
+++ b/pages/account/apply-a-code.tsx
@@ -4,7 +4,6 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import Image from 'next/legacy/image';
 import { useEffect, useState } from 'react';
-import { RootState } from '../../app/store';
 import Link from '../../components/common/Link';
 import ApplyCodeForm from '../../components/forms/ApplyCodeForm';
 import Header from '../../components/layout/Header';
@@ -51,7 +50,9 @@ const ApplyACode: NextPage = () => {
   const t = useTranslations('Account');
   const tS = useTranslations('Shared');
 
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const [allPartnersContent, setAllPartnersContent] = useState<PartnerContent[]>([]);
 
   useEffect(() => {
@@ -59,10 +60,10 @@ const ApplyACode: NextPage = () => {
   }, []);
 
   useEffect(() => {
-    const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+    const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
     logEvent(ASSIGN_NEW_PARTNER_VIEWED, eventUserData);
-  }, []);
+  });
 
   const headerProps = {
     title: t('applyCode.title'),

--- a/pages/admin/dashboard.tsx
+++ b/pages/admin/dashboard.tsx
@@ -3,7 +3,6 @@ import { GetStaticPropsContext, NextPage } from 'next';
 import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { useEffect } from 'react';
-import { RootState } from '../../app/store';
 import CreatePartnerAdminForm from '../../components/forms/CreatePartnerAdminForm';
 import UpdateTherapyAdminForm from '../../components/forms/UpdateTherapyAdminForm';
 import AdminHeader from '../../components/layout/PartnerAdminHeader';
@@ -24,16 +23,18 @@ const cardStyle = {
 
 const Dashboard: NextPage = () => {
   const t = useTranslations('Admin');
-  const { partnerAdmin, user, partnerAccesses } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const headerProps = {
     title: t('title'),
   };
 
   useEffect(() => {
-    logEvent(CREATE_PARTNER_ACCESS_VIEWED, { ...eventUserData });
-  }, []);
+    logEvent(CREATE_PARTNER_ACCESS_VIEWED, eventUserData);
+  });
 
   return (
     <Box>

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -14,7 +14,6 @@ import Head from 'next/head';
 import Image from 'next/legacy/image';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { RootState } from '../../app/store';
 import Link from '../../components/common/Link';
 import LoginForm from '../../components/forms/LoginForm';
 import PartnerHeader from '../../components/layout/PartnerHeader';
@@ -58,10 +57,15 @@ const Login: NextPage = () => {
   const t = useTranslations('Auth');
   const tS = useTranslations('Shared');
   const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
   const router = useRouter();
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+
+  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const headerProps = {
     partnerLogoSrc: welcomeToBloom,
@@ -74,10 +78,10 @@ const Login: NextPage = () => {
 
   useEffect(() => {
     // Redirect if the user is on the login page but is already logged in and their data has been retrieved from the backend
-    if (user.token && user.id) {
+    if (userToken && userId) {
       router.push('/courses');
     }
-  }, [user.token]);
+  });
 
   const ExtraContent = () => {
     return (

--- a/pages/auth/register.tsx
+++ b/pages/auth/register.tsx
@@ -14,7 +14,6 @@ import Head from 'next/head';
 import Image from 'next/legacy/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { RootState } from '../../app/store';
 import Link from '../../components/common/Link';
 import RegisterForm, { PartnerRegisterForm } from '../../components/forms/RegisterForm';
 import PartnerHeader from '../../components/layout/PartnerHeader';
@@ -75,8 +74,10 @@ const Register: NextPage = () => {
   const router = useRouter();
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const [codeParam, setCodeParam] = useState<string>('');
   const [partnerContent, setPartnerContent] = useState<PartnerContent | null>(null);

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -3,7 +3,6 @@ import { GetStaticPropsContext, NextPage } from 'next';
 import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
-import { RootState } from '../app/store';
 import { SignUpBanner } from '../components/banner/SignUpBanner';
 import CrispButton from '../components/crisp/CrispButton';
 import Header, { HeaderProps } from '../components/layout/Header';
@@ -22,15 +21,21 @@ interface Props {
 
 const Chat: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
   let configuredStory = useStoryblok(story, preview, sbParams, locale);
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
   const t = useTranslations('Courses');
+
+  const userEmail = useTypedSelector((state) => state.user.email);
+  const userToken = useTypedSelector((state) => state.user.token);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+
   const headerProps: HeaderProps = {
     title: configuredStory.content.title,
     introduction: configuredStory.content.description,
     imageSrc: configuredStory.content.header_image.filename,
     translatedImageAlt: configuredStory.content.header_image.alt,
   };
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   return (
     <>
@@ -39,16 +44,16 @@ const Chat: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
         <Header
           {...headerProps}
           cta={
-            user.token && (
+            userToken && (
               <CrispButton
-                email={user.email}
+                email={userEmail}
                 eventData={eventUserData}
                 buttonText={t('sessionDetail.chat.startButton')}
               />
             )
           }
         />
-        {user.token ? (
+        {userToken ? (
           configuredStory.content.page_sections?.length > 0 &&
           configuredStory.content.page_sections.map((section: any, index: number) => (
             <StoryblokPageSection

--- a/pages/courses/[slug].tsx
+++ b/pages/courses/[slug].tsx
@@ -5,7 +5,6 @@ import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
 import { render } from 'storyblok-rich-text-react-renderer';
-import { RootState } from '../../app/store';
 import SessionCard from '../../components/cards/SessionCard';
 import { ContentUnavailable } from '../../components/common/ContentUnavailable';
 import Link from '../../components/common/Link';
@@ -49,15 +48,17 @@ const CourseOverview: NextPage<Props> = ({ story, preview, sbParams, locale }) =
 
   story = useStoryblok(story, preview, sbParams, locale);
 
-  const { user, partnerAccesses, partnerAdmin, courses } = useTypedSelector(
-    (state: RootState) => state,
-  );
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const courses = useTypedSelector((state) => state.courses);
+
   const [incorrectAccess, setIncorrectAccess] = useState<boolean>(true);
   const [courseProgress, setCourseProgress] = useState<PROGRESS_STATUS>(
     PROGRESS_STATUS.NOT_STARTED,
   );
 
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const courseComingSoon: boolean = story.content.coming_soon;
   const courseLiveSoon: boolean = courseIsLiveSoon(story.content);
@@ -87,7 +88,7 @@ const CourseOverview: NextPage<Props> = ({ story, preview, sbParams, locale }) =
 
   useEffect(() => {
     logEvent(COURSE_OVERVIEW_VIEWED, eventData);
-  }, []);
+  });
 
   if (incorrectAccess) {
     return (

--- a/pages/courses/[slug]/[sessionSlug].tsx
+++ b/pages/courses/[slug]/[sessionSlug].tsx
@@ -13,7 +13,6 @@ import { StoriesParams, StoryData } from 'storyblok-js-client';
 import { render } from 'storyblok-rich-text-react-renderer';
 import { useStartSessionMutation } from '../../../app/api';
 import { Course, Session } from '../../../app/coursesSlice';
-import { RootState } from '../../../app/store';
 import SessionContentCard from '../../../components/cards/SessionContentCard';
 import Link from '../../../components/common/Link';
 import CrispButton from '../../../components/crisp/CrispButton';
@@ -86,9 +85,12 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
   story = useStoryblok(story, preview, sbParams, locale);
   const course = story.content.course.content;
 
-  const { user, partnerAccesses, partnerAdmin, courses } = useTypedSelector(
-    (state: RootState) => state,
-  );
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const userEmail = useTypedSelector((state) => state.user.email);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const courses = useTypedSelector((state) => state.courses);
+
   const [incorrectAccess, setIncorrectAccess] = useState<boolean>(true);
   const [liveChatAccess, setLiveChatAccess] = useState<boolean>(false);
   const [sessionProgress, setSessionProgress] = useState<PROGRESS_STATUS>(
@@ -99,7 +101,7 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
   const [weekString, setWeekString] = useState<string>('');
   const [startSession, { isLoading: startSessionIsLoading }] = useStartSessionMutation();
 
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
   const courseComingSoon: boolean = course.coming_soon;
   const courseLiveSoon: boolean = courseIsLiveSoon(course);
   const courseLiveNow: boolean = courseIsLiveNow(course);
@@ -158,7 +160,7 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
           : setSessionProgress(PROGRESS_STATUS.STARTED);
       }
     }
-  }, [courses, story]);
+  }, [courses, course.weeks, story]);
 
   useEffect(() => {
     if (openTranscriptModal === null) return;
@@ -211,7 +213,7 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
 
   useEffect(() => {
     logEvent(SESSION_VIEWED, eventData);
-  }, []);
+  });
 
   const Dots = () => {
     return (
@@ -364,7 +366,7 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
                       </Box>
                       <Box sx={crispButtonContainerStyle}>
                         <CrispButton
-                          email={user.email}
+                          email={userEmail}
                           eventData={eventData}
                           buttonText={t('sessionDetail.chat.startButton')}
                         />

--- a/pages/courses/image-based-abuse-and-rebuilding-ourselves/[sessionSlug].tsx
+++ b/pages/courses/image-based-abuse-and-rebuilding-ourselves/[sessionSlug].tsx
@@ -11,7 +11,6 @@ import { StoriesParams, StoryData } from 'storyblok-js-client';
 import { render } from 'storyblok-rich-text-react-renderer';
 import { useStartSessionMutation } from '../../../app/api';
 import { Course, Session } from '../../../app/coursesSlice';
-import { RootState } from '../../../app/store';
 import SessionContentCard from '../../../components/cards/SessionContentCard';
 import { Dots } from '../../../components/common/Dots';
 import Link from '../../../components/common/Link';
@@ -88,9 +87,12 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
   story = useStoryblok(story, preview, sbParams, locale);
   const course = story.content.course.content;
 
-  const { user, partnerAccesses, partnerAdmin, courses } = useTypedSelector(
-    (state: RootState) => state,
-  );
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const userEmail = useTypedSelector((state) => state.user.email);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const courses = useTypedSelector((state) => state.courses);
+
   const [incorrectAccess, setIncorrectAccess] = useState<boolean>(true);
   const [liveChatAccess, setLiveChatAccess] = useState<boolean>(false);
   const [sessionProgress, setSessionProgress] = useState<PROGRESS_STATUS>(
@@ -101,7 +103,7 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
   const [weekString, setWeekString] = useState<string>('');
   const [startSession] = useStartSessionMutation();
 
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const eventData = {
     ...eventUserData,
@@ -207,7 +209,7 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
 
   useEffect(() => {
     logEvent(SESSION_VIEWED, eventData);
-  }, []);
+  });
 
   return (
     <Box>
@@ -332,7 +334,7 @@ const SessionDetail: NextPage<Props> = ({ story, preview, sbParams, locale }) =>
                     </Box>
                     <Box sx={crispButtonContainerStyle}>
                       <CrispButton
-                        email={user.email}
+                        email={userEmail}
                         eventData={eventData}
                         buttonText={t('sessionDetail.chat.startButton')}
                       />

--- a/pages/courses/image-based-abuse-and-rebuilding-ourselves/index.tsx
+++ b/pages/courses/image-based-abuse-and-rebuilding-ourselves/index.tsx
@@ -4,7 +4,6 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
-import { RootState } from '../../../app/store';
 import SessionCard from '../../../components/cards/SessionCard';
 import { ContentUnavailable } from '../../../components/common/ContentUnavailable';
 import Link from '../../../components/common/Link';
@@ -46,15 +45,17 @@ const CourseOverview: NextPage<Props> = ({ story, preview, sbParams, locale }) =
 
   story = useStoryblok(story, preview, sbParams, locale);
 
-  const { user, partnerAccesses, partnerAdmin, courses } = useTypedSelector(
-    (state: RootState) => state,
-  );
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const courses = useTypedSelector((state) => state.courses);
+
   const [incorrectAccess, setIncorrectAccess] = useState<boolean>(true);
   const [courseProgress, setCourseProgress] = useState<PROGRESS_STATUS>(
     PROGRESS_STATUS.NOT_STARTED,
   );
 
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const eventData = {
     ...eventUserData,
@@ -75,7 +76,7 @@ const CourseOverview: NextPage<Props> = ({ story, preview, sbParams, locale }) =
 
   useEffect(() => {
     logEvent(COURSE_OVERVIEW_VIEWED, eventData);
-  }, []);
+  });
 
   if (incorrectAccess) {
     return (

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -4,7 +4,6 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import { StoryData, StoryParams } from 'storyblok-js-client';
-import { RootState } from '../../app/store';
 import { SignUpBanner } from '../../components/banner/SignUpBanner';
 import CourseCard from '../../components/cards/CourseCard';
 import LoadingContainer from '../../components/common/LoadingContainer';
@@ -43,10 +42,14 @@ const CourseList: NextPage<Props> = ({ stories, preview, sbParams, locale }) => 
   const [loadedCourses, setLoadedCourses] = useState<StoryData[] | null>(null);
   const [coursesStarted, setCoursesStarted] = useState<Array<number>>([]);
   const [coursesCompleted, setCoursesCompleted] = useState<Array<number>>([]);
-  const { user, partnerAccesses, partnerAdmin, courses } = useTypedSelector(
-    (state: RootState) => state,
-  );
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const userToken = useTypedSelector((state) => state.user.token);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const courses = useTypedSelector((state) => state.courses);
+
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
   const liveCourseAccess = partnerAccesses.length === 0 && !partnerAdmin.id;
   const t = useTranslations('Courses');
 
@@ -58,10 +61,8 @@ const CourseList: NextPage<Props> = ({ stories, preview, sbParams, locale }) => 
   };
 
   useEffect(() => {
-    logEvent(COURSE_LIST_VIEWED, {
-      ...eventUserData,
-    });
-  }, []);
+    logEvent(COURSE_LIST_VIEWED, eventUserData);
+  });
 
   useEffect(() => {
     if (partnerAdmin && partnerAdmin.partner) {
@@ -105,7 +106,7 @@ const CourseList: NextPage<Props> = ({ stories, preview, sbParams, locale }) => 
     }
   }, [partnerAccesses, partnerAdmin, stories, courses]);
   // Show sign up banner if user is logged out
-  if (!user.token) {
+  if (!userToken) {
     return (
       <Box>
         <Head>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,7 +5,6 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
 import { render } from 'storyblok-rich-text-react-renderer';
-import { RootState } from '../app/store';
 import Link from '../components/common/Link';
 import PartnerHeader from '../components/layout/PartnerHeader';
 import StoryblokPageSection from '../components/storyblok/StoryblokPageSection';
@@ -48,8 +47,12 @@ interface Props {
 
 const Index: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
   const t = useTranslations('Welcome');
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+
+  const userToken = useTypedSelector((state) => state.user.token);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   story = useStoryblok(story, preview, sbParams, locale);
 
@@ -75,7 +78,7 @@ const Index: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
         <Box sx={introContainerStyle}>{render(story.content.introduction, RichTextOptions)}</Box>
         <Card sx={rowItem}>
           <CardContent>
-            {user.token ? (
+            {userToken ? (
               <>
                 <Typography variant="h2" component="h2">
                   {t('continueCourses')}

--- a/pages/meet-the-team.tsx
+++ b/pages/meet-the-team.tsx
@@ -4,7 +4,6 @@ import Head from 'next/head';
 import { useEffect } from 'react';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
 import { render } from 'storyblok-rich-text-react-renderer';
-import { RootState } from '../app/store';
 import TeamMemberCard from '../components/cards/TeamMemberCard';
 import Header from '../components/layout/Header';
 import StoryblokPageSection from '../components/storyblok/StoryblokPageSection';
@@ -46,8 +45,10 @@ interface Props {
 const MeetTheTeam: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
   story = useStoryblok(story, preview, sbParams, locale);
 
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const headerProps = {
     title: story.content.title,
@@ -57,10 +58,8 @@ const MeetTheTeam: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
   };
 
   useEffect(() => {
-    logEvent(MEET_THE_TEAM_VIEWED, {
-      ...eventUserData,
-    });
-  }, []);
+    logEvent(MEET_THE_TEAM_VIEWED, eventUserData);
+  });
 
   return (
     <Box>

--- a/pages/partner-admin/create-access-code.tsx
+++ b/pages/partner-admin/create-access-code.tsx
@@ -3,7 +3,6 @@ import { GetStaticPropsContext, NextPage } from 'next';
 import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { useEffect } from 'react';
-import { RootState } from '../../app/store';
 import CreateAccessCodeForm from '../../components/forms/CreateAccessCodeForm';
 import AdminHeader from '../../components/layout/PartnerAdminHeader';
 import { CREATE_PARTNER_ACCESS_VIEWED } from '../../constants/events';
@@ -23,8 +22,10 @@ const cardStyle = {
 
 const CreateAccessCode: NextPage = () => {
   const t = useTranslations('PartnerAdmin.createAccessCode');
-  const { partnerAdmin, user, partnerAccesses } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const headerProps = {
     title: t('title'),
@@ -35,7 +36,7 @@ const CreateAccessCode: NextPage = () => {
 
   useEffect(() => {
     logEvent(CREATE_PARTNER_ACCESS_VIEWED, { ...eventUserData });
-  }, []);
+  });
 
   return (
     <Box>

--- a/pages/subscription/whatsapp.tsx
+++ b/pages/subscription/whatsapp.tsx
@@ -4,7 +4,6 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
-import { RootState } from '../../app/store';
 import { SignUpBanner } from '../../components/banner/SignUpBanner';
 import ImageTextColumn from '../../components/common/ImageTextColumn';
 import { ImageTextItem } from '../../components/common/ImageTextGrid';
@@ -68,11 +67,12 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story, preview, sbParams,
 
   const [hasActiveWhatsappSub, setHasActiveWhatsappSub] = useState<boolean>(false);
 
-  const { user } = useTypedSelector((state: RootState) => state);
+  const userActiveSubscriptions = useTypedSelector((state) => state.user.activeSubscriptions);
+  const userToken = useTypedSelector((state) => state.user.token);
 
   useEffect(() => {
-    setHasActiveWhatsappSub(hasWhatsappSubscription(user.activeSubscriptions));
-  }, [user.activeSubscriptions]);
+    setHasActiveWhatsappSub(hasWhatsappSubscription(userActiveSubscriptions));
+  }, [userActiveSubscriptions]);
 
   const headerProps: HeaderProps = {
     title: configuredStory.content.title,
@@ -86,8 +86,8 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story, preview, sbParams,
       <Head>{configuredStory.content.title}</Head>
       <Box>
         <Header {...headerProps} />
-        {!user.token && <SignUpBanner />}
-        {user.token && (
+        {!userToken && <SignUpBanner />}
+        {userToken && (
           <Container sx={containerStyle}>
             <Box sx={infoBoxStyle}>
               <ImageTextColumn items={steps} translations="Whatsapp.steps" />
@@ -97,7 +97,7 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story, preview, sbParams,
             </Box>
           </Container>
         )}
-        {user.token &&
+        {userToken &&
           configuredStory.content.page_sections?.length > 0 &&
           configuredStory.content.page_sections.map((section: any, index: number) => (
             <StoryblokPageSection

--- a/pages/therapy/book-session.tsx
+++ b/pages/therapy/book-session.tsx
@@ -6,7 +6,6 @@ import Image from 'next/legacy/image';
 import Script from 'next/script';
 import { useEffect, useState } from 'react';
 import { PartnerAccess } from '../../app/partnerAccessSlice';
-import { RootState } from '../../app/store';
 import Faqs from '../../components/common/Faqs';
 import ImageTextGrid, { ImageTextItem } from '../../components/common/ImageTextGrid';
 import Header from '../../components/layout/Header';
@@ -75,8 +74,10 @@ const BookSession: NextPage = () => {
   const [hasTherapyRemaining, setHasTherapyRemaining] = useState<boolean>(false);
   const [widgetOpen, setWidgetOpen] = useState(false);
 
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const user = useTypedSelector((state) => state.user);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(user.createdAt, partnerAccesses, partnerAdmin);
 
   useEffect(() => {
     let partnerAccess = partnerAccesses.find(
@@ -101,7 +102,7 @@ const BookSession: NextPage = () => {
 
   useEffect(() => {
     logEvent(THERAPY_BOOKING_VIEWED, eventUserData);
-  }, []);
+  });
 
   const headerProps = {
     title: t('title'),

--- a/pages/therapy/confirmed-session.tsx
+++ b/pages/therapy/confirmed-session.tsx
@@ -5,7 +5,6 @@ import Head from 'next/head';
 import Image from 'next/legacy/image';
 import { useEffect, useState } from 'react';
 import { PartnerAccess } from '../../app/partnerAccessSlice';
-import { RootState } from '../../app/store';
 import Faqs from '../../components/common/Faqs';
 import Link from '../../components/common/Link';
 import Header from '../../components/layout/Header';
@@ -21,8 +20,10 @@ const ConfirmedSession: NextPage = () => {
   const t = useTranslations('Therapy');
   const tS = useTranslations('Shared');
 
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
   const [partnerAccess, setPartnerAccess] = useState<PartnerAccess | null>(null);
 
   useEffect(() => {
@@ -43,7 +44,7 @@ const ConfirmedSession: NextPage = () => {
 
   useEffect(() => {
     logEvent(THERAPY_CONFIRMATION_VIEWED, eventUserData);
-  }, []);
+  });
 
   const headerProps = {
     title: t('confirmation.title'),

--- a/pages/welcome/[partnerName].tsx
+++ b/pages/welcome/[partnerName].tsx
@@ -8,7 +8,6 @@ import { useEffect, useState } from 'react';
 import { StoriesParams, StoryData } from 'storyblok-js-client';
 import { render } from 'storyblok-rich-text-react-renderer';
 import { useGetAutomaticAccessCodeFeatureForPartnerQuery } from '../../app/api';
-import { RootState } from '../../app/store';
 import Link from '../../components/common/Link';
 import WelcomeCodeForm from '../../components/forms/WelcomeCodeForm';
 import PartnerHeader from '../../components/layout/PartnerHeader';
@@ -56,10 +55,6 @@ interface Props {
 }
 
 const Welcome: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
-  const t = useTranslations('Welcome');
-
-  const { user, partnerAccesses, partnerAdmin } = useTypedSelector((state: RootState) => state);
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
   story = useStoryblok(story, preview, sbParams, locale);
   const partnerContent = getPartnerContent(story.slug);
 
@@ -100,14 +95,19 @@ const Welcome: NextPage<Props> = ({ story, preview, sbParams, locale }) => {
 
 const CallToActionCard = ({ partnerName }: { partnerName: string }) => {
   const router = useRouter();
-  const { user, partnerAccesses, partnerAdmin, partners } = useTypedSelector(
-    (state: RootState) => state,
-  );
-  const t = useTranslations('Welcome');
+
+  const userToken = useTypedSelector((state) => state.user.token);
+  const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
+  const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
+  const partners = useTypedSelector((state) => state.partners);
+  const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
 
   const [accessCodeRequired, setAccessCodeRequired] = useState<boolean>(true);
   const [codeParam, setCodeParam] = useState<string>('');
-  const eventUserData = getEventUserData({ user, partnerAccesses, partnerAdmin });
+
+  const t = useTranslations('Welcome');
+
   useGetAutomaticAccessCodeFeatureForPartnerQuery(partnerName);
   useEffect(() => {
     const partnerData = partners.find((p) => p.name.toLowerCase() === partnerName.toLowerCase());
@@ -124,7 +124,7 @@ const CallToActionCard = ({ partnerName }: { partnerName: string }) => {
   return (
     <Card sx={rowItem}>
       <CardContent>
-        {user.token && (
+        {userToken && (
           <>
             <Typography variant="h2" component="h2">
               {t('continueCourses')}
@@ -145,7 +145,7 @@ const CallToActionCard = ({ partnerName }: { partnerName: string }) => {
             </Button>
           </>
         )}
-        {!user.token && accessCodeRequired && (
+        {!userToken && accessCodeRequired && (
           <>
             <Typography variant="h2" component="h2">
               {t('getStarted')}
@@ -154,7 +154,7 @@ const CallToActionCard = ({ partnerName }: { partnerName: string }) => {
             <WelcomeCodeForm codeParam={codeParam} partnerParam={partnerName} />
           </>
         )}
-        {!user.token && !accessCodeRequired && (
+        {!userToken && !accessCodeRequired && (
           <>
             <Typography variant="h2" component="h2">
               {t('getStarted')}

--- a/utils/hashString.ts
+++ b/utils/hashString.ts
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 
 export const hashString = (string: string) => {
-  const shasum = crypto.createHash('sha1');
+  const shasum = crypto.createHash('sha256');
   shasum.update(JSON.stringify(string));
   const hashedString = shasum.digest('hex');
   return hashedString;

--- a/utils/logEvent.ts
+++ b/utils/logEvent.ts
@@ -1,6 +1,8 @@
 import { track } from '@vercel/analytics/react';
 import { getAnalytics } from 'firebase/analytics';
 import { GetUserResponse } from '../app/api';
+import { PartnerAccesses } from '../app/partnerAccessSlice';
+import { PartnerAdmin } from '../app/partnerAdminSlice';
 import {
   joinedFeatureLiveChat,
   joinedFeatureTherapy,
@@ -19,17 +21,29 @@ export const logEvent = (event: string, params?: {}) => {
   track(event) 
 };
 
-export const getEventUserData = (data: Partial<GetUserResponse>) => {
+export const getEventUserData = (
+  userCreatedAt: Date | null,
+  partnerAccesses: PartnerAccesses,
+  partnerAdmin: PartnerAdmin,
+) => {
   return {
-    account_type: getAccountType(data.partnerAdmin, data.partnerAccesses),
-    registered_at: data.user?.createdAt,
-    partner: joinedPartners(data.partnerAccesses, data.partnerAdmin),
-    partner_live_chat: joinedFeatureLiveChat(data.partnerAccesses),
-    partner_therapy: joinedFeatureTherapy(data.partnerAccesses),
-    partner_therapy_remaining: totalTherapyRemaining(data.partnerAccesses),
-    partner_therapy_redeemed: totalTherapyRemaining(data.partnerAccesses),
-    partner_activated_at: data.partnerAccesses ? data.partnerAccesses[0]?.activatedAt : null,
+    account_type: getAccountType(partnerAdmin, partnerAccesses),
+    registered_at: userCreatedAt,
+    partner: joinedPartners(partnerAccesses, partnerAdmin),
+    partner_live_chat: joinedFeatureLiveChat(partnerAccesses),
+    partner_therapy: joinedFeatureTherapy(partnerAccesses),
+    partner_therapy_remaining: totalTherapyRemaining(partnerAccesses),
+    partner_therapy_redeemed: totalTherapyRemaining(partnerAccesses),
+    partner_activated_at: partnerAccesses ? partnerAccesses[0]?.activatedAt : null,
   };
+};
+
+export const getEventUserResponseData = (userResponse: GetUserResponse) => {
+  return getEventUserData(
+    userResponse.user.createdAt,
+    userResponse.partnerAccesses,
+    userResponse.partnerAdmin,
+  );
 };
 
 export default logEvent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,6 +2022,13 @@
   dependencies:
     webpack-bundle-analyzer "4.7.0"
 
+"@next/bundle-analyzer@^14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-14.0.4.tgz#12672238b8ee48dd7cfa253f024374690bde6991"
+  integrity sha512-Nn2PiCkFBJBlVmpSGVNItpISws0fuc9E8AkCafBz/moRv1cfASOpFBBVzSRfWLP9BPdAhfDkb6TafN0rvs2IJQ==
+  dependencies:
+    webpack-bundle-analyzer "4.7.0"
+
 "@next/env@13.4.19":
   version "13.4.19"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.19.tgz#46905b4e6f62da825b040343cbc233144e9578d3"
@@ -2104,6 +2111,11 @@
   version "1.0.0-next.24"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
   integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
+
+"@popperjs/core@^2.11.3":
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.4.tgz#d8c7b8db9226d2d7664553a0741ad7d0397ee503"
+  integrity sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg==
 
 "@popperjs/core@^2.11.8":
   version "2.11.8"
@@ -4729,6 +4741,13 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
 
 gzip-size@^6.0.0:
   version "6.0.0"
@@ -7366,6 +7385,15 @@ signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+sirv@^1.0.7:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
+  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.20"
+    mrmime "^1.0.0"
+    totalist "^1.0.0"
 
 sirv@^1.0.7:
   version "1.0.19"


### PR DESCRIPTION
### What changes did you make?
Improved redux state selectors to only select the required data, instead of the entire state. This was a poor early implementation (my bad) that is now improved by selecting the nearest sensible state property

E.g.
`const userId = useTypedSelector((state) => state.user.id);`
instead of
`const { user } = useTypedSelector((state) => state);`


Fixes warning: Selector unknown returned the root state when called. This can lead to unnecessary rerenders.
Selectors that return the entire state are almost certainly a mistake, as they will cause a rerender whenever *anything* in state changes.

### Other fixes
- Removed empty dependency arrays from `useEffect` hooks to reduce build warnings
- ⚠️ **Sets a default timezone on `next-intl`** - this is now a requirement and errors if no default is found. It seems we didn't have one set anywhere, so the previous default would have been the nextjs server location. As our backend is set to `Europe/London`, our frontend now matches and seems this was already the case, so there should be no effect here. I also don't think there are any features where users set a datetime on a form - but would confirm with @eleanorreem on this, therapy sessions may be effected?

### Why did you make the changes?
As part of wider goal to improve Bloom performance. This change will reduce rerenders and the amount of data referenced in each component.
