### PR TITLE
App router migration - Root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,13 @@
+export default function RootLayout({
+  // Layouts must accept a children prop.
+  // This will be populated with nested layouts or pages
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from 'next';
 
+// Nextjs automatically includes for each route two default meta tags, charset and viewport
+// https://nextjs.org/docs/app/building-your-application/optimizing/metadata#default-fields
 export const metadata: Metadata = {
   title: 'Bloom',
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,9 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Bloom',
+};
+
 export default function RootLayout({
   // Layouts must accept a children prop.
   // This will be populated with nested layouts or pages

--- a/app/public-route-test/page.tsx
+++ b/app/public-route-test/page.tsx
@@ -1,0 +1,3 @@
+export default async function Page() {
+  return <div>PUBLIC TESTING PAGE</div>;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
Parent PR for the progressive migration of _app.tsx and _document.tsx within the Root Layout

### Issue link / number:
#1083

### What changes did you make?

1. Created basic root layout
2. Added metadata to root layout
3. Created public testing page to check migration

### Why did you make the changes?
In order to be able to migrate the product from pages router to app router and benefits of all the new features available in the app router

### Did you run tests?
Yes


Navigate to http://localhost:3000/public-route-test to check that title, charset and viewport meta tags are added properly

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/8809c09a-21fd-4037-9ad7-cc9f8ac86311">
