### PR TITLE
Improve quote block styles

### DIFF
--- a/components/common/Quote.tsx
+++ b/components/common/Quote.tsx
@@ -19,20 +19,10 @@ const Quote = (props: QuoteProps) => {
       : textSize === 'small'
         ? { xs: 1, md: 1.125 }
         : textSize === 'large'
-          ? { xs: 1.25, md: 1.5 }
+          ? { xs: 1.25, md: 1.375 }
           : textSize === 'extra-large'
-            ? { xs: 1.5, md: 1.75 }
+            ? { xs: 1.375, md: 1.5 }
             : { xs: 1.125, md: 1.25 }; // default / medium
-  const quotePosition =
-    textSize === 'extra-small'
-      ? { top: '-50px', left: '0' }
-      : textSize === 'small'
-        ? { top: '-40px', left: '0' }
-        : { top: '-50px', left: '0' }; // medium/ large/ extra large
-  const quoteSize =
-    textSize === 'extra-small' || textSize === 'small'
-      ? { height: '20px', width: '20px' }
-      : { height: '20px', width: '30px' }; // medium/ large/ extra large
 
   const containerStyle = {
     fontFamily: 'Montserrat, sans-serif',
@@ -40,7 +30,7 @@ const Quote = (props: QuoteProps) => {
     maxWidth: 700,
     blockquote: {
       fontSize: { xs: `${fontSize.xs}rem`, md: `${fontSize.md}rem` },
-      lineHeight: `calc(${fontSize.md} * 1.75rem)`,
+      lineHeight: { xs: `calc(${fontSize.xs} * 1.625rem)`, md: `calc(${fontSize.md} * 1.625rem)` },
       marginX: 0,
       position: 'relative',
       '&:before': {
@@ -50,11 +40,13 @@ const Quote = (props: QuoteProps) => {
         color: iconColor,
         fontSize: `calc(${fontSize.md} * 4rem)`,
         position: 'absolute',
-        ...quoteSize,
-        ...quotePosition,
+        height: '28px',
+        width: '28px',
+        top: { xs: '-60px', md: '-40px' },
+        left: { xs: 0, md: '-44px' },
       },
       '&:after': {
-        content: 'no-close-quote',
+        content: 'none',
       },
     },
     cite: {

--- a/components/storyblok/StoryblokQuote.tsx
+++ b/components/storyblok/StoryblokQuote.tsx
@@ -3,10 +3,21 @@ import { ISbRichtext, storyblokEditable } from '@storyblok/react';
 import Image from 'next/image';
 import Quote from '../common/Quote';
 
+const containerStyle = {
+  display: 'flex',
+  marginX: { xs: 2, lg: 3 },
+  flexDirection: { xs: 'column', md: 'row' },
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: { xs: 2, md: 10 },
+  paddingTop: 1,
+} as const;
+
 const imageContainerStyle = {
   marginX: 'auto',
   marginY: 4,
-  width: { xs: 200, md: 250 },
+  minWidth: { xs: 200, md: 230, lg: 260 },
+  maxWidth: { xs: 200, md: 230, lg: 260 },
   '.image': {
     objectFit: 'contain',
     width: '100% !important',
@@ -32,17 +43,11 @@ const StoryblokQuote = (props: StoryblokQuoteProps) => {
   return (
     <Box
       {...storyblokEditable({ _uid, _editable, text, text_size, icon_color, image })}
-      sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', md: 'row' },
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        gap: 7,
-      }}
+      sx={containerStyle}
     >
       {image && (
         <Box sx={imageContainerStyle}>
-          <Image src={image.filename} alt={image.alt} className="image" fill sizes="100vw" />
+          <Image src={image.filename} alt={image.alt} className="image" fill sizes="520px" />
         </Box>
       )}
       <Quote text={text} textSize={text_size} iconColor={icon_color} />


### PR DESCRIPTION
### What changes did you make?
Improved the styling of the quote block, by moving the quote mark to the side instead of above the text.
Also slighting increased the image size and padding, and slightly reduced the text sizes and line heights.

### Why did you make the changes?
Styling improvements flagged by Nadine

### Before/after

<img width="993" alt="Screenshot 2024-09-11 at 17 20 06" src="https://github.com/user-attachments/assets/125d1b82-dadd-4652-8a3a-183ea0a10073">
<img width="1001" alt="Screenshot 2024-09-11 at 17 19 50" src="https://github.com/user-attachments/assets/26ad20b4-ae68-4b3a-9830-9e21c7442b16">
<img width="1221" alt="Screenshot 2024-09-11 at 17 20 21" src="https://github.com/user-attachments/assets/09188441-4712-4087-bfec-fcc1cb68293c">
<img width="1225" alt="Screenshot 2024-09-11 at 17 20 30" src="https://github.com/user-attachments/assets/94e5d746-84fd-4384-8ffe-488f4420da9f">

