### PR TITLE
Haydnba: Update partner admin authguard

### DIFF
--- a/app/partnerAdminSlice.tsx
+++ b/app/partnerAdminSlice.tsx
@@ -4,6 +4,7 @@ import { api, GetUserResponse } from './api';
 
 export interface PartnerAdmin {
   id: string | null;
+  active: boolean | null;
   createdAt: Date | null;
   updatedAt: Date | null;
   partner: PartnerContent | null;
@@ -11,6 +12,7 @@ export interface PartnerAdmin {
 
 const initialState: PartnerAdmin = {
   id: null,
+  active: null,
   createdAt: null,
   updatedAt: null,
   partner: null,

--- a/guards/partnerAdminGuard.tsx
+++ b/guards/partnerAdminGuard.tsx
@@ -1,7 +1,7 @@
 import { Container, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import Head from 'next/head';
-import Image from "next/image";
+import Image from 'next/image';
 import { useTranslations } from 'use-intl';
 import Link from '../components/common/Link';
 import { useTypedSelector } from '../hooks/store';
@@ -22,11 +22,12 @@ const imageContainerStyle = {
 
 export function PartnerAdminGuard({ children }: { children: JSX.Element }) {
   const partnerAdminId = useTypedSelector((state) => state.partnerAdmin.id);
+  const partnerAdminIsActive = useTypedSelector((state) => state.partnerAdmin.active);
 
   const t = useTranslations('PartnerAdmin.accessGuard');
   const tS = useTranslations('Shared');
 
-  if (!partnerAdminId) {
+  if (!partnerAdminId || !partnerAdminIsActive) {
     return (
       <Container sx={containerStyle}>
         <Head>{t('title')}</Head>
@@ -34,11 +35,9 @@ export function PartnerAdminGuard({ children }: { children: JSX.Element }) {
           <Image
             alt={tS('alt.personTea')}
             src={illustrationPerson4Peach}
-            fill
-            sizes="100vw"
-            style={{
-              objectFit: "contain"
-            }} />
+            layout="fill"
+            objectFit="contain"
+          />
         </Box>
         <Typography variant="h2" component="h2" mb={2}>
           {t('title')}

--- a/guards/partnerAdminGuard.tsx
+++ b/guards/partnerAdminGuard.tsx
@@ -35,8 +35,11 @@ export function PartnerAdminGuard({ children }: { children: JSX.Element }) {
           <Image
             alt={tS('alt.personTea')}
             src={illustrationPerson4Peach}
-            layout="fill"
-            objectFit="contain"
+            fill
+            sizes="100vw"
+            style={{
+              objectFit: 'contain',
+            }}
           />
         </Box>
         <Typography variant="h2" component="h2" mb={2}>


### PR DESCRIPTION
### Issue link / number:

Relates #917

### What changes did you make?

- Update the `PartnerAdmin` interface and initial store state to represent the `active` property
- Update the `partnerAdminGuard` to reject where `active` status is not `true`

### Why did you make the changes?

- The changes are necessary for satisfying requirements in issue #917 
- The store state and type system must be able to represent the new `active` property
- The auth guard must be able to check against this property

### Did you run tests?

- Unit tests are all passing
- Cypress e2e has numerous failing tests locally mainly due do unavailable environment variables from what I can see...

<!---IMPORTANT NOTE ABOUT RUNNING TESTS: ->
- Some tests may require multiple runs before success.
- Some test failures may not be due to your contribution and can be ignored.
- If tests fail without resolution, please let us know here.
- Directions for running tests are in the README.md 

<!--- PR CHECKLIST: PLEASE REMOVE BEFORE SUBMITTING —>
Before submitting, check that you have completed the following tasks:
- [x] Answered the questions above.
- [x] Read Chayn's Contributing Guidelines in the CONTRIBUTING.md file.
- [x] Enabled "Allow edits and access to secrets by maintainers" on this PR.
- [x] If applicable, include images in the description.
After submitting, please be available for discussion. Thank you!
