### PR TITLE
Fix header CTA position

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -40,11 +40,6 @@ const headerContainerStyle = {
   },
 };
 
-const ctaContainerStyle = {
-  ...columnStyle,
-  width: { xs: '100%', sm: 'auto' },
-} as const;
-
 const imageContainerStyle = {
   position: 'relative',
   width: { xs: 190, lg: 200 },
@@ -131,11 +126,11 @@ const Header = (props: HeaderProps) => {
           )}
         </Box>
         {progressStatus && <ProgressStatus status={progressStatus} />}
+        {cta && <Box mt={4}>{cta}</Box>}
       </Box>
       <Box sx={imageContainerStyle}>
         <Image alt={imageAltText} src={imageSrc} layout="fill" objectFit="contain" />
       </Box>
-      {cta && <Box sx={ctaContainerStyle}>{cta}</Box>}
     </Container>
   );
 };


### PR DESCRIPTION
### What changes did you make?
Fixed position of cta in header - the cta container is now within the left text container, instead of in the root of the row flex

### Why did you make the changes?
Recent changes moved the "start a chat" button on the chat page to be on the right instead of below the text - see screenshots

Before:
<img width="1180" alt="Screenshot 2024-02-16 at 10 41 32" src="https://github.com/chaynHQ/bloom-frontend/assets/11525717/9b22f24b-434c-408a-9a70-84261097d1ab">

After:
<img width="1071" alt="Screenshot 2024-02-16 at 10 42 19" src="https://github.com/chaynHQ/bloom-frontend/assets/11525717/e3d8ff8b-044f-4343-ada4-b316e5ca0665">
