### PR TITLE
Fix: Language Menu should disappear when a user selects a language

### DIFF
--- a/components/layout/LanguageMenu.tsx
+++ b/components/layout/LanguageMenu.tsx
@@ -98,6 +98,7 @@ export default function LanguageMenu() {
                   locale={language}
                   onClick={() => {
                     logEvent(generateLanguageMenuEvent(language), eventUserData);
+                    handleClose()
                   }}
                 >
                   {languageLabel}


### PR DESCRIPTION
### Issue : https://github.com/chaynHQ/bloom-frontend/issues/910

### What changes did you make?
Made Language Menu should disappear when a user selects a language