### PR TITLE
feat: enable rows in carousels and add options to row/column

### DIFF
--- a/components/common/Column.tsx
+++ b/components/common/Column.tsx
@@ -3,12 +3,34 @@ import { Box } from '@mui/system';
 interface ColumnProps {
   children: any;
   width?: string;
+  horizontalAlignment?: string;
 }
 
 const Column = (props: ColumnProps) => {
-  const { width, children } = props;
+  const { width, children, horizontalAlignment } = props;
 
   const columnStyles = {
+    'h3:only-child': { marginBottom: 0 },
+    ...(horizontalAlignment && {
+      textAlign:
+        horizontalAlignment === 'center'
+          ? { xs: 'center', md: 'center' }
+          : horizontalAlignment === 'right'
+          ? { xs: 'right', md: 'right' }
+          : horizontalAlignment === 'mobile-left-desktop-center'
+          ? { xs: 'left', md: 'center' }
+          : { xs: 'left', md: 'left' },
+    }),
+    ...(horizontalAlignment && {
+      justifyContent:
+        horizontalAlignment === 'center'
+          ? 'center'
+          : horizontalAlignment === 'right'
+          ? 'flex-end'
+          : horizontalAlignment === 'mobile-left-desktop-center'
+          ? { xs: 'flex-start', md: 'center' }
+          : 'flex-start',
+    }),
     width:
       width === 'extra-small'
         ? {
@@ -27,6 +49,10 @@ const Column = (props: ColumnProps) => {
         ? { xs: '100%', md: '80%' }
         : width === 'full-width'
         ? { xs: `100%`, md: '100%' }
+        : width === 'mobile-large-desktop-full'
+        ? { xs: `60%`, md: '100%' }
+        : width === 'mobile-med-desktop-full'
+        ? { xs: `40%`, md: '100%' }
         : { xs: `100%`, md: 'auto' },
     ...(!width ? { flex: { md: 1 } } : {}),
   };

--- a/components/common/Row.tsx
+++ b/components/common/Row.tsx
@@ -6,20 +6,27 @@ interface RowProps {
   numberOfColumns: number;
   horizontalAlignment: string;
   verticalAlignment: string;
+  gap?: string;
 }
 
 const Row = (props: RowProps) => {
-  const { children, horizontalAlignment, verticalAlignment, numberOfColumns } = props;
+  const { children, horizontalAlignment, verticalAlignment, numberOfColumns, gap } = props;
+  const calculatedGap =
+    gap === 'none'
+      ? 0
+      : { xs: 3, sm: 8 / numberOfColumns, md: 10 / numberOfColumns, lg: 16 / numberOfColumns };
 
   const rowStyles = {
     width: '100%',
-    gap: { xs: 3, sm: 8 / numberOfColumns, md: 10 / numberOfColumns, lg: 16 / numberOfColumns },
+    gap: calculatedGap,
     ...rowStyle,
     textAlign:
       horizontalAlignment === 'center'
         ? 'center'
         : horizontalAlignment === 'right'
         ? 'right'
+        : horizontalAlignment === 'mobile-left-desktop-center'
+        ? { xs: 'left', md: 'center' }
         : 'left',
     ...(horizontalAlignment && {
       justifyContent:
@@ -27,6 +34,8 @@ const Row = (props: RowProps) => {
           ? 'center'
           : horizontalAlignment === 'right'
           ? 'flex-end'
+          : horizontalAlignment === 'mobile-left-desktop-center'
+          ? { xs: 'flex-start', md: 'center' }
           : 'flex-start',
     }),
     ...(verticalAlignment && {

--- a/components/storyblok/StoryblokCard.tsx
+++ b/components/storyblok/StoryblokCard.tsx
@@ -34,7 +34,7 @@ const StoryblokCard = (props: StoryblokCardProps) => {
     padding: { xs: 2, sm: 1, md: 2, lg: 2 },
     '&:last-child': { paddingBottom: { xs: 2, sm: 2, md: 2, lg: 2 } },
     gap: { xs: 3, sm: 1, md: 1 },
-    '& h3': {
+    '& h3:only-child': {
       marginBottom: 0,
     },
   };

--- a/components/storyblok/StoryblokCarousel.tsx
+++ b/components/storyblok/StoryblokCarousel.tsx
@@ -5,16 +5,15 @@ import { Box } from '@mui/system';
 import NukaCarousel from 'nuka-carousel';
 import { StoryblokComponent } from 'storyblok-js-client';
 import { Component as DynamicComponent } from './DynamicComponent';
-import StoryblokCard from './StoryblokCard';
 import StoryblokImage from './StoryblokImage';
 import StoryblokQuote from './StoryblokQuote';
-import StoryblokVideo from './StoryblokVideo';
+import StoryblokRowColumnBlock from './StoryblokRowColumnBlock';
 
 const components: DynamicComponent[] = [
   { name: 'image', component: StoryblokImage },
-  { name: 'video', component: StoryblokVideo },
   { name: 'quote', component: StoryblokQuote },
-  { name: 'card', component: StoryblokCard },
+  { name: 'row_new', component: StoryblokRowColumnBlock },
+
 ];
 
 interface StoryblokCarouselProps {

--- a/components/storyblok/StoryblokRowColumnBlock.tsx
+++ b/components/storyblok/StoryblokRowColumnBlock.tsx
@@ -20,10 +20,11 @@ interface StoryblokRowColumnBlockProps {
   columns: StoryblokColumn[];
   horizontal_alignment: string;
   vertical_alignment: string;
+  gap: string;
 }
 
 const StoryblokRowColumnBlock = (props: StoryblokRowColumnBlockProps) => {
-  const { columns, horizontal_alignment, vertical_alignment } = props;
+  const { columns, horizontal_alignment, vertical_alignment, gap } = props;
 
   if (!columns) return <></>;
 
@@ -32,10 +33,11 @@ const StoryblokRowColumnBlock = (props: StoryblokRowColumnBlockProps) => {
       numberOfColumns={columns.length}
       verticalAlignment={vertical_alignment}
       horizontalAlignment={horizontal_alignment}
+      gap={gap}
     >
       {columns.map((column: any, index: number) => {
         return (
-          <Column width={column.width} key={`row_column_${index}_${Math.random() * 100}`}>
+          <Column width={column.width} horizontalAlignment={column.horizontal_alignment} key={`row_column_${index}_${Math.random() * 100}`}>
             {render(column.content, RichTextOptions)}
           </Column>
         );


### PR DESCRIPTION
### Issue link / number:
N/A part of homepage redesign. 

### What changes did you make?
- enabled columns and rows to have extra horiztonal alighments and widths to fit with new design

### Why did you make the changes?
Enable these designs
<img width="1115" alt="Screenshot 2023-12-19 at 15 49 52" src="https://github.com/chaynHQ/bloom-frontend/assets/16049515/eb01ccc1-20bf-43aa-9935-039109cad4d1">
<img width="1127" alt="Screenshot 2023-12-19 at 15 49 45" src="https://github.com/chaynHQ/bloom-frontend/assets/16049515/72748020-029e-403e-b3d1-d3374cdb1db2">

