### PR TITLE
Fix CI triggers

### DIFF
--- a/.github/workflows/build-and-test-prs.yml
+++ b/.github/workflows/build-and-test-prs.yml
@@ -2,7 +2,7 @@ name: Build & test # on both PRs and push to develop/main
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop]
   push:
     branches: [develop]
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: 'CodeQL'
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop]
   push:
     branches: [develop, main]
   schedule:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -2,8 +2,7 @@ name: Create release PR
 
 on:
   push:
-    branches:
-      - develop
+    branches: [develop]
 
 jobs:
   create-pr-to-main:

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -1,8 +1,6 @@
 name: Cypress release tests
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [develop]
 

--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -1,8 +1,6 @@
 name: Lighthouse Performance
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [develop]
 


### PR DESCRIPTION
### What changes did you make?
Removed CI triggers for `pull_request` on `main` branch

### Why did you make the changes?
CI actions were being run twice on develop -> main PRs, due to `push` on `develop` and `pull_request` on `main` being concurrent