### PR TITLE
Fix Github workflow triggers

### DIFF
--- a/.github/workflows/build-and-test-prs.yml
+++ b/.github/workflows/build-and-test-prs.yml
@@ -3,6 +3,8 @@ name: Build & test # on both PRs and push to develop/main
 on:
   pull_request:
     branches: [develop, main]
+  push:
+    branches: [develop]
 
 jobs:
   build-and-test:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,8 @@
 name: 'CodeQL'
 
 on:
+  pull_request:
+    branches: [develop, main]
   push:
     branches: [develop, main]
   schedule:

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -3,6 +3,8 @@ name: Cypress release tests
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [develop]
 
 jobs:
   # vercel will redeploy the develop/staging app on creating a PR to main

--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -3,6 +3,8 @@ name: Lighthouse Performance
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [develop]
 
 jobs:
   # vercel will deploy a preview branch and domain for this PR


### PR DESCRIPTION
### What changes did you make?
Fixed the workflow triggers (e.g.` on: push: branches: [develop]`) so that actions are also run on `push` and not just `pull_request`. The `push` to `develop` trigger is required for the first commit from `develop` -> `main` 

### Why did you make the changes?
The following actions weren't being run on the initial commit on `develop` -> `main` PRs:
- cypress release tests
- build and test

See #797 for example of the first commit actions not including `cypress release tests` and `build and test` on the initial commit. From the second commit, those actions were run.