### PR TITLE
Fix user settings tests

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -2,7 +2,7 @@ name: Cypress release tests
 
 on:
   push:
-    branches: [develop, dependabot/**]
+    branches: [develop, dependabot/**, '*test*']
 
 jobs:
   # vercel will redeploy the develop/staging app on creating a PR to main

--- a/cypress/integration/user-account-settings.cy.tsx
+++ b/cypress/integration/user-account-settings.cy.tsx
@@ -11,7 +11,6 @@ describe('User account settings page', () => {
     cy.visit('/account/settings');
     cy.get('#email').should('have.value', publicEmail);
     cy.get('#name').should('have.value', publicName);
-    cy.wait(3000);
   });
 
   it('Should have marketing and service email checkbox fields and submit button', () => {
@@ -19,17 +18,20 @@ describe('User account settings page', () => {
     cy.get('input[name="contactPermission"]').check();
     cy.get('input[name="serviceEmailsPermission"]').check();
     cy.get('button[type="submit"]').contains('Save email preferences').click();
-    cy.wait(3000);
-    cy.get('input[name="contactPermission"]').eq(1).should('be.checked');
-    cy.get('input[name="serviceEmailsPermission"]').eq(1).should('be.checked');
+    cy.wait(2000);
+    cy.get('input[name="contactPermission"]').should('be.checked');
+    cy.get('input[name="serviceEmailsPermission"]').should('be.checked');
   });
 
   it('Should have email reminder frequency form and load user data', () => {
     cy.visit('/account/settings');
     cy.get('input[name="email-reminders-settings"]').eq(1).check();
     cy.get('button[type="submit"]').contains('Save email reminders').click();
-    cy.wait(3000);
+    cy.wait(2000);
     cy.get('input[name="email-reminders-settings"]').eq(1).should('be.checked');
+    // Reset the value to 'never' so the test works on next run
+    cy.get('input[name="email-reminders-settings"]').eq(3).check();
+    cy.get('button[type="submit"]').contains('Save email reminders').click();
   });
 
   after(() => {

--- a/cypress/integration/user-account-settings.cy.tsx
+++ b/cypress/integration/user-account-settings.cy.tsx
@@ -32,6 +32,7 @@ describe('User account settings page', () => {
     // Reset the value to 'never' so the test works on next run
     cy.get('input[name="email-reminders-settings"]').eq(3).check();
     cy.get('button[type="submit"]').contains('Save email reminders').click();
+    cy.wait(2000);
   });
 
   after(() => {


### PR DESCRIPTION
### What changes did you make?
Fixes account settings test `Should have email reminder frequency form and load user data`
Resets the email frequency setting to `never` so that the submit button is not disabled next time the test runs

### Did you run tests?
Yes