### PR TITLE
Theme cards

### DIFF
--- a/components/common/Row.tsx
+++ b/components/common/Row.tsx
@@ -14,7 +14,9 @@ const Row = (props: RowProps) => {
   const calculatedGap =
     gap === 'none'
       ? 0
-      : { xs: 3, sm: 8 / numberOfColumns, md: 10 / numberOfColumns, lg: 16 / numberOfColumns };
+      : gap === 'mobile-small-desktop-default'
+        ? { xs: 2, sm: 8 / numberOfColumns, md: 10 / numberOfColumns, lg: 16 / numberOfColumns }
+        : { xs: 3, sm: 8 / numberOfColumns, md: 10 / numberOfColumns, lg: 16 / numberOfColumns };
 
   const rowStyles = {
     width: '100%',
@@ -24,27 +26,27 @@ const Row = (props: RowProps) => {
       horizontalAlignment === 'center'
         ? 'center'
         : horizontalAlignment === 'right'
-        ? 'right'
-        : horizontalAlignment === 'mobile-left-desktop-center'
-        ? { xs: 'left', md: 'center' }
-        : 'left',
+          ? 'right'
+          : horizontalAlignment === 'mobile-left-desktop-center'
+            ? { xs: 'left', md: 'center' }
+            : 'left',
     ...(horizontalAlignment && {
       justifyContent:
         horizontalAlignment === 'center'
           ? 'center'
           : horizontalAlignment === 'right'
-          ? 'flex-end'
-          : horizontalAlignment === 'mobile-left-desktop-center'
-          ? { xs: 'flex-start', md: 'center' }
-          : 'flex-start',
+            ? 'flex-end'
+            : horizontalAlignment === 'mobile-left-desktop-center'
+              ? { xs: 'flex-start', md: 'center' }
+              : 'flex-start',
     }),
     ...(verticalAlignment && {
       alignItems:
         verticalAlignment === 'center'
           ? 'center'
           : verticalAlignment === 'bottom'
-          ? 'flex-end'
-          : 'flex-start',
+            ? 'flex-end'
+            : 'flex-start',
     }),
     ...richtextContentStyle,
   } as const;

--- a/components/storyblok/StoryblokCard.tsx
+++ b/components/storyblok/StoryblokCard.tsx
@@ -2,6 +2,7 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Card, CardActions, CardContent, Collapse, IconButton, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { ISbRichtext, storyblokEditable } from '@storyblok/react';
+import { useTranslations } from 'next-intl';
 import Image from 'next/legacy/image';
 import { useState } from 'react';
 import { render } from 'storyblok-rich-text-react-renderer';
@@ -57,6 +58,8 @@ const StoryblokCard = (props: StoryblokCardProps) => {
     dropdown_button = false,
     dropdown_content,
   } = props;
+
+  const t = useTranslations('Courses');
 
   const handleExpandClick = () => {
     setExpanded(!expanded);
@@ -115,7 +118,7 @@ const StoryblokCard = (props: StoryblokCardProps) => {
           <CardActions sx={cardActionsStyle}>
             <IconButton
               sx={{ marginLeft: 'auto' }}
-              // aria-label={`${t('expandSummary')}`}
+              aria-label={`${t('expandSummary')}`}
               onClick={handleExpandClick}
               size="small"
             >

--- a/components/storyblok/StoryblokCard.tsx
+++ b/components/storyblok/StoryblokCard.tsx
@@ -1,7 +1,9 @@
-import { Card, CardContent } from '@mui/material';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { Card, CardActions, CardContent, Collapse, IconButton, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { ISbRichtext, storyblokEditable } from '@storyblok/react';
 import Image from 'next/legacy/image';
+import { useState } from 'react';
 import { render } from 'storyblok-rich-text-react-renderer';
 import { RichTextOptions } from '../../utils/richText';
 
@@ -13,9 +15,37 @@ interface StoryblokCardProps {
   alignment: string;
   background: string;
   style: string;
+  dropdown_button?: boolean;
+  dropdown_content?: ISbRichtext;
 }
 
+const cardActionsStyle = {
+  position: 'absolute',
+  right: 1,
+  bottom: 0,
+} as const;
+
+const slimImageStyle = {
+  width: { xs: 80, sm: 80, md: 80 },
+  height: { xs: 80, sm: 80, md: 80 },
+  minWidth: { xs: 80, sm: 80, md: 80 },
+  minHeight: { xs: 80, sm: 80, md: 80 },
+};
+const defaultStyle = {
+  width: { xs: 80, md: 100 },
+  height: { xs: 80, md: 100 },
+  minWidth: { xs: 80, md: 100 },
+  minHeight: { xs: 80, md: 100 },
+};
+
+const cardStyle = {
+  '&:first-of-type': {
+    marginTop: 0,
+  },
+};
+
 const StoryblokCard = (props: StoryblokCardProps) => {
+  const [expanded, setExpanded] = useState<boolean>(false);
   const {
     _uid,
     _editable,
@@ -24,18 +54,21 @@ const StoryblokCard = (props: StoryblokCardProps) => {
     alignment = 'left',
     background = 'common.white',
     style = 'default',
+    dropdown_button = false,
+    dropdown_content,
   } = props;
 
-  if (!image || !image.filename) return <></>;
+  const handleExpandClick = () => {
+    setExpanded(!expanded);
+  };
 
-  const cardStyle = {
-    '&:first-of-type': {
-      marginTop: 0,
-    },
+  const arrowStyle = {
+    transform: expanded ? 'rotate(180deg)' : 'none',
   } as const;
 
   const slimPadding = {
-    padding: { xs: 2, sm: 1, md: 2, lg: 2 },
+    padding: { xs: 2, sm: 2, md: 2, lg: 2 },
+    ...(dropdown_button ? { paddingRight: { xs: 2, sm: 2, md: 4, lg: 2 } } : {}),
     '&:last-child': { paddingBottom: { xs: 2, sm: 2, md: 2, lg: 2 } },
     gap: { xs: 3, sm: 1, md: 1 },
     '& h3:only-child': {
@@ -44,6 +77,7 @@ const StoryblokCard = (props: StoryblokCardProps) => {
   };
 
   const cardContentStyle = {
+    ...(style == 'slim' ? slimPadding : {}),
     display: 'flex',
     flexDirection:
       alignment === 'right' ? 'row-reverse' : alignment === 'center' ? 'column' : 'row',
@@ -51,19 +85,18 @@ const StoryblokCard = (props: StoryblokCardProps) => {
     textAlign: alignment === 'right' ? 'right' : alignment === 'center' ? 'center' : 'left',
     gap: 3,
     backgroundColor: background,
-    ...(style == 'slim' ? slimPadding : {}),
-  } as const;
-  const slimImageStyle = {
-    width: { xs: 80, sm: 80, md: 80 },
-    height: { xs: 80, sm: 80, md: 80 },
-    minWidth: { xs: 80, sm: 80, md: 80 },
-    minHeight: { xs: 80, sm: 80, md: 80 },
-  };
-  const imageContainerStyle = {
     position: 'relative',
-    width: { xs: 80, md: 100 },
-    height: { xs: 80, md: 100 },
-    ...(style == 'slim' ? slimImageStyle : {}),
+  } as const;
+
+  const imageContainerStyle = {
+    ...(style == 'slim' ? slimImageStyle : defaultStyle),
+    position: 'relative',
+  } as const;
+
+  const collapseContentStyle = {
+    backgroundColor: background,
+    textAlign: alignment === 'right' ? 'right' : alignment === 'center' ? 'center' : 'left',
+    ...(style == 'slim' ? slimPadding : {}),
   } as const;
 
   return (
@@ -78,7 +111,26 @@ const StoryblokCard = (props: StoryblokCardProps) => {
           </Box>
         )}
         <Box maxWidth={700}>{render(content, RichTextOptions)}</Box>
+        {dropdown_button && (
+          <CardActions sx={cardActionsStyle}>
+            <IconButton
+              sx={{ marginLeft: 'auto' }}
+              // aria-label={`${t('expandSummary')}`}
+              onClick={handleExpandClick}
+              size="small"
+            >
+              <KeyboardArrowDownIcon sx={arrowStyle} color="error" />
+            </IconButton>
+          </CardActions>
+        )}
       </CardContent>
+      {dropdown_button && (
+        <Collapse in={expanded} timeout="auto" unmountOnExit>
+          <CardContent sx={collapseContentStyle}>
+            <Typography>{render(dropdown_content, RichTextOptions)}</Typography>
+          </CardContent>
+        </Collapse>
+      )}
     </Card>
   );
 };

--- a/components/storyblok/StoryblokCarousel.tsx
+++ b/components/storyblok/StoryblokCarousel.tsx
@@ -4,6 +4,7 @@ import { IconButton, useMediaQuery, useTheme } from '@mui/material';
 import { Box } from '@mui/system';
 import { SbBlokData, storyblokEditable } from '@storyblok/react';
 import NukaCarousel from 'nuka-carousel';
+import { columnStyle } from '../../styles/common';
 import { Component as DynamicComponent } from './DynamicComponent';
 import StoryblokImage from './StoryblokImage';
 import StoryblokQuote from './StoryblokQuote';
@@ -20,6 +21,8 @@ interface StoryblokCarouselProps {
   _editable: string;
   items: Array<SbBlokData>;
   theme: 'primary' | 'secondary';
+  number_desktop_slides?: number;
+  number_mobile_slides?: number;
 }
 const PreviousButton = ({ onClick }: { onClick: () => void }) => {
   return (
@@ -67,11 +70,22 @@ const NextButton = ({ onClick }: { onClick: () => void }) => {
   );
 };
 const StoryblokCarousel = (props: StoryblokCarouselProps) => {
-  const { _uid, _editable, items, theme = 'primary' } = props;
+  const {
+    _uid,
+    _editable,
+    items,
+    theme = 'primary',
+    number_mobile_slides,
+    number_desktop_slides,
+  } = props;
 
   const siteTheme = useTheme();
 
   const isMobileScreen = useMediaQuery(siteTheme.breakpoints.down('md'));
+  const mobileSlidesToShow = number_mobile_slides || 1;
+  const desktopSlidesToShow = number_desktop_slides || 1;
+  const slidesToShow = isMobileScreen ? mobileSlidesToShow : desktopSlidesToShow;
+  const hideControls = items.length <= slidesToShow;
 
   return (
     <Box {...storyblokEditable({ _uid, _editable, items, theme })}>
@@ -84,6 +98,8 @@ const StoryblokCarousel = (props: StoryblokCarouselProps) => {
           },
           pagingDotsContainerClassName: 'paging-dots-container',
         }}
+        slidesToShow={isMobileScreen ? mobileSlidesToShow : desktopSlidesToShow}
+        withoutControls={hideControls}
         renderCenterLeftControls={
           isMobileScreen
             ? () => {
@@ -104,7 +120,7 @@ const StoryblokCarousel = (props: StoryblokCarouselProps) => {
           if (component) {
             const Component = component.component;
             return (
-              <Box sx={{}} key={index}>
+              <Box sx={columnStyle} key={index}>
                 <Component {...item} key={index} />
               </Box>
             );


### PR DESCRIPTION
### Issue link / number:
N/A

### What changes did you make?
- Enabled dropdown option on cards
- When carousel slides = slides to show. The carousel disappears

<img width="1047" alt="Screenshot 2023-12-27 at 11 19 11" src="https://github.com/chaynHQ/bloom-frontend/assets/16049515/116f6b6f-9903-41f3-aac4-67a9afd64809">
<img width="1051" alt="Screenshot 2023-12-27 at 11 19 01" src="https://github.com/chaynHQ/bloom-frontend/assets/16049515/2d9748c8-2e56-4461-92f6-8a2dc0a6bd62">


### Why did you make the changes?
- enable new desktop designs
