### PR TITLE
Fix build paths

### DIFF
--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -37,7 +37,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
 
 export async function getStaticPaths({ locales }: GetStaticPathsContext) {
   const storyblokApi = getStoryblokApi();
-  let { data } = await storyblokApi.get('cdn/links/', { published: true });
+  let { data } = await storyblokApi.get('cdn/links/', { version: 'published' });
 
   const excludePaths: string[] = [
     'home',
@@ -50,7 +50,7 @@ export async function getStaticPaths({ locales }: GetStaticPathsContext) {
 
   let paths: any = [];
   Object.keys(data.links).forEach((linkKey) => {
-    if (data.links[linkKey].is_folder) {
+    if (data.links[linkKey].is_folder || !data.links[linkKey].published) {
       return;
     }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from '@mui/material/styles';
 // Import the functions you need from the SDKs you need
 import { Analytics } from '@vercel/analytics/react';
 import { NextComponentType } from 'next';
-import { NextIntlClientProvider } from 'next-intl';
+import { IntlError, NextIntlClientProvider } from 'next-intl';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -57,12 +57,21 @@ function MyApp(props: MyAppProps) {
   // Get top level directory of path e.g pathname /courses/course_name has pathHead courses
   const pathHead = router.pathname.split('/')[1]; // E.g. courses | therapy | partner-admin
 
+  function onIntlError(error: IntlError) {
+    if (error.code === 'MISSING_MESSAGE') {
+      console.error(`${error.message} Page: ${router.asPath}`);
+    } else {
+      console.error(error);
+    }
+  }
+
   return (
     <ErrorBoundary>
       <NextIntlClientProvider
         messages={pageProps.messages}
         locale={router.locale}
         timeZone="Europe/London"
+        onError={onIntlError}
       >
         <Head>
           <meta name="viewport" content="initial-scale=1, width=device-width" />

--- a/pages/courses/[slug].tsx
+++ b/pages/courses/[slug].tsx
@@ -51,7 +51,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
 
 export async function getStaticPaths({ locales }: GetStaticPathsContext) {
   let sbParams: ISbStoriesParams = {
-    published: true,
+    version: 'published',
     starts_with: 'courses/',
     filter_query: {
       component: {

--- a/pages/courses/[slug].tsx
+++ b/pages/courses/[slug].tsx
@@ -66,7 +66,7 @@ export async function getStaticPaths({ locales }: GetStaticPathsContext) {
   let paths: any = [];
 
   courses.forEach((course: Partial<ISbStoryData>) => {
-    if (!course.slug) return;
+    if (!course.slug || !course.published) return;
 
     if (!course.is_startpage || isAlternativelyHandledCourse(course.slug)) {
       return;

--- a/pages/courses/[slug]/[sessionSlug].tsx
+++ b/pages/courses/[slug]/[sessionSlug].tsx
@@ -75,7 +75,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
 
 export async function getStaticPaths({ locales }: GetStaticPathsContext) {
   let sbParams: ISbStoriesParams = {
-    published: true,
+    version: 'published',
     starts_with: 'courses/',
   };
 

--- a/pages/courses/[slug]/[sessionSlug].tsx
+++ b/pages/courses/[slug]/[sessionSlug].tsx
@@ -88,7 +88,12 @@ export async function getStaticPaths({ locales }: GetStaticPathsContext) {
     const slug = session.slug;
     if (!slug) return;
 
-    if (session.is_startpage || session.is_folder || isAlternativelyHandledSession(slug)) {
+    if (
+      session.is_startpage ||
+      session.is_folder ||
+      isAlternativelyHandledSession(slug) ||
+      !session.published
+    ) {
       return;
     }
 

--- a/pages/courses/image-based-abuse-and-rebuilding-ourselves/[sessionSlug].tsx
+++ b/pages/courses/image-based-abuse-and-rebuilding-ourselves/[sessionSlug].tsx
@@ -88,7 +88,7 @@ export async function getStaticPaths({ locales }: GetStaticPathsContext) {
     const slug = session.slug;
     if (!slug) return;
 
-    if (session.is_startpage || session.is_folder) {
+    if (session.is_startpage || session.is_folder || !session.published) {
       return;
     }
 

--- a/pages/courses/image-based-abuse-and-rebuilding-ourselves/[sessionSlug].tsx
+++ b/pages/courses/image-based-abuse-and-rebuilding-ourselves/[sessionSlug].tsx
@@ -75,7 +75,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
 
 export async function getStaticPaths({ locales }: GetStaticPathsContext) {
   let sbParams: ISbStoriesParams = {
-    published: true,
+    version: 'published',
     starts_with: 'courses/image-based-abuse-and-rebuilding-ourselves/',
   };
 

--- a/pages/welcome/[partnerName].tsx
+++ b/pages/welcome/[partnerName].tsx
@@ -61,7 +61,7 @@ export async function getStaticPaths({ locales }: GetStaticPathsContext) {
   let paths: any = [];
 
   data.forEach((story: Partial<ISbStoryData>) => {
-    if (!story.slug) return;
+    if (!story.slug || !story.published) return;
 
     // get array for slug because of catch all
     let splittedSlug = story.slug.split('/');

--- a/pages/welcome/[partnerName].tsx
+++ b/pages/welcome/[partnerName].tsx
@@ -39,6 +39,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
     props: {
       ...storyblokProps,
       messages: {
+        ...require(`../../messages/courses/${locale}.json`),
         ...require(`../../messages/shared/${locale}.json`),
         ...require(`../../messages/navigation/${locale}.json`),
         ...require(`../../messages/welcome/${locale}.json`),
@@ -50,7 +51,7 @@ export async function getStaticProps({ locale, preview = false, params }: GetSta
 
 export async function getStaticPaths({ locales }: GetStaticPathsContext) {
   let sbParams: ISbStoriesParams = {
-    published: true,
+    version: 'published',
     starts_with: 'welcome/',
   };
 

--- a/utils/getStoryblokPageProps.ts
+++ b/utils/getStoryblokPageProps.ts
@@ -9,7 +9,6 @@ export const getStoryblokPageProps = async (
   if (!slug) {
     return {
       story: null,
-      key: false,
       preview,
       locale: locale || null,
       error: 'No slug provided',
@@ -27,11 +26,10 @@ export const getStoryblokPageProps = async (
     let { data } = await storyblokApi.get(`cdn/stories/${slug}`, sbParams);
     return {
       story: data ? data.story : null,
-      key: data ? data.story.id : false,
       preview,
       locale: locale || null,
     };
   } catch (error) {
-    console.log('Error getting storyblok data for page', error);
+    console.log('Error getting storyblok data for page', slug, sbParams, error);
   }
 };


### PR DESCRIPTION
### What changes did you make?
Fixed `getStaticPaths` functions to ensure only storyblok pages that have been published, are added to the static paths list.

### Why did you make the changes?
When building the app, there were many 404 errors for fetching storyblok data for pages. The errors were diluting the logging for builds - it's now easier to see the relevant issues from build logs
