### PR TITLE
Ensure page title is set on all bloom pages.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,10 @@ Chayn team members usually respond within 3 business days.
 Chayn is open to all kinds of contributions, such as:
 
 - additional software tests / test coverage
-- dependency updates *check Dependabot pull requests 
+- dependency updates \*check Dependabot pull requests
 - code (requested features, bug fixes, quality enhancements, maintenance help)
 - accessibility and language support.
-- no-code (documentation, translations) *see spam policy below for accepted documentation changes.
+- no-code (documentation, translations) \*see spam policy below for accepted documentation changes.
 
 # Chayn's Spam Contribution Policy 🚫
 

--- a/components/storyblok/StoryblokPage.tsx
+++ b/components/storyblok/StoryblokPage.tsx
@@ -33,7 +33,9 @@ const StoryblokPage = (props: StoryblokPageProps) => {
 
   return (
     <>
-      <Head>{title}</Head>
+      <Head>
+        <title>{title}</title>
+      </Head>
       <main
         {...storyblokEditable({ _uid, _editable, title, description, header_image, page_sections })}
       >

--- a/guards/PartnerAdminGuard.tsx
+++ b/guards/PartnerAdminGuard.tsx
@@ -29,7 +29,9 @@ export function PartnerAdminGuard({ children }: { children: JSX.Element }) {
   if (!partnerAdminId || !partnerAdminIsActive) {
     return (
       <Container sx={containerStyle}>
-        <Head>{t('title')}</Head>
+        <Head>
+          <title>{t('title')}</title>
+        </Head>
         <Box sx={imageContainerStyle}>
           <Image
             alt={tS('alt.personTea')}

--- a/guards/SuperAdminGuard.tsx
+++ b/guards/SuperAdminGuard.tsx
@@ -27,7 +27,9 @@ export function SuperAdminGuard({ children }: { children: JSX.Element }) {
   if (!userIsSuperAdmin) {
     return (
       <Container sx={containerStyle}>
-        <Head>{t('title')}</Head>
+        <Head>
+          <title>{t('title')}</title>
+        </Head>
         <Box sx={imageContainerStyle}>
           <Image
             alt={tS('alt.personTea')}

--- a/guards/TherapyAccessGuard.tsx
+++ b/guards/TherapyAccessGuard.tsx
@@ -31,7 +31,9 @@ export function TherapyAccessGuard({ children }: { children: JSX.Element }) {
   if (!therapyAccess) {
     return (
       <Container sx={containerStyle}>
-        <Head>{t('title')}</Head>
+        <Head>
+          <title>{t('title')}</title>
+        </Head>
         <Box sx={imageContainerStyle}>
           <Image
             alt={tS('alt.personTea')}

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -41,7 +41,9 @@ const Chat: NextPage<Props> = ({ story }) => {
 
   return (
     <>
-      <Head>{headerProps.title}</Head>
+      <Head>
+        <title>{headerProps.title}</title>
+      </Head>
       <Box>
         <Header
           {...headerProps}

--- a/pages/subscription/whatsapp.tsx
+++ b/pages/subscription/whatsapp.tsx
@@ -81,7 +81,9 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story }) => {
 
   return (
     <>
-      <Head>{story.content.title}</Head>
+      <Head>
+        <title>{story.content.title}</title>
+      </Head>
       <Box>
         <Header {...headerProps} />
         {!userId && <SignUpBanner />}

--- a/pages/therapy/book-session.tsx
+++ b/pages/therapy/book-session.tsx
@@ -200,6 +200,7 @@ const BookSession: NextPage = () => {
           src="//widget.simplybook.it/v2/widget/widget.js"
           onLoad={() => {
             new (window as any).SimplybookWidget(getSimplybookWidgetConfig(user));
+            document.title = t('title');
           }}
         />
       )}


### PR DESCRIPTION
### Issue link / number:

#1043

### What changes did you make?
Ensured that the page title on all Bloom pages matches the actual title of the respective page.

### Why did you make the changes?
As per the ticket's request, the default title was set to "Bloom" and updated to match the actual title of each page.

### Did you run tests?
Yes

@eleanorreem  and @annarhughes , please review this and let me know if anything else is needed or if it doesn't match the requirements.


