### PR TITLE
Fix cypress CI missing public_name

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -69,6 +69,7 @@ jobs:
           CYPRESS_super_admin_password: ${{secrets.CYPRESS_SUPER_ADMIN_PASSWORD}}
           CYPRESS_public_email: ${{secrets.CYPRESS_PUBLIC_EMAIL}}
           CYPRESS_public_password: ${{secrets.CYPRESS_PUBLIC_PASSWORD}}
+          CYPRESS_public_name: ${{secrets.CYPRESS_PUBLIC_NAME}}
           CYPRESS_api_url: ${{secrets.CYPRESS_BLOOM_BACKEND_API_URL}}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -91,6 +91,7 @@ jobs:
           CYPRESS_super_admin_password: ${{secrets.CYPRESS_SUPER_ADMIN_PASSWORD}}
           CYPRESS_public_email: ${{secrets.CYPRESS_PUBLIC_EMAIL}}
           CYPRESS_public_password: ${{secrets.CYPRESS_PUBLIC_PASSWORD}}
+          CYPRESS_public_name: ${{secrets.CYPRESS_PUBLIC_NAME}}
           CYPRESS_api_url: ${{secrets.CYPRESS_BLOOM_BACKEND_API_URL}}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What changes did you make?
Added new `public_name` cypress variables to CI, added in #900 