### PR TITLE
Fix simplybook user_id custom field

### DIFF
--- a/config/simplybook.ts
+++ b/config/simplybook.ts
@@ -1,11 +1,5 @@
 import { User } from '../app/userSlice';
 
-// Simplybook hardcodes additional field IDs
-const userIdFieldId =
-  process.env.NEXT_PUBLIC_ENV === 'production'
-    ? '86a541b6d059de75eaba4e18a288cd24'
-    : 'b3b2455c79e69e6baf6e8c1fcf34b691';
-
 export const getSimplybookWidgetConfig = (user?: User) => {
   return {
     widget_type: 'iframe',
@@ -40,7 +34,7 @@ export const getSimplybookWidgetConfig = (user?: User) => {
             email: user.email,
           },
           fields: {
-            [userIdFieldId]: user.id,
+            data_field_1: user.id,
           },
         },
       }),


### PR DESCRIPTION
### What changes did you make?
Renamed the simplybook custom field for user ID, as it's now named `data_field_1` on both environments. Presumably simplybook made a change here or we were using a different id for this simplybook [intake form field](https://help.simplybook.me/index.php/Intake_Forms_custom_feature)

### Why did you make the changes?
The field name was disconnected on zapier due to renamed field, meaning the `client_id` (now `user_id`) zapier -> backend webhook was not being populated

<img width="675" alt="Screenshot 2024-01-16 at 17 45 36" src="https://github.com/chaynHQ/bloom-frontend/assets/11525717/b7d494a7-dfe0-42cf-9b0c-b0dc257817b4">
<img width="304" alt="Screenshot 2024-01-16 at 17 45 25" src="https://github.com/chaynHQ/bloom-frontend/assets/11525717/3921865b-0f30-4843-8ab4-ff27d690c443">
