### PR TITLE
Run cypress before all only once

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       return require('./cypress/config/plugins')(on, config);
     },
-    specPattern: 'cypress/integration/**/*.cy.{js,jsx,ts,tsx}',
+    specPattern: [
+      './cypress/integration/_beforeAll.cy.tsx',
+      'cypress/integration/**/*.cy.{js,jsx,ts,tsx}',
+    ],
     baseUrl: 'http://localhost:3000',
     supportFile: 'cypress/support/index.js',
   },

--- a/cypress/integration/_beforeAll.cy.tsx
+++ b/cypress/integration/_beforeAll.cy.tsx
@@ -1,0 +1,16 @@
+describe('_beforeAll', () => {
+  before(() => {
+    cy.logInWithEmailAndPassword(
+      Cypress.env('super_admin_email'),
+      Cypress.env('super_admin_password'),
+    );
+    cy.deleteCypressAccessCodes();
+    cy.deleteAllCypressUsers();
+    cy.logout();
+  });
+
+  // Note: It is important to have at least one test to trigger the before block
+  it('completes before all function', () => {
+    cy.log('Before all function completed');
+  });
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,17 +1,6 @@
 // index.js
 const customCommands = require('./commands.js');
 
-after(() => {
-  //Delete all cypress test users before cypress test suite runs
-  cy.logInWithEmailAndPassword(
-    Cypress.env('super_admin_email'),
-    Cypress.env('super_admin_password'),
-  );
-  cy.deleteCypressAccessCodes();
-  cy.deleteAllCypressUsers();
-  cy.logout();
-});
-
 module.exports = {
   commands: customCommands,
 };


### PR DESCRIPTION
### What changes did you make?
Created a new test suite `_beforeAll` to run the _before all_ function that deletes cypress test users.
The _before_ functionality was previously stored in `/cypress/support/index` and ran before/after every test suite, so 16 times. We just want this cleanup function to run once, instead of for each test suite.

### Why did you make the changes?
To speed up tests and prevent 429 Too Many Requests errors, if we call this iterative cleanup function 16 times