### PR TITLE
Remove more about bloom link from partner register page

### DIFF
--- a/messages/auth/de.json
+++ b/messages/auth/de.json
@@ -13,7 +13,6 @@
     "register": {
       "title": "Konto anlegen",
       "loginRedirect": "Du hast bereits ein Konto? <loginLink>Login</loginLink>",
-      "moreInfo": "Mehr dazu <welcomeLink>wie Bloom funktioniert</welcomeLink>.",
       "partnershipsTitle": "Unsere Partnerschaften",
       "partnershipsDescription": "Wenn du über eine unserer Partnerorganisationen zu Bloom gekommen bist, klicke unten auf deren Logo. "
     },

--- a/messages/auth/en.json
+++ b/messages/auth/en.json
@@ -13,7 +13,6 @@
     "register": {
       "title": "Create account",
       "loginRedirect": "Already have an account? <loginLink>Log in</loginLink>",
-      "moreInfo": "More on <welcomeLink>how Bloom works</welcomeLink>.",
       "partnershipsTitle": "Our partnerships",
       "partnershipsDescription": "If you're coming to Bloom from one of our partners, click their logo below."
     },

--- a/messages/auth/es.json
+++ b/messages/auth/es.json
@@ -13,7 +13,6 @@
     "register": {
       "title": "Crea una cuenta",
       "loginRedirect": "¿Ya tienes una cuenta? <loginLink>Inicia sesión</loginLink>",
-      "moreInfo": "Más sobre <welcomeLink>cómo funciona Bloom</welcomeLink>.",
       "partnershipsTitle": "Nuestros socios",
       "partnershipsDescription": "Si fuiste referido a Bloom por parte de uno de nuestros socios, haz click en su logo a continuación."
     },

--- a/messages/auth/fr.json
+++ b/messages/auth/fr.json
@@ -13,7 +13,6 @@
     "register": {
       "title": "Créer un compte",
       "loginRedirect": "Vous avez déjà un compte ? <loginLink>Connectez-vous</loginLink>",
-      "moreInfo": "En savoir plus <welcomeLink>sur le fonctionnement de Bloom </welcomeLink>.",
       "partnershipsTitle": "Nos partenaires",
       "partnershipsDescription": "Si vous avez découvert Bloom par l'un de nos partenaires, cliquez sur son logo ci-dessous."
     },

--- a/messages/auth/hi.json
+++ b/messages/auth/hi.json
@@ -13,7 +13,6 @@
     "register": {
       "title": "Account banaiye",
       "loginRedirect": "Aapke paas pehle se he account hai? <loginLink>Log in</loginLink>",
-      "moreInfo": "Aur jaankari hai <welcomeLink>Bloom kese kaam karta hai</welcomeLink>.",
       "partnershipsTitle": "Hamari partnerships",
       "partnershipsDescription": "Agar aap Bloom par hamare kisi partner se aa rahe hain, toh unke logo kar click kariye. "
     },

--- a/messages/auth/pt.json
+++ b/messages/auth/pt.json
@@ -13,7 +13,6 @@
     "register": {
       "title": "Criar uma conta",
       "loginRedirect": "Já tem uma conta? <loginLink>Log in</loginLink>",
-      "moreInfo": "Mais sobre <welcomeLink>como funciona o Bloom</welcomeLink>.",
       "partnershipsTitle": "Nossas parcerias",
       "partnershipsDescription": "Se você chegou no Bloom por meio de uma de nossas parcerias, clique no logotipo abaixo."
     },

--- a/pages/auth/register.tsx
+++ b/pages/auth/register.tsx
@@ -109,22 +109,7 @@ const Register: NextPage = () => {
         <Box sx={imageContainerStyle}>
           <Image alt={tS('alt.leafMixDots')} src={illustrationLeafMixDots} layout="fill" />
         </Box>
-        {partnerContent ? (
-          // Show only the partner's welcome page link
-          <Typography mt="2rem !important">
-            {t.rich('register.moreInfo', {
-              welcomeLink: (children) => (
-                <Link
-                  href={`/welcome/${partnerContent.name.toLowerCase()}${
-                    codeParam && '?code=' + codeParam
-                  }`}
-                >
-                  {children}
-                </Link>
-              ),
-            })}
-          </Typography>
-        ) : (
+        {!partnerContent && (
           // Show the public bloom and all other partner's welcome page links
           <>
             <Card sx={publicCardStyle}>


### PR DESCRIPTION
### What changes did you make?
Removed "More about how bloom works" link from the partner register pages

### Why did you make the changes?
When we first designed Bloom we had access codes and more need to include this link. Now it's not as required so we're moving it for a more focussed flow