### PR TITLE
Set dependabot blocking to high severity only

### DIFF
--- a/.github/workflows/dependabot-pr-review.yml
+++ b/.github/workflows/dependabot-pr-review.yml
@@ -19,4 +19,4 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           # fails when moderate vulnerabilities are deteched
-          fail-on-severity: moderate
+          fail-on-severity: high


### PR DESCRIPTION
### What changes did you make?
Updated the dependabot vulnerability blocking setting from `moderate` to `high` 

### Why did you make the changes?
All builds were failing due to required updates. Once we've updated our deps we could update the severity setting back to `moderate`