### PR TITLE
Swap lighthouse jobs order

### DIFF
--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -21,35 +21,6 @@ jobs:
           max_timeout: 1000
           check_interval: 5
 
-  lighthouse-mobile:
-    runs-on: ubuntu-latest
-    needs: wait-for-vercel-deployment
-    steps:
-      - uses: actions/checkout@v3
-      - name: Audit URLs using Lighthouse
-        uses: treosh/lighthouse-ci-action@v10
-        env:
-          USER_EMAIL: ${{ secrets.USER_EMAIL }}
-          USER_PASSWORD: ${{ secrets.USER_PASSWORD }}
-        with:
-          urls: |
-            https://bloom-frontend-git-develop-chaynhq.vercel.app
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/activities
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/chat
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/grounding
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/subscription/whatsapp
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/therapy/book-session
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/image-based-abuse-and-rebuilding-ourselves
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/dating-boundaries-and-relationships
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/recovering-from-toxic-and-abusive-relationships
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/image-based-abuse-and-rebuilding-ourselves/the-social-context-of-image-based-abuse-and-victim-blaming
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/dating-boundaries-and-relationships/emotional-boundaries
-            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/recovering-from-toxic-and-abusive-relationships/introduction-and-what-you-should-know
-          budgetPath: ./lighthouse_budget.json # test performance budgets
-          uploadArtifacts: true # save results as an action artifacts
-          configPath: '.github/configs/lighthouse-rc.yml' # set lighthouse config
-
   lighthouse-desktop:
     runs-on: ubuntu-latest
     needs: wait-for-vercel-deployment
@@ -78,4 +49,33 @@ jobs:
           budgetPath: ./lighthouse_desktop_budget.json # test performance budgets
           uploadArtifacts: true # save results as an action artifacts
           configPath: '.github/configs/lighthouse-desktop-rc.yml' # set lighthouse config
+
+  lighthouse-mobile:
+    runs-on: ubuntu-latest
+    needs: wait-for-vercel-deployment
+    steps:
+      - uses: actions/checkout@v3
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v10
+        env:
+          USER_EMAIL: ${{ secrets.USER_EMAIL }}
+          USER_PASSWORD: ${{ secrets.USER_PASSWORD }}
+        with:
+          urls: |
+            https://bloom-frontend-git-develop-chaynhq.vercel.app
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/activities
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/chat
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/grounding
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/subscription/whatsapp
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/therapy/book-session
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/image-based-abuse-and-rebuilding-ourselves
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/dating-boundaries-and-relationships
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/recovering-from-toxic-and-abusive-relationships
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/image-based-abuse-and-rebuilding-ourselves/the-social-context-of-image-based-abuse-and-victim-blaming
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/dating-boundaries-and-relationships/emotional-boundaries
+            https://bloom-frontend-git-develop-chaynhq.vercel.app/courses/recovering-from-toxic-and-abusive-relationships/introduction-and-what-you-should-know
+          budgetPath: ./lighthouse_budget.json # test performance budgets
+          uploadArtifacts: true # save results as an action artifacts
+          configPath: '.github/configs/lighthouse-rc.yml' # set lighthouse config
 


### PR DESCRIPTION
### What changes did you make?
Lighthouse CI action is uploading artifacts for mobile only, presumably because only one set of artifacts can be uploaded (or a dir name clash) and the mobile job was run first. As desktop is the primary indicator, swapping artifacts to use desktop instead of mobile.