### PR TITLE
Session card scroll to sign up

### DIFF
--- a/components/banner/SignUpBanner.tsx
+++ b/components/banner/SignUpBanner.tsx
@@ -29,7 +29,7 @@ export const SignUpBanner = () => {
   }, []);
 
   return (
-    <Container sx={containerStyle}>
+    <Container id="signup-banner" sx={containerStyle}>
       <Typography variant="h2" component="h2" mb={2}>
         {t('signUpTodayPromo.title')}
       </Typography>

--- a/components/cards/SessionCard.tsx
+++ b/components/cards/SessionCard.tsx
@@ -11,9 +11,9 @@ import {
 } from '@mui/material';
 import { ISbStoryData } from '@storyblok/react';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { rowStyle } from '../../styles/common';
-import Link from '../common/Link';
 import { SessionProgressDisplay } from '../session/SessionProgressDisplay';
 
 const cardStyle = {
@@ -55,14 +55,29 @@ interface SessionCardProps {
   session: ISbStoryData;
   sessionSubtitle: string;
   storyblokCourseId: number;
-  clickable: boolean;
+  isLoggedIn: boolean;
 }
 
 const SessionCard = (props: SessionCardProps) => {
-  const { session, sessionSubtitle, storyblokCourseId, clickable } = props;
+  const { session, sessionSubtitle, storyblokCourseId, isLoggedIn } = props;
   const [expanded, setExpanded] = useState<boolean>(false);
 
   const t = useTranslations('Courses');
+  const router = useRouter();
+
+  const handleCardClick = () => {
+    if (isLoggedIn) {
+      router.push(`/${session.full_slug}`);
+    } else {
+      const signupBanner = document.getElementById('signup-banner');
+
+      if (signupBanner) {
+        const scrollToY = signupBanner.getBoundingClientRect().top + window.scrollY - 136;
+
+        window.scrollTo({ top: scrollToY, behavior: 'smooth' });
+      }
+    }
+  };
 
   const handleExpandClick = () => {
     setExpanded(!expanded);
@@ -74,27 +89,11 @@ const SessionCard = (props: SessionCardProps) => {
 
   return (
     <Card sx={cardStyle}>
-      {clickable ? (
-        <CardActionArea
-          sx={cardActionStyle}
-          component={Link}
-          href={`/${session.full_slug}`}
-          aria-label={`${t('navigateToSession')} ${session.name}`}
-        >
-          <CardContent sx={cardContentStyle}>
-            <Box sx={cardContentRowStyles}>
-              <SessionProgressDisplay
-                sessionId={session.id}
-                storyblokCourseId={storyblokCourseId}
-              />
-              <Typography flex={1} component="h3" variant="h3">
-                {session.content.name}
-              </Typography>
-            </Box>
-            <Typography color="grey.700">{sessionSubtitle}</Typography>
-          </CardContent>
-        </CardActionArea>
-      ) : (
+      <CardActionArea
+        sx={cardActionStyle}
+        onClick={handleCardClick}
+        aria-label={`${t('navigateToSession')} ${session.name}`}
+      >
         <CardContent sx={cardContentStyle}>
           <Box sx={cardContentRowStyles}>
             <SessionProgressDisplay sessionId={session.id} storyblokCourseId={storyblokCourseId} />
@@ -104,7 +103,7 @@ const SessionCard = (props: SessionCardProps) => {
           </Box>
           <Typography color="grey.700">{sessionSubtitle}</Typography>
         </CardContent>
-      )}
+      </CardActionArea>
       <CardActions sx={cardActionsStyle}>
         <IconButton
           sx={{ marginLeft: 'auto' }}

--- a/components/storyblok/StoryblokCoursePage.tsx
+++ b/components/storyblok/StoryblokCoursePage.tsx
@@ -19,6 +19,7 @@ import { determineCourseProgress } from '../../utils/courseProgress';
 import hasAccessToPage from '../../utils/hasAccessToPage';
 import { getEventUserData, logEvent } from '../../utils/logEvent';
 import { RichTextOptions } from '../../utils/richText';
+import { SignUpBanner } from '../banner/SignUpBanner';
 
 const containerStyle = {
   backgroundColor: 'secondary.light',
@@ -217,7 +218,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
                             session={session}
                             sessionSubtitle={position}
                             storyblokCourseId={storyId}
-                            clickable={isLoggedIn}
+                            isLoggedIn={isLoggedIn}
                           />
                         );
                       })}
@@ -229,6 +230,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
           </>
         )}
       </Container>
+      {!isLoggedIn && <SignUpBanner />}
     </Box>
   );
 };

--- a/pages/courses/image-based-abuse-and-rebuilding-ourselves/index.tsx
+++ b/pages/courses/image-based-abuse-and-rebuilding-ourselves/index.tsx
@@ -6,7 +6,6 @@ import StoryblokCoursePage, {
 } from '../../../components/storyblok/StoryblokCoursePage';
 import { getStoryblokPageProps } from '../../../utils/getStoryblokPageProps';
 
-import { SignUpBanner } from '../../../components/banner/SignUpBanner';
 import { useTypedSelector } from '../../../hooks/store';
 interface Props {
   story: ISbStoryData | null;
@@ -23,7 +22,6 @@ const CourseOverview: NextPage<Props> = ({ story }) => {
   return (
     <>
       <StoryblokCoursePage {...(story.content as StoryblokCoursePageProps)} storyId={story.id} />
-      {!userId && <SignUpBanner />}
     </>
   );
 };


### PR DESCRIPTION
### Issue link / number:
#1108 

### What changes did you make?
Added functionality to ensure that if a user is not logged in, and clicks a session card on a course page (e.g. https://bloom.chayn.co/courses/recovering-from-toxic-and-abusive-relationships), the sign up banner is scrolled into view.

### Why did you make the changes?
Previously, clicking a session card would result in no action, the card wasn't clickable. This scroll-to is better UX, leading the user to sign up to access a session
