### PR TITLE
Fix New Relic file path

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -35,6 +35,7 @@ exports.config = {
      * production applications.
      */
     level: 'info',
+    filepath: '/tmp',
   },
   application_logging: {
     forwarding: {


### PR DESCRIPTION
### What changes did you make?
Updates default location of New Relic log file path to `/tmp` instead of `/var/task` which is read-only on vercel build

### Why did you make the changes?
The default file path was causing the error below
```
New Relic failed to open log file /var/task/newrelic_agent.log
[Error: EROFS: read-only file system, open '/var/task/newrelic_agent.log'] {
  errno: -30,
  code: 'EROFS',
  syscall: 'open',
  path: '/var/task/newrelic_agent.log'
}
```