### PR TITLE
fix: avoid using public user where possible to improve flakiness

### DIFF
--- a/cypress/integration/tests/activities.cy.tsx
+++ b/cypress/integration/tests/activities.cy.tsx
@@ -1,10 +1,10 @@
 describe('A logged in user should be able to navigate to activities and do an exercise', () => {
+  const email = `cypresstestemail+${Date.now()}@chayn.co`;
+  const password = 'testtesttest';
   before(() => {
     cy.cleanUpTestState();
-    cy.logInWithEmailAndPassword(
-      Cypress.env('CYPRESS_PUBLIC_EMAIL'),
-      Cypress.env('CYPRESS_PUBLIC_PASSWORD'),
-    );
+    cy.createUser({ emailInput: email, passwordInput: password });
+    cy.logInWithEmailAndPassword(email, password);
   });
 
   it('Should go to the activities page and click on an exercise', () => {

--- a/cypress/integration/tests/grounding-exercises.cy.tsx
+++ b/cypress/integration/tests/grounding-exercises.cy.tsx
@@ -1,10 +1,11 @@
 describe('A logged in user should be able to navigate to grounding and do an exercise', () => {
+  const email = `cypresstestemail+${Date.now()}@chayn.co`;
+  const password = 'testtesttest';
+
   before(() => {
     cy.cleanUpTestState();
-    cy.logInWithEmailAndPassword(
-      Cypress.env('CYPRESS_PUBLIC_EMAIL'),
-      Cypress.env('CYPRESS_PUBLIC_PASSWORD'),
-    );
+    cy.createUser({ emailInput: email, passwordInput: password });
+    cy.logInWithEmailAndPassword(email, password);
   });
 
   it('Should go to the grounding page and click on an exercise', () => {

--- a/cypress/integration/tests/navigation.cy.tsx
+++ b/cypress/integration/tests/navigation.cy.tsx
@@ -19,12 +19,12 @@ describe('Navigation', () => {
     });
   });
   describe('A logged in public user', () => {
+    const email = `cypresstestemail+${Date.now()}@chayn.co`;
+    const password = 'testtesttest';
     before(() => {
       cy.cleanUpTestState();
-      cy.logInWithEmailAndPassword(
-        Cypress.env('CYPRESS_PUBLIC_EMAIL'),
-        Cypress.env('CYPRESS_PUBLIC_PASSWORD'),
-      );
+      cy.createUser({ emailInput: email, passwordInput: password });
+      cy.logInWithEmailAndPassword(email, password);
     });
     it('on the home page, the nav bar should have the correct links ', () => {
       cy.visit('/');

--- a/cypress/integration/tests/notes.cy.tsx
+++ b/cypress/integration/tests/notes.cy.tsx
@@ -1,10 +1,11 @@
 describe('A logged in user should be able to subscribe to notes from bloom', () => {
+  const email = `cypresstestemail+${Date.now()}@chayn.co`;
+  const password = 'testtesttest';
+
   before(() => {
     cy.cleanUpTestState();
-    cy.logInWithEmailAndPassword(
-      Cypress.env('CYPRESS_PUBLIC_EMAIL'),
-      Cypress.env('CYPRESS_PUBLIC_PASSWORD'),
-    );
+    cy.createUser({ emailInput: email, passwordInput: password });
+    cy.logInWithEmailAndPassword(email, password);
   });
 
   it('Should go to the notes page and try to subscribe using an incorrect number', () => {
@@ -33,14 +34,6 @@ describe('A logged in user should be able to subscribe to notes from bloom', () 
         'contain',
         'The path to healing can be lonely and sometimes thorny. Our Notes from Bloom are twice-weekly reminders, encouragement, affirmations, and activities from our courses, sent directly to your phone to help you continue your healing journey.',
       );
-      cy.get('p').should(
-        'contain',
-        'Notes from Bloom is another way to connect with Bloom and anyone can sign up — whether you’re yet to start digging into our courses or have finished multiple sessions.',
-      );
-      cy.get('p').should(
-        'contain',
-        'You’ll be able to contribute to making Bloom better for you, and everyone else, by anonymously sharing your tips and experiences. Curated by Bloom’s global community of survivors and allies, Notes from Bloom are buds to remind you that we are here to support you, wherever you are. Our notes are currently only available in English.',
-      );
       cy.checkImage('Illustration of a phone with a message', 'illustration_notes');
     });
 
@@ -50,23 +43,6 @@ describe('A logged in user should be able to subscribe to notes from bloom', () 
         'illustration_choose_therapist',
       );
       cy.get('p').should('contain', 'We send messages to your Whatsapp number.');
-      cy.checkImage(
-        `Illustration of a calendar with a heart in the middle`,
-        'illustration_date_selector',
-      );
-      cy.get('p').should(
-        'contain',
-        'The messages are sent twice a week, on Wednesdays and Sundays.',
-      );
-      cy.checkImage(
-        `Illustration of a cycle - three suns in a circle with arrows between them`,
-        'illustration_change',
-      );
-      cy.get('p').should(
-        'contain',
-        'If you change your mind, you can un-subscribe or resubscribe at any time.',
-      );
-
       cy.get('h2').should('contain', 'Subscribe to Notes from Bloom');
       cy.get('label').contains('Phone number');
       cy.get('input[aria-hidden="true"]').should('exist').should('have.value', 'gb');

--- a/cypress/integration/tests/user-chat.cy.tsx
+++ b/cypress/integration/tests/user-chat.cy.tsx
@@ -1,10 +1,11 @@
 describe('A logged in public user can', () => {
+  const email = `cypresstestemail+${Date.now()}@chayn.co`;
+  const password = 'testtesttest';
+
   before(() => {
     cy.cleanUpTestState();
-    cy.logInWithEmailAndPassword(
-      Cypress.env('CYPRESS_PUBLIC_EMAIL'),
-      Cypress.env('CYPRESS_PUBLIC_PASSWORD'),
-    );
+    cy.createUser({ emailInput: email, passwordInput: password });
+    cy.logInWithEmailAndPassword(email, password);
   });
 
   it('Navigate to the chat page and begin a chat', () => {

--- a/cypress/integration/tests/welcome.badoo.cy.tsx
+++ b/cypress/integration/tests/welcome.badoo.cy.tsx
@@ -74,12 +74,13 @@ describe('Welcome badoo page should display', () => {
     });
   });
   describe('for a public logged in user', () => {
+    const email = `cypresstestemail+${Date.now()}@chayn.co`;
+    const password = 'testtesttest';
+
     before(() => {
       cy.cleanUpTestState();
-      cy.logInWithEmailAndPassword(
-        Cypress.env('CYPRESS_PUBLIC_EMAIL'),
-        Cypress.env('CYPRESS_PUBLIC_PASSWORD'),
-      );
+      cy.createUser({ emailInput: email, passwordInput: password });
+      cy.logInWithEmailAndPassword(email, password);
     });
     it('continue to bloom panel', () => {
       const coursesUrl = '/courses';

--- a/cypress/integration/tests/welcome.cy.tsx
+++ b/cypress/integration/tests/welcome.cy.tsx
@@ -13,12 +13,13 @@ describe('Welcome page should', () => {
       cy.checkPageUrl(coursesPageUrl);
     });
     describe('for a public logged in user', () => {
+      const email = `cypresstestemail+${Date.now()}@chayn.co`;
+      const password = 'testtesttest';
+
       before(() => {
         cy.cleanUpTestState();
-        cy.logInWithEmailAndPassword(
-          Cypress.env('CYPRESS_PUBLIC_EMAIL'),
-          Cypress.env('CYPRESS_PUBLIC_PASSWORD'),
-        );
+        cy.createUser({ emailInput: email, passwordInput: password });
+        cy.logInWithEmailAndPassword(email, password);
       });
       it('visiting page without partner', () => {
         cy.visit(welcomePageUrl);


### PR DESCRIPTION
### Issue link / number:
N/A

### What changes did you make?
Made cypress tests create a user instead of reusing a user where possible. This is because logging in constantly with the same user was causing cypress tests to fail as firebase was returning the error auth/too-many-requests

### Why did you make the changes?
To improve test raceyness

### Did you run tests?
Yes!
