### PR TITLE
Fix auth tests: refactor userToken -> userId

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -2,7 +2,7 @@ name: Cypress release tests
 
 on:
   push:
-    branches: [develop, dependabot/**]
+    branches: [develop, fix-auth-tests, dependabot/**]
 
 jobs:
   # vercel will redeploy the develop/staging app on creating a PR to main

--- a/components/layout/PrimaryNavigationDrawerLinks.tsx
+++ b/components/layout/PrimaryNavigationDrawerLinks.tsx
@@ -47,7 +47,7 @@ const listButtonStyle = {
     opacity: 0.2,
   },
   ':hover': {
-    color: 'primary.dark',
+    backgroundColor: 'unset !important',
   },
 } as const;
 
@@ -55,6 +55,7 @@ const loginButtonStyle = {
   width: 'auto',
   ml: 2,
   mt: 1,
+  color: 'text.main !important',
 } as const;
 
 interface NavigationItem {
@@ -73,7 +74,7 @@ const PrimaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
   const t = useTranslations('Navigation');
 
   const userLoading = useTypedSelector((state) => state.user.loading);
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
@@ -85,11 +86,7 @@ const PrimaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
   useEffect(() => {
     let links: Array<NavigationItem> = [];
 
-    if (!userLoading) {
-      if (userToken && router.pathname === '/auth/login') {
-        router.push('/courses');
-      }
-
+    if (!userLoading && userId) {
       if (partnerAdmin && partnerAdmin.partner) {
         links.push({
           title: t('admin'),
@@ -116,7 +113,7 @@ const PrimaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
 
     setNavigationLinks(links);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [t, userToken, userLoading, partnerAccesses, partnerAdmin]);
+  }, [t, userId, userLoading, partnerAccesses, partnerAdmin]);
 
   return (
     <List sx={listStyle} onClick={() => setAnchorEl && setAnchorEl(null)}>
@@ -133,7 +130,7 @@ const PrimaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
           </ListItemButton>
         </ListItem>
       ))}
-      {!userLoading && !userToken && (
+      {!userLoading && !userId && (
         <li>
           <Button
             variant="contained"

--- a/components/layout/SecondaryNavigationDrawerLinks.tsx
+++ b/components/layout/SecondaryNavigationDrawerLinks.tsx
@@ -77,7 +77,7 @@ const SecondaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
 
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
   const userLoading = useTypedSelector((state) => state.user.loading);
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
@@ -118,26 +118,24 @@ const SecondaryNavigationDrawerLinks = (props: NavigationMenuProps) => {
       },
     ];
 
-    if (!userLoading) {
-      if (userToken) {
-        const therapyAccess = partnerAccesses.find(
-          (partnerAccess) => partnerAccess.featureTherapy === true,
-        );
+    if (!userLoading && userId) {
+      const therapyAccess = partnerAccesses.find(
+        (partnerAccess) => partnerAccess.featureTherapy === true,
+      );
 
-        if (!!therapyAccess) {
-          links.push({
-            label: t('therapy'),
-            href: '/therapy/book-session',
-            event: DRAWER_THERAPY_CLICKED,
-            icon: <SecondaryNavIcon src={therapyIcon} alt={t('alt.therapyIcon')} />,
-          });
-        }
+      if (!!therapyAccess) {
+        links.push({
+          label: t('therapy'),
+          href: '/therapy/book-session',
+          event: DRAWER_THERAPY_CLICKED,
+          icon: <SecondaryNavIcon src={therapyIcon} alt={t('alt.therapyIcon')} />,
+        });
       }
     }
 
     setNavigationLinks(links);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [t, userLoading, userToken, partnerAccesses, partnerAdmin]);
+  }, [t, userLoading, userId, partnerAccesses, partnerAdmin]);
 
   return (
     <List sx={listStyle} onClick={() => setAnchorEl && setAnchorEl(null)}>

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -43,7 +43,7 @@ const TopBar = () => {
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
   const [welcomeUrl, setWelcomeUrl] = useState<string>('/');
 
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
@@ -83,9 +83,9 @@ const TopBar = () => {
           </Link>
           <Box sx={{ ...rowStyle, alignItems: 'center', alignContent: 'center' }}>
             {!isSmallScreen && <NavigationMenu />}
-            {userToken && <UserMenu />}
+            {userId && <UserMenu />}
             <LanguageMenu />
-            {!isSmallScreen && !userToken && (
+            {!isSmallScreen && !userId && (
               <Button
                 variant="contained"
                 size="medium"

--- a/components/storyblok/StoryblokPage.tsx
+++ b/components/storyblok/StoryblokPage.tsx
@@ -19,7 +19,7 @@ export interface StoryblokPageProps {
 const StoryblokPage = (props: StoryblokPageProps) => {
   const { _uid, _editable, title, description, header_image, page_sections } = props;
 
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
   const router = useRouter();
 
   const headerProps = {
@@ -43,8 +43,8 @@ const StoryblokPage = (props: StoryblokPageProps) => {
           imageSrc={headerProps.imageSrc}
           translatedImageAlt={headerProps.translatedImageAlt}
         />
-        {!userToken && isPartiallyPublicPage && <SignUpBanner />}
-        {userToken &&
+        {!userId && isPartiallyPublicPage && <SignUpBanner />}
+        {userId &&
           page_sections?.length > 0 &&
           page_sections.map((section: StoryblokPageSectionProps, index: number) => (
             <StoryblokPageSection key={`page_section_${index}`} {...section} />

--- a/components/storyblok/StoryblokWelcomePage.tsx
+++ b/components/storyblok/StoryblokWelcomePage.tsx
@@ -102,7 +102,7 @@ const StoryblokWelcomePage = (props: StoryblokWelcomePageProps) => {
 const CallToActionCard = ({ partnerName }: { partnerName: string }) => {
   const router = useRouter();
 
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
@@ -130,7 +130,7 @@ const CallToActionCard = ({ partnerName }: { partnerName: string }) => {
   return (
     <Card sx={rowItem}>
       <CardContent>
-        {userToken && (
+        {userId && (
           <>
             <Typography variant="h2" component="h2">
               {t('continueCourses')}
@@ -151,7 +151,7 @@ const CallToActionCard = ({ partnerName }: { partnerName: string }) => {
             </Button>
           </>
         )}
-        {!userToken && accessCodeRequired && (
+        {!userId && accessCodeRequired && (
           <>
             <Typography variant="h2" component="h2">
               {t('getStarted')}
@@ -160,7 +160,7 @@ const CallToActionCard = ({ partnerName }: { partnerName: string }) => {
             <WelcomeCodeForm codeParam={codeParam} partnerParam={partnerName} />
           </>
         )}
-        {!userToken && !accessCodeRequired && (
+        {!userId && !accessCodeRequired && (
           <>
             <Typography variant="h2" component="h2">
               {t('getStarted')}

--- a/cypress/integration/user-account-settings.cy.tsx
+++ b/cypress/integration/user-account-settings.cy.tsx
@@ -31,6 +31,7 @@ describe('User account settings page', () => {
     cy.get('input[name="email-reminders-settings"]').eq(1).should('be.checked');
     cy.get('input[name="email-reminders-settings"]').eq(3).check();
     cy.get('button[type="submit"]').contains('Save email reminders').click();
+    cy.wait(3000);
   });
 
   after(() => {

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -26,7 +26,7 @@ const imageContainerStyle = {
 
 const Custom404: NextPage = () => {
   const t = useTranslations('Shared');
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
   const userLoading = useTypedSelector((state) => state.user.loading);
 
   if (userLoading) {
@@ -45,16 +45,16 @@ const Custom404: NextPage = () => {
         {t('404.title')}
       </Typography>
       <Typography>
-        {userToken ? t('404.authenticatedDescription') : t('404.unauthenticatedDescription')}
+        {userId ? t('404.authenticatedDescription') : t('404.unauthenticatedDescription')}
       </Typography>
       <Button
         sx={{ mt: 3 }}
         variant="contained"
         color="secondary"
         component={Link}
-        href={userToken ? '/courses' : '/login'}
+        href={userId ? '/courses' : '/login'}
       >
-        {userToken ? t('404.authenticatedRedirectButton') : t('404.unauthenticatedRedirectButton')}
+        {userId ? t('404.authenticatedRedirectButton') : t('404.unauthenticatedRedirectButton')}
       </Button>
     </Container>
   );

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -12,7 +12,7 @@ import { columnStyle } from '../styles/common';
 
 const Custom500: NextPage = () => {
   const t = useTranslations('Shared');
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
   const userLoading = useTypedSelector((state) => state.user.loading);
 
   const containerStyle = {
@@ -50,9 +50,9 @@ const Custom500: NextPage = () => {
         variant="contained"
         color="secondary"
         component={Link}
-        href={userToken ? '/courses' : '/login'}
+        href={userId ? '/courses' : '/login'}
       >
-        {userToken ? t('500.authenticatedRedirectButton') : t('500.unauthenticatedRedirectButton')}
+        {userId ? t('500.authenticatedRedirectButton') : t('500.unauthenticatedRedirectButton')}
       </Button>
     </Container>
   );

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -60,7 +60,7 @@ const Login: NextPage = () => {
   const router = useRouter();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
@@ -77,19 +77,19 @@ const Login: NextPage = () => {
 
   useEffect(() => {
     // Redirect if the user is on the login page but is already logged in and their data has been retrieved from the backend
-    if (!userToken) return;
+    if (!userId) return;
     // Checking if the query type is a string to keep typescript happy
     // because a query value can be an array
     const returnUrl = typeof router.query.return_url === 'string' ? router.query.return_url : null;
 
-    if (!!partnerAdmin?.id) {
+    if (partnerAdmin?.id) {
       router.push('/partner-admin/create-access-code');
     } else if (!!returnUrl) {
       router.push(returnUrl);
     } else {
       router.push('/courses');
     }
-  }, [userToken, partnerAdmin?.id, router]);
+  }, [userId, partnerAdmin?.id, router]);
 
   const ExtraContent = () => {
     return (

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -22,7 +22,7 @@ const Chat: NextPage<Props> = ({ story }) => {
   const t = useTranslations('Courses');
 
   const userEmail = useTypedSelector((state) => state.user.email);
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
@@ -46,7 +46,7 @@ const Chat: NextPage<Props> = ({ story }) => {
         <Header
           {...headerProps}
           cta={
-            userToken && (
+            userId && (
               <CrispButton
                 email={userEmail}
                 eventData={eventUserData}
@@ -55,7 +55,7 @@ const Chat: NextPage<Props> = ({ story }) => {
             )
           }
         />
-        {userToken ? (
+        {userId ? (
           story.content.page_sections?.length > 0 &&
           story.content.page_sections.map((section: any, index: number) => (
             <StoryblokPageSection key={`page_section_${index}`} {...section} />

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -42,7 +42,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
   const [showEmailRemindersBanner, setShowEmailRemindersBanner] = useState<boolean>(false);
 
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
   const userEmailRemindersFrequency = useTypedSelector(
     (state) => state.user.emailRemindersFrequency,
   );
@@ -126,7 +126,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
     }
   }, [partnerAccesses, partnerAdmin, stories, courses]);
   // Show sign up banner if user is logged out
-  if (!userToken) {
+  if (!userId) {
     return (
       <Box>
         <Head>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,7 +24,6 @@ const Index: NextPage<Props> = ({ story, preview }) => {
 
   const t = useTranslations('Welcome');
 
-  const userToken = useTypedSelector((state) => state.user.token);
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
@@ -64,7 +63,7 @@ const Index: NextPage<Props> = ({ story, preview }) => {
             onClick={() => {
               logEvent(PROMO_GET_STARTED_CLICKED, eventUserData);
             }}
-            href="/auth/register"
+            href={registerPath}
             size="large"
           >
             {t('getStarted')}

--- a/pages/subscription/whatsapp.tsx
+++ b/pages/subscription/whatsapp.tsx
@@ -62,7 +62,7 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story }) => {
   const [hasActiveWhatsappSub, setHasActiveWhatsappSub] = useState<boolean>(false);
 
   const userActiveSubscriptions = useTypedSelector((state) => state.user.activeSubscriptions);
-  const userToken = useTypedSelector((state) => state.user.token);
+  const userId = useTypedSelector((state) => state.user.id);
 
   useEffect(() => {
     setHasActiveWhatsappSub(hasWhatsappSubscription(userActiveSubscriptions));
@@ -84,8 +84,8 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story }) => {
       <Head>{story.content.title}</Head>
       <Box>
         <Header {...headerProps} />
-        {!userToken && <SignUpBanner />}
-        {userToken && (
+        {!userId && <SignUpBanner />}
+        {userId && (
           <Container sx={containerStyle}>
             <Box sx={infoBoxStyle}>
               <ImageTextColumn items={steps} translations="Whatsapp.steps" />
@@ -95,7 +95,7 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story }) => {
             </Box>
           </Container>
         )}
-        {userToken &&
+        {userId &&
           story.content.page_sections?.length > 0 &&
           story.content.page_sections.map((section: any, index: number) => (
             <StoryblokPageSection key={`page_section_${index}`} {...section} />


### PR DESCRIPTION
### What changes did you make?
Refactor use of userToken state to userId. The user `id` is set after the user database record is set in state, but listening to `userToken` will create a race condition becuse there is a delay between token being set (login) and retrieving the user profile. Fixes partner admin redirect test

### Why did you make the changes?
