### PR TITLE
Replace delete cypress users function

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,16 +1,15 @@
 // index.js
 const customCommands = require('./commands.js');
 
-before(() => {
+after(() => {
   //Delete all cypress test users before cypress test suite runs
-  // cy.visit('/');
-  // cy.logInWithEmailAndPassword(
-  //   Cypress.env('super_admin_email'),
-  //   Cypress.env('super_admin_password'),
-  // );
-  // cy.deleteCypressAccessCodes();
-  // cy.deleteAllCypressUsers();
-  // cy.logout();
+  cy.logInWithEmailAndPassword(
+    Cypress.env('super_admin_email'),
+    Cypress.env('super_admin_password'),
+  );
+  cy.deleteCypressAccessCodes();
+  cy.deleteAllCypressUsers();
+  cy.logout();
 });
 
 module.exports = {


### PR DESCRIPTION
### What changes did you make?
Replaces and fixes function to delete cypress users after cypress tests run

### Why did you make the changes?
This was previously removed due to errors and too many cypress users existing in the db - they have now been cleared out and this function should safely run

