### PR TITLE
feat: made course content available pre login

### DIFF
--- a/components/cards/SessionCard.tsx
+++ b/components/cards/SessionCard.tsx
@@ -55,10 +55,11 @@ interface SessionCardProps {
   session: ISbStoryData;
   sessionSubtitle: string;
   storyblokCourseId: number;
+  clickable: boolean;
 }
 
 const SessionCard = (props: SessionCardProps) => {
-  const { session, sessionSubtitle, storyblokCourseId } = props;
+  const { session, sessionSubtitle, storyblokCourseId, clickable } = props;
   const [expanded, setExpanded] = useState<boolean>(false);
 
   const t = useTranslations('Courses');
@@ -73,12 +74,27 @@ const SessionCard = (props: SessionCardProps) => {
 
   return (
     <Card sx={cardStyle}>
-      <CardActionArea
-        sx={cardActionStyle}
-        component={Link}
-        href={`/${session.full_slug}`}
-        aria-label={`${t('navigateToSession')} ${session.name}`}
-      >
+      {clickable ? (
+        <CardActionArea
+          sx={cardActionStyle}
+          component={Link}
+          href={`/${session.full_slug}`}
+          aria-label={`${t('navigateToSession')} ${session.name}`}
+        >
+          <CardContent sx={cardContentStyle}>
+            <Box sx={cardContentRowStyles}>
+              <SessionProgressDisplay
+                sessionId={session.id}
+                storyblokCourseId={storyblokCourseId}
+              />
+              <Typography flex={1} component="h3" variant="h3">
+                {session.content.name}
+              </Typography>
+            </Box>
+            <Typography color="grey.700">{sessionSubtitle}</Typography>
+          </CardContent>
+        </CardActionArea>
+      ) : (
         <CardContent sx={cardContentStyle}>
           <Box sx={cardContentRowStyles}>
             <SessionProgressDisplay sessionId={session.id} storyblokCourseId={storyblokCourseId} />
@@ -88,7 +104,7 @@ const SessionCard = (props: SessionCardProps) => {
           </Box>
           <Typography color="grey.700">{sessionSubtitle}</Typography>
         </CardContent>
-      </CardActionArea>
+      )}
       <CardActions sx={cardActionsStyle}>
         <IconButton
           sx={{ marginLeft: 'auto' }}

--- a/components/storyblok/StoryblokCoursePage.tsx
+++ b/components/storyblok/StoryblokCoursePage.tsx
@@ -80,7 +80,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const courses = useTypedSelector((state) => state.courses);
-  const isLoggedIn = useTypedSelector((state) => state.user.id);
+  const isLoggedIn = useTypedSelector((state) => Boolean(state.user.id));
   const [incorrectAccess, setIncorrectAccess] = useState<boolean>(true);
   const [courseProgress, setCourseProgress] = useState<PROGRESS_STATUS>(
     PROGRESS_STATUS.NOT_STARTED,

--- a/components/storyblok/StoryblokCoursePage.tsx
+++ b/components/storyblok/StoryblokCoursePage.tsx
@@ -80,7 +80,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const courses = useTypedSelector((state) => state.courses);
-
+  const isLoggedIn = useTypedSelector((state) => state.user.id);
   const [incorrectAccess, setIncorrectAccess] = useState<boolean>(true);
   const [courseProgress, setCourseProgress] = useState<PROGRESS_STATUS>(
     PROGRESS_STATUS.NOT_STARTED,
@@ -217,6 +217,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
                             session={session}
                             sessionSubtitle={position}
                             storyblokCourseId={storyId}
+                            clickable={isLoggedIn}
                           />
                         );
                       })}

--- a/guards/AuthGuard.tsx
+++ b/guards/AuthGuard.tsx
@@ -23,17 +23,12 @@ const publicPathHeads = [
   'meet-the-team',
   'partnership',
   'about-our-courses',
+  'courses',
 ];
 
 // As the subpages of courses are not public and these pages are only partially public,
 // they are treated differently as they are not public path heads
-const partiallyPublicPages = [
-  '/courses',
-  '/activities',
-  '/grounding',
-  '/subscription/whatsapp',
-  '/chat',
-];
+const partiallyPublicPages = ['/activities', '/grounding', '/subscription/whatsapp', '/chat'];
 
 // Adds required permissions guard to pages, redirecting where required permissions are missing
 // New pages will default to requiring authenticated and public pages must be added to the array above

--- a/guards/AuthGuard.tsx
+++ b/guards/AuthGuard.tsx
@@ -23,12 +23,23 @@ const publicPathHeads = [
   'meet-the-team',
   'partnership',
   'about-our-courses',
-  'courses',
 ];
 
 // As the subpages of courses are not public and these pages are only partially public,
 // they are treated differently as they are not public path heads
-const partiallyPublicPages = ['/activities', '/grounding', '/subscription/whatsapp', '/chat'];
+const partiallyPublicPages = [
+  '/courses',
+  '/courses/image-based-abuse-and-rebuilding-ourselves',
+  '/courses/recovering-from-toxic-and-abusive-relationships',
+  '/courses/society-patriarchy-and-sexual-trauma',
+  '/courses/healing-from-sexual-trauma',
+  '/courses/dating-boundaries-and-relationships',
+  '/courses/reclaiming-resilience-in-your-trauma-story',
+  '/activities',
+  '/grounding',
+  '/subscription/whatsapp',
+  '/chat',
+];
 
 // Adds required permissions guard to pages, redirecting where required permissions are missing
 // New pages will default to requiring authenticated and public pages must be added to the array above

--- a/pages/courses/[slug].tsx
+++ b/pages/courses/[slug].tsx
@@ -10,6 +10,8 @@ import StoryblokCoursePage, {
   StoryblokCoursePageProps,
 } from '../../components/storyblok/StoryblokCoursePage';
 import { getStoryblokPageProps } from '../../utils/getStoryblokPageProps';
+import { SignUpBanner } from '../../components/banner/SignUpBanner';
+import { useTypedSelector } from '../../hooks/store';
 
 interface Props {
   story: ISbStoryData | null;
@@ -18,12 +20,16 @@ interface Props {
 const CourseOverview: NextPage<Props> = ({ story }) => {
   story = useStoryblokState(story);
 
+  const userId = useTypedSelector((state) => state.user.id);
   if (!story) {
     return <NoDataAvailable />;
   }
 
   return (
-    <StoryblokCoursePage {...(story.content as StoryblokCoursePageProps)} storyId={story.id} />
+    <>
+      <StoryblokCoursePage {...(story.content as StoryblokCoursePageProps)} storyId={story.id} />
+      {!userId && <SignUpBanner />}
+    </>
   );
 };
 

--- a/pages/courses/[slug].tsx
+++ b/pages/courses/[slug].tsx
@@ -10,8 +10,6 @@ import StoryblokCoursePage, {
   StoryblokCoursePageProps,
 } from '../../components/storyblok/StoryblokCoursePage';
 import { getStoryblokPageProps } from '../../utils/getStoryblokPageProps';
-import { SignUpBanner } from '../../components/banner/SignUpBanner';
-import { useTypedSelector } from '../../hooks/store';
 
 interface Props {
   story: ISbStoryData | null;
@@ -20,7 +18,6 @@ interface Props {
 const CourseOverview: NextPage<Props> = ({ story }) => {
   story = useStoryblokState(story);
 
-  const userId = useTypedSelector((state) => state.user.id);
   if (!story) {
     return <NoDataAvailable />;
   }
@@ -28,7 +25,6 @@ const CourseOverview: NextPage<Props> = ({ story }) => {
   return (
     <>
       <StoryblokCoursePage {...(story.content as StoryblokCoursePageProps)} storyId={story.id} />
-      {!userId && <SignUpBanner />}
     </>
   );
 };

--- a/pages/courses/image-based-abuse-and-rebuilding-ourselves/index.tsx
+++ b/pages/courses/image-based-abuse-and-rebuilding-ourselves/index.tsx
@@ -6,6 +6,8 @@ import StoryblokCoursePage, {
 } from '../../../components/storyblok/StoryblokCoursePage';
 import { getStoryblokPageProps } from '../../../utils/getStoryblokPageProps';
 
+import { SignUpBanner } from '../../../components/banner/SignUpBanner';
+import { useTypedSelector } from '../../../hooks/store';
 interface Props {
   story: ISbStoryData | null;
 }
@@ -13,12 +15,16 @@ interface Props {
 const CourseOverview: NextPage<Props> = ({ story }) => {
   story = useStoryblokState(story);
 
+  const userId = useTypedSelector((state) => state.user.id);
   if (!story) {
     return <NoDataAvailable />;
   }
 
   return (
-    <StoryblokCoursePage {...(story.content as StoryblokCoursePageProps)} storyId={story.id} />
+    <>
+      <StoryblokCoursePage {...(story.content as StoryblokCoursePageProps)} storyId={story.id} />
+      {!userId && <SignUpBanner />}
+    </>
   );
 };
 

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -152,7 +152,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
                   return (
                     <CourseCard
                       key={course.id}
-                      clickable={false}
+                      clickable={true}
                       course={course}
                       courseProgress={null}
                       liveCourseAccess={false}
@@ -166,7 +166,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
                   return (
                     <CourseCard
                       key={course.id}
-                      clickable={false}
+                      clickable={true}
                       course={course}
                       courseProgress={null}
                       liveCourseAccess={false}


### PR DESCRIPTION
### Issue link / number:
#920

### What changes did you make?
1. Make course cards on `/courses` page clickable, linking to `/courses/:slug`.
2. Ensure `/courses/:slug` pages are accessible pre-login.
3. Verify course sessions on `/courses/:slug` are non-clickable pre-login, clickable post-login.
4. Add signup CTA banner before the footer on `/courses/:slug`.

### Why did you make the changes?
To make course content accessible pre-login.

### Did you run tests?
yes
