### PR TITLE
Increase total-blocking-time

### DIFF
--- a/lighthouse_desktop_budget.json
+++ b/lighthouse_desktop_budget.json
@@ -34,7 +34,7 @@
       },
       {
         "metric": "total-blocking-time",
-        "budget": 800
+        "budget": 1500
       },
       {
         "metric": "speed-index",


### PR DESCRIPTION
### What changes did you make?
Increase lighthouse `total-blocking-time` budget value as it was quite low at 800ms and sometimes failing on CI
