### PR TITLE
Fix cypress firebase command

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -207,4 +207,4 @@ const attachCustomCommands = (Cypress, { auth }) => {
   });
 };
 
-attachCustomCommands(Cypress, firebase);
+attachCustomCommands(Cypress);


### PR DESCRIPTION
### What changes did you make?
Removed reference to undefined var, causing all tests to fail on setup

### Why did you make the changes?
Left over bug from previous commits on firebase update #747 