### PR TITLE
Redirect unauthenticated user to partner register page

### DIFF
--- a/components/banner/SignUpBanner.tsx
+++ b/components/banner/SignUpBanner.tsx
@@ -1,5 +1,6 @@
 import { Button, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
 import { STORYBLOK_COLORS } from '../../constants/enums';
 import { SIGN_UP_TODAY_BANNER_BUTTON_CLICKED } from '../../constants/events';
 import { useTypedSelector } from '../../hooks/store';
@@ -17,6 +18,15 @@ export const SignUpBanner = ({}: SignUpBannerProps) => {
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
+  const [registerPath, setRegisterPath] = useState('/auth/register');
+
+  useEffect(() => {
+    const referralPartner = window.localStorage.getItem('referralPartner');
+
+    if (referralPartner) {
+      setRegisterPath(`/auth/register?partner=${referralPartner}`);
+    }
+  }, []);
 
   return (
     <PageSection color={STORYBLOK_COLORS.BLOOM_GRADIENT} alignment="center">
@@ -37,7 +47,7 @@ export const SignUpBanner = ({}: SignUpBannerProps) => {
             component={Link}
             variant="contained"
             color="secondary"
-            href={'/auth/register'}
+            href={registerPath}
             onClick={() => {
               logEvent(SIGN_UP_TODAY_BANNER_BUTTON_CLICKED, eventUserData);
             }}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -107,6 +107,21 @@ function MyApp(props: MyAppProps) {
     return <AuthGuard>{children || component}</AuthGuard>;
   };
 
+  useEffect(() => {
+    // Check if entry path is from a partner referral and if so, store referring partner in local storage
+    // This enables us to redirect a user to the correct sign up page later (e.g. in SignUpBanner)
+    const path = router.asPath;
+
+    if (path?.includes('/welcome/')) {
+      const referralPartner = path.split('/')[2]; // Gets "bumble" from /welcome/bumble
+
+      if (referralPartner) {
+        window.localStorage.setItem('referralPartner', referralPartner);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <ErrorBoundary>
       <NextIntlClientProvider
@@ -148,6 +163,7 @@ function AppReduxWrapper({ Component, ...rest }: MyAppProps) {
         (window as any).store = store;
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,7 @@ import type { NextPage } from 'next';
 import { GetStaticPropsContext } from 'next';
 import { useTranslations } from 'next-intl';
 import Head from 'next/head';
+import { useEffect, useState } from 'react';
 import { render } from 'storyblok-rich-text-react-renderer';
 import Link from '../components/common/Link';
 import NoDataAvailable from '../components/common/NoDataAvailable';
@@ -38,6 +39,13 @@ const rowItem = {
   height: '100%',
 } as const;
 
+const headerProps = {
+  partnerLogoSrc: welcomeToBloom,
+  partnerLogoAlt: 'alt.welcomeToBloom',
+  imageSrc: illustrationBloomHeadYellow,
+  imageAlt: 'alt.bloomHead',
+};
+
 interface Props {
   story: ISbStoryData | null;
   preview: boolean;
@@ -53,13 +61,15 @@ const Index: NextPage<Props> = ({ story, preview }) => {
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
+  const [registerPath, setRegisterPath] = useState('/auth/register');
 
-  const headerProps = {
-    partnerLogoSrc: welcomeToBloom,
-    partnerLogoAlt: 'alt.welcomeToBloom',
-    imageSrc: illustrationBloomHeadYellow,
-    imageAlt: 'alt.bloomHead',
-  };
+  useEffect(() => {
+    const referralPartner = window.localStorage.getItem('referralPartner');
+
+    if (referralPartner) {
+      setRegisterPath(`/auth/register?partner=${referralPartner}`);
+    }
+  }, []);
 
   if (!story) {
     return <NoDataAvailable />;
@@ -116,7 +126,7 @@ const Index: NextPage<Props> = ({ story, preview }) => {
                   onClick={() => {
                     logEvent(PROMO_GET_STARTED_CLICKED, eventUserData);
                   }}
-                  href="/auth/register"
+                  href={registerPath}
                 >
                   {t('getStarted')}
                 </Button>


### PR DESCRIPTION
### What changes did you make?
Added functionality to store the referring partner for a user, to handle the case of a user entering via a promo url `/welcome/bumble` but then exploring the app and possibly signing up as a public user by navigating to `/register` instead of `/register?partner=bumble`. 

The `partnerReferral` value is stored in local storage so it's persisted, i.e. a user can leave the site and return later and we'll still know they originally reached Bloom via a partner referral link. This local storage is then read and applied to register urls