### PR TITLE
fix: activities test failing due to to auth rerender

### DIFF
--- a/cypress/integration/activities.cy.tsx
+++ b/cypress/integration/activities.cy.tsx
@@ -5,7 +5,11 @@ describe('A logged in user should be able to navigate to activities and do an ex
   });
 
   it('Should go to the activities page and click on an exercise', () => {
-    cy.get(`[qa-id=secondary-nav-activities-button]`, {timeout: 10000}).should('exist').click().click(); //navigate to activities - double clicking just in case
+    cy.get(`[qa-id=secondary-nav-activities-button]`, { timeout: 10000 })
+      .should('exist')
+      .click()
+      .click(); //navigate to activities - double clicking just in case
+    cy.wait(2000); // wait to ensure the page has rendered and the auth checks have resolved
     // Default timeout is 4 seconds so extended to 8 to avoid racy tests
     cy.get('h3', { timeout: 8000 }).contains('Thought diaries').should('exist').click(); //check click first  exercise exists and open it
 


### PR DESCRIPTION
### Issue link / number:
N/A

### What changes did you make?
Added a wait to ensure that auth checks are done before page content is checked 

### Why did you make the changes?
- activities cypress test was blocking deployment
