### PR TITLE
fix: change url for bloom_social_preview

### DIFF
--- a/components/head/OpenGraphMetadata.tsx
+++ b/components/head/OpenGraphMetadata.tsx
@@ -6,7 +6,7 @@ const descriptionContent =
   'Join us on your healing journey. Bloom is here for you to learn, heal and grow towards a confident future. It is bought to you by Chayn, a global non-profit, run by survivors and allies from around the world.';
 const twitterDescriptionContent =
   'Join us on your healing journey. Bloom is here for you to learn, heal and grow towards a confident future. It is bought to you by Chayn, a global non-profit, run by survivors and allies from around the world.';
-const imageContent = `${BASE_URL}/bloom_socials_preview.png`;
+const imageContent = `${BASE_URL}/public/bloom_socials_preview.png`;
 const imageAltContent =
   'An cartoon drawing of a person with almost shoulder length hair against a pink background. They have flowers and leaves coming out of their head. The word "Bloom" hovers above the person.';
 


### PR DESCRIPTION
### Issue link / number:
N/A

### What changes did you make?
 I updated the url of the image url in the OpenGraphMetadata 

### Why did you make the changes?
The url for the open graph image was incorrect so the social preview was broken. 
<img width="238" alt="Screenshot 2024-06-04 at 19 21 03" src="https://github.com/chaynHQ/bloom-frontend/assets/16049515/670c4ec0-64a0-42cc-bfa4-c829ea017b76">

