### PR TITLE
feat: improved demographics gender sheets data

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -2,7 +2,7 @@ name: Cypress release tests
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, dependabot/**]
 
 jobs:
   # vercel will redeploy the develop/staging app on creating a PR to main

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - 'run-cypress-tests/**'
-      - 'dependabot/**'
   workflow_dispatch:
 
 jobs:

--- a/components/forms/AboutYouDemographicForm.tsx
+++ b/components/forms/AboutYouDemographicForm.tsx
@@ -98,6 +98,10 @@ const AboutYouDemographicForm = () => {
         genderOptionsSelected.push(matchedGenderOption.englishLabel);
       } else {
         genderFreeText.push(input.toLowerCase());
+
+        if (!genderOptionsSelected.includes('other')) {
+          genderOptionsSelected.push('other');
+        }
       }
     });
 

--- a/components/forms/AboutYouDemographicForm.tsx
+++ b/components/forms/AboutYouDemographicForm.tsx
@@ -24,6 +24,7 @@ import {
   ABOUT_YOU_DEMO_REQUEST,
   ABOUT_YOU_DEMO_SUCCESS,
 } from '../../constants/events';
+import { genderOptions } from '../../constants/gender';
 import { useTypedSelector } from '../../hooks/store';
 import { rowStyle, staticFieldLabelStyle } from '../../styles/common';
 import { hashString } from '../../utils/hashString';
@@ -51,6 +52,7 @@ const AboutYouDemographicForm = () => {
   const [eventUserData, setEventUserData] = useState<any>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [genderInput, setGenderInput] = useState<Array<string>>([]);
+  const [genderTextInput, setGenderTextInput] = useState<string>('');
   const [neurodivergentInput, setNeurodivergentInput] = useState<string>('');
   const [raceEthnNatn, setRaceEthnNatn] = useState<string>('');
   const [countryInput, setCountryInput] = useState<string>('');
@@ -84,6 +86,21 @@ const AboutYouDemographicForm = () => {
 
     logEvent(ABOUT_YOU_DEMO_REQUEST, eventUserData);
 
+    const genderOptionsSelected: string[] = [];
+    const genderFreeText: string[] = [];
+
+    genderInput.forEach((input) => {
+      const matchedGenderOption = genderOptions.find(
+        (option) => t(`genderOptions.${option.translationLabel}`) === input,
+      );
+
+      if (matchedGenderOption) {
+        genderOptionsSelected.push(matchedGenderOption.englishLabel);
+      } else {
+        genderFreeText.push(input.toLowerCase());
+      }
+    });
+
     const formData = {
       date: new Date().toISOString(),
       user_id: userId && hashString(userId),
@@ -92,10 +109,13 @@ const AboutYouDemographicForm = () => {
         .map((gender) => gender.toLowerCase())
         .sort()
         .join(','),
+      gender_options: genderOptionsSelected.sort().join(','),
+      gender_free_text: genderFreeText.sort().join(','),
       neurodivergent: neurodivergentInput,
       race_ethn_natn: raceEthnNatn,
       current_country: countryInput,
       age: ageInput,
+      language: router.locale as LANGUAGES,
       ...eventUserData, // add user data
     };
 
@@ -129,8 +149,6 @@ const AboutYouDemographicForm = () => {
     }
   };
 
-  const genderOptions = t('genderOptions').split(';');
-
   return (
     <Box mt={3}>
       <form autoComplete="off" onSubmit={submitHandler}>
@@ -138,9 +156,21 @@ const AboutYouDemographicForm = () => {
           id="gender"
           multiple
           value={genderInput}
-          options={genderOptions.map((option) => option)}
+          inputValue={genderTextInput}
+          options={genderOptions.map((option) => t(`genderOptions.${option.translationLabel}`))}
           freeSolo
-          onChange={(e, value) => setGenderInput(value)}
+          onChange={(e, value) => {
+            setGenderInput(value);
+          }}
+          onInputChange={(e, value) => {
+            setGenderTextInput(value);
+          }}
+          onBlur={(e) => {
+            if (genderTextInput) {
+              setGenderInput([...genderInput, genderTextInput]);
+              setGenderTextInput('');
+            }
+          }}
           renderTags={(value: readonly string[]) =>
             value.map((option: string, index: number) => (
               <Chip

--- a/components/forms/RegisterForm.tsx
+++ b/components/forms/RegisterForm.tsx
@@ -135,7 +135,7 @@ const RegisterForm = (props: RegisterFormProps) => {
         if (token) {
           await dispatch(setUserToken(token));
           setLoading(false);
-          router.push('/courses');
+          return userResponse.data.user;
         }
       } catch (err) {
         setFormError(
@@ -198,10 +198,13 @@ const RegisterForm = (props: RegisterFormProps) => {
     try {
       partnerName && accessCodeRequired && (await validateAccessCode());
       dispatch(setUserLoading(true));
-      await createUserRecord();
+      const user = await createUserRecord();
       dispatch(setUserLoading(false));
       setLoading(false);
-      await router.push('/account/about-you');
+
+      if (user) {
+        await router.push('/account/about-you');
+      }
     } catch (error) {
       // errors handled in each function
       dispatch(setUserLoading(false));

--- a/constants/gender.ts
+++ b/constants/gender.ts
@@ -1,0 +1,38 @@
+export const genderOptions = [
+  {
+    englishLabel: 'woman',
+    translationLabel: 'woman',
+  },
+  {
+    englishLabel: 'man',
+    translationLabel: 'man',
+  },
+  {
+    englishLabel: 'non binary',
+    translationLabel: 'nonBinary',
+  },
+  {
+    englishLabel: 'transgender',
+    translationLabel: 'transgender',
+  },
+  {
+    englishLabel: 'intersex',
+    translationLabel: 'intersex',
+  },
+  {
+    englishLabel: 'two-spirit',
+    translationLabel: 'twoSpirit',
+  },
+  {
+    englishLabel: 'gender non conforming',
+    translationLabel: 'genderNonConforming',
+  },
+  {
+    englishLabel: 'other',
+    translationLabel: 'other',
+  },
+  {
+    englishLabel: 'prefer not to answer',
+    translationLabel: 'preferNotToAnswer',
+  },
+];

--- a/messages/account/de.json
+++ b/messages/account/de.json
@@ -38,7 +38,17 @@
       "demographicForm": {
         "genderLabel": "Bitte wähle die Kategorie(n) aus, die deine Geschlechtsidentität widerspiegelt oder widerspiegeln. Du kannst auch mehrere Antworten auswählen.",
         "genderHelpText": "Wir fragen das, um besser zu verstehen, wie sich Nutzer*innen geschlechtlich identifizieren, mit dem Ziel Angebote anzubieten, die inklusiver sind und Nutzer*innen mehr in ihrem Geschlecht bekräftigen. Du kannst auch „Das möchte ich nicht sagen” als Antwort auswählen.",
-        "genderOptions": "Frau;Mann;Nicht-binär;Transgender;Intersex;Two-spirit;Geschlechtlich non-konform;Anderes (bitte gib hier den Namen an);Das möchte ich nicht sagen",
+        "genderOptions": {
+          "woman": "Frau",
+          "man": "Mann",
+          "nonBinary": "Nicht-binär",
+          "transgender": "Transgender",
+          "intersex": "Intersex",
+          "twoSpirit": "Two-spirit",
+          "genderNonConforming": "Geschlechtlich non-konform",
+          "other": "Anderes (bitte gib hier den Namen an)",
+          "preferNotToAnswer": "Das möchte ich nicht sagen"
+        },
         "neurodivergentLabel": "Würdest Du Dich selbst als neurodivergent bezeichnen?",
         "neurodivergentHelpText": "Wir gestalten unser Angebot inklusiv. Deshalb ist es hilfreich, wenn wir Feedback von neurodivergenten Menschen erhalten. ",
         "neurodivergentLabels": {

--- a/messages/account/en.json
+++ b/messages/account/en.json
@@ -38,7 +38,17 @@
       "demographicForm": {
         "genderLabel": "Please select one or more options that reflect your gender identity",
         "genderHelpText": "We are asking this to better understand how our users identify, with a view to designing even more inclusive and gender-affirming resources. You can select 'Prefer not to answer'.",
-        "genderOptions": "Woman;Man;Non Binary;Transgender;Intersex;Two-spirit;Gender non conforming;Other (please state);Prefer not to answer",
+        "genderOptions": {
+          "woman": "Woman",
+          "man": "Man",
+          "nonBinary": "Non Binary",
+          "transgender": "Transgender",
+          "intersex": "Intersex",
+          "twoSpirit": "Two-spirit",
+          "genderNonConforming": "Gender non conforming",
+          "other": "Other (please state)",
+          "preferNotToAnswer": "Prefer not to answer"
+        },
         "neurodivergentLabel": "Would you describe yourself as neurodivergent?",
         "neurodivergentHelpText": "We design our services to be inclusive, so it’s helpful for us to hear feedback from people who are neurodivergent",
         "neurodivergentLabels": {

--- a/messages/account/es.json
+++ b/messages/account/es.json
@@ -38,7 +38,17 @@
       "demographicForm": {
         "genderLabel": "Por favor elige una o más opciones que reflejen tu identidad de género",
         "genderHelpText": "Hacemos esta pregunta para entender mejor cómo se identifican nuestres usuaries, con la perspectiva de diseñar recursos aún más inclusivos y con perspectiva de género. Puedes elegir la opción 'Prefiero no responder'.",
-        "genderOptions": "Mujer;Hombre;Género no binario;Transgénero;Intersexual;Dos espíritus;Género no conforme;Otro (por favor, explícalo);Prefiero no responder",
+        "genderOptions": {
+          "woman": "Mujer",
+          "man": "Hombre",
+          "nonBinary": "Género no binario",
+          "transgender": "Transgénero",
+          "intersex": "Intersexual",
+          "twoSpirit": "Dos espíritus",
+          "genderNonConforming": "Género no conforme",
+          "other": "Otro (por favor, explícalo)",
+          "preferNotToAnswer": "Prefiero no responder"
+        },
         "neurodivergentLabel": "¿Te identificas como neurodivergente?",
         "neurodivergentHelpText": "Diseñamos nuestros servicios para ser inclusivos, así que escuchar los comentarios de personas neurodivergentes nos ayuda.",
         "neurodivergentLabels": {

--- a/messages/account/fr.json
+++ b/messages/account/fr.json
@@ -38,7 +38,17 @@
       "demographicForm": {
         "genderLabel": "Veuillez sélectionner une ou plusieurs options qui reflètent votre identité de genre",
         "genderHelpText": "Nous posons cette question pour mieux comprendre comment nos utilisateurs s'identifient en vue de concevoir des ressources encore plus inclusives et respectueuses. Vous pouvez sélectionner 'Préfére ne pas répondre'.",
-        "genderOptions": "Femme;Homme;Non-binaire;Transgenre;Intersexe;Bispirituel(le);Non-conformité au genre;Autre (à préciser);Préfère ne pas répondre",
+        "genderOptions": {
+          "woman": "Femme",
+          "man": "Homme",
+          "nonBinary": "Non-binaire",
+          "transgender": "Transgenre",
+          "intersex": "Intersexe",
+          "twoSpirit": "Bispirituel(le)",
+          "genderNonConforming": "Non-conformité au genre",
+          "other": "Autre (à préciser)",
+          "preferNotToAnswer": "Préfère ne pas répondre"
+        },
         "neurodivergentLabel": "Vous décririez-vous comme une personne neuro-divergente ?",
         "neurodivergentHelpText": "Nos services sont conçus en accord avec la notion d'inclusivité, nous encourageons donc vivement les personnes neurodivergentes à laisser leurs commentaires.",
         "neurodivergentLabels": {

--- a/messages/account/hi.json
+++ b/messages/account/hi.json
@@ -38,7 +38,17 @@
       "demographicForm": {
         "genderLabel": "Kripya ek ya ek se adhik option chuniye jis bhi ling se aap pehchaan karte hain.",
         "genderHelpText": "Hum yeh aap se pooch rahe hain taki hum behtar samjh sakein ki humare user kis ling se pehchaan karte hain, taki hum zada sahit aur ling-pushti jankaari wale sansadhan bana sakein. Aap “Batana pasand nahi karte” option bhi chun sakte hain.",
-        "genderOptions": "Mahila;Purush;Gaer Avidhari (Non Binary);Kinnar;Intersex;Do-bhawan;Anya (kripya darshaiye);Likhiye;Batana pasand nahi karte",
+        "genderOptions": {
+          "woman": "Mahila",
+          "man": "Purush",
+          "nonBinary": "Gaer Avidhari (Non Binary)",
+          "transgender": "Kinnar",
+          "intersex": "Intersex",
+          "twoSpirit": "Do-bhawan",
+          "genderNonConforming": "Non-conformité au genre",
+          "other": "Autre (à préciser)",
+          "preferNotToAnswer": "Batana pasand nahi karte"
+        },
         "neurodivergentLabel": "Kya aap apne aapko neuro-divergent ke roop mein describe karenge?",
         "neurodivergentHelpText": "Hum apni sevaon ko ese design karte hai ko vo sabke liye inclusive ho. Toh humare liye bahut helpful hota hai jab humein neurodivergent logon se feedback milti hai.",
         "neurodivergentLabels": {

--- a/messages/account/pt.json
+++ b/messages/account/pt.json
@@ -38,7 +38,17 @@
       "demographicForm": {
         "genderLabel": "Por favor, selecione uma ou mais opções que reflitam sua identidade de gênero",
         "genderHelpText": "Estamos fazendo essa pergunta para entender melhor como nossos usuários se identificam, com o objetivo de projetar recursos ainda mais inclusivos e afirmativos em relação ao gênero. Você pode selecionar 'Prefiro não responder'.",
-        "genderOptions": "Mulher;Homem;Não-binário;Transgênero;Intersexo;Dois-espíritos ou espíritos duplos;Não conformidade de gênero;Outro (por favor, especifique);Prefiro não responder",
+        "genderOptions": {
+          "woman": "Mulher",
+          "man": "Homem",
+          "nonBinary": "Não-binário",
+          "transgender": "Transgênero",
+          "intersex": "Intersexo",
+          "twoSpirit": "Dois-espíritos ou espíritos duplos",
+          "genderNonConforming": "Não conformidade de gênero",
+          "other": "Outro (por favor, especifique)",
+          "preferNotToAnswer": "Prefiro não responder"
+        },
         "neurodivergentLabel": "Você se identifica como uma pessoa neurodivergente?",
         "neurodivergentHelpText": "Construímos nossos serviços para que sejam inclusivos. Então, receber avaliações e comentários de pessoas neurodivergentes nos ajuda. ",
         "neurodivergentLabels": {


### PR DESCRIPTION
### What changes did you make?
Responses from the demographics `/account/about-you` form are sent to google sheets. Users can select predefined options for gender, and/or use free text. The existing `gender` column is sent to google sheets as unserialised/unprocessed, which is valuable and will remain unchanged, but we're also adding new columns here for easier data processing.

This PR adds two new columns, `gender_options` and `gender_free_text`, so we have:
- selected options + free text (raw input) in users language, the existing `gender` field
- selected options only (no free text) in english, new `gender_options` field
- free text input in users language, new `gender_free_text`

### Why did you make the changes?
To make gender data processing easier, e.g. by translating and formatting selected gender options, vs having to filter in multiple languages, or filter out selected options from free text etc