### PR TITLE
Fix nav links colours

### DIFF
--- a/components/layout/NavigationDrawer.tsx
+++ b/components/layout/NavigationDrawer.tsx
@@ -12,13 +12,6 @@ import logEvent, { getEventUserData } from '../../utils/logEvent';
 import PrimaryNavigationDrawerLinks from './PrimaryNavigationDrawerLinks';
 import SecondaryNavigationDrawerLinks from './SecondaryNavigationDrawerLinks';
 
-const logoContainerStyle = {
-  position: 'relative',
-  width: 120,
-  height: 60,
-  marginLeft: 2,
-} as const;
-
 const buttonStyle = {
   color: 'common.white',
   ':hover': { backgroundColor: 'background.default', color: 'primary.dark' },
@@ -39,7 +32,6 @@ const NavigationDrawer = () => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const t = useTranslations('Navigation');
-  const tS = useTranslations('Shared');
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
@@ -79,7 +71,7 @@ const NavigationDrawer = () => {
       <Drawer
         hideBackdrop={false}
         PaperProps={{
-          sx: { backgroundColor: 'primary.dark', color: 'common.white', top: { xs: 48, sm: 64 } },
+          sx: { backgroundColor: 'primary.dark', top: { xs: 48, sm: 64 } },
         }}
         sx={{ width: '100%', top: { xs: 48, sm: 64 } }}
         anchor="top"

--- a/components/layout/PrimaryNavigationDrawerLinks.tsx
+++ b/components/layout/PrimaryNavigationDrawerLinks.tsx
@@ -27,6 +27,7 @@ const listItemStyle = {
   mb: 0,
   ml: 1,
   mr: 1,
+  color: 'common.white',
 } as const;
 
 const listItemTextStyle = {
@@ -38,7 +39,6 @@ const listItemTextStyle = {
 
 const listButtonStyle = {
   borderRadius: 20,
-  color: 'common.white',
   fontFamily: 'Monterrat, sans-serif',
   paddingY: 0.25,
 
@@ -49,6 +49,12 @@ const listButtonStyle = {
   ':hover': {
     color: 'primary.dark',
   },
+} as const;
+
+const loginButtonStyle = {
+  width: 'auto',
+  ml: 2,
+  mt: 1,
 } as const;
 
 interface NavigationItem {
@@ -132,7 +138,7 @@ const PrimaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
           <Button
             variant="contained"
             size="large"
-            sx={{ width: 'auto', ml: 2, mt: 1 }}
+            sx={loginButtonStyle}
             component={Link}
             href="/auth/login"
             onClick={() => {


### PR DESCRIPTION
### What changes did you make?
Fixed nav bar colours being set to white due to new change in `globals.css` `color: inherit !important`

Before:
<img width="871" alt="Screenshot 2024-06-17 at 09 53 07" src="https://github.com/chaynHQ/bloom-frontend/assets/11525717/1797e84f-501a-4240-8d45-61bc11120045">

After: 
<img width="557" alt="Screenshot 2024-06-25 at 09 50 11" src="https://github.com/chaynHQ/bloom-frontend/assets/11525717/bcb8af05-00e9-4c71-9ab5-aa6c7f92edf8">
