### PR TITLE
feat: redirect about our courses to courses page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -51,6 +51,11 @@ module.exports = withBundleAnalyzer(
           destination: '/courses',
           permanent: false,
         },
+        {
+          source: '/about-our-courses',
+          destination: '/courses',
+          permanent: false,
+        },
       ];
     },
     async rewrites() {


### PR DESCRIPTION
### Issue link / number:
n/a

### What changes did you make?
we are retiring our about-our-courses page so have added the redirect 

### Why did you make the changes?
To ensure that users don't land on a 404

### Did you run tests?
Yes


