### PR TITLE
Fix github actions on push 

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -1,7 +1,7 @@
 name: Cypress release tests
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -1,7 +1,7 @@
 name: Lighthouse Performance
 
 on:
-  pull_request:
+  push:
     branches: [main]
 
 jobs:


### PR DESCRIPTION
### What changes did you make?
Sets trigger for workflows on `push` instead of `pull_request`

### Why did you make the changes?
Actions weren't being triggered consistently on `main` PRs
