### PR TITLE
Add email reminders for partner users

### DIFF
--- a/components/forms/AboutYouSetAForm.tsx
+++ b/components/forms/AboutYouSetAForm.tsx
@@ -61,7 +61,6 @@ const AboutYouSetAForm = () => {
   const user = useTypedSelector((state) => state.user);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
-  const isPublicUser = partnerAccesses.length === 0 && !partnerAdmin.id;
 
   const scaleQuestions: ScaleFieldItem[] = [
     { name: 'Q1', inputState: scale1Input, inputStateSetter: setScale1Input },
@@ -187,19 +186,15 @@ const AboutYouSetAForm = () => {
         ))}
 
         {/* Additional user setting for email reminders frequency */}
-        {isPublicUser && (
-          <>
-            <Typography mt={3} mb={1.5}>
-              {tAccount('introduction')}
-            </Typography>
-            <Typography>{tAccount('description')}</Typography>
-            <EmailRemindersSettingsFormControl
-              selectedInput={emailRemindersSettingInput}
-              setSelectedInput={setEmailRemindersSettingInput}
-            />
-            <Typography variant="body2">{tAccount('update')}</Typography>
-          </>
-        )}
+        <Typography mt={3} mb={1.5}>
+          {tAccount('introduction')}
+        </Typography>
+        <Typography>{tAccount('description')}</Typography>
+        <EmailRemindersSettingsFormControl
+          selectedInput={emailRemindersSettingInput}
+          setSelectedInput={setEmailRemindersSettingInput}
+        />
+        <Typography variant="body2">{tAccount('update')}</Typography>
 
         {formError && (
           <Typography color="error.main" mb={2}>

--- a/pages/account/settings.tsx
+++ b/pages/account/settings.tsx
@@ -30,7 +30,6 @@ const AccountSettings: NextPage = () => {
   const t = useTranslations('Account.accountSettings');
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
-  const isPublicUser = partnerAccesses.length === 0 && !partnerAdmin.id;
 
   const headerProps = {
     title: t('title'),
@@ -57,7 +56,7 @@ const AccountSettings: NextPage = () => {
         </Box>
         <Box sx={columnContainerStyle}>
           <AccountActionsCard />
-          {isPublicUser && <EmailRemindersSettingsCard />}
+          <EmailRemindersSettingsCard />
         </Box>
       </Container>
     </Box>

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -50,7 +50,6 @@ const CourseList: NextPage<Props> = ({ stories }) => {
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const courses = useTypedSelector((state) => state.courses);
-  const isPublicUser = partnerAccesses.length === 0 && !partnerAdmin.id;
 
   const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
   const liveCourseAccess = partnerAccesses.length === 0 && !partnerAdmin.id;
@@ -240,7 +239,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
           </Box>
         )}
       </Container>
-      {!!showEmailRemindersBanner && isPublicUser && <EmailRemindersSettingsBanner />}
+      {!!showEmailRemindersBanner && <EmailRemindersSettingsBanner />}
     </Box>
   );
 };


### PR DESCRIPTION
### What changes did you make?
Made email reminders available to all users, not just public.

### Why did you make the changes?
We originally wanted to trial email reminders with public users before enabling for partner users. We're now ready to invite partner users to the new feature.

