### PR TITLE
Add SEO description field

### DIFF
--- a/components/head/DefaultHeadMetadata.tsx
+++ b/components/head/DefaultHeadMetadata.tsx
@@ -1,20 +1,17 @@
+import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import theme from '../../styles/theme';
 
-const titleContent = 'Welcome to Bloom';
-const descriptionContent =
-  'Join us on your healing journey. Bloom is here for you to learn, heal and grow towards a confident future. It is bought to you by Chayn, a global non-profit, run by survivors and allies from around the world.';
-const imageAltContent =
-  'An cartoon drawing of a person with almost shoulder length hair against a pink background. They have flowers and leaves coming out of their head. The word "Bloom" hovers above the person.';
-
 const DefaultHeadMetadata = () => {
+  const t = useTranslations('Shared.metadata');
+
   return (
     <Head>
       <meta name="viewport" content="initial-scale=1, width=device-width" />
-      <meta property="og:title" content={titleContent} key="og-title" />
-      <meta property="og:description" content={descriptionContent} key="og-description" />
+      <meta property="og:title" content={t('title')} key="og-title" />
+      <meta property="og:description" content={t('description')} key="og-description" />
       <meta property="og:image" content="/preview.png" key="og-image" />
-      <meta property="og:image:alt" content={imageAltContent} key="og-image-alt" />
+      <meta property="og:image:alt" content={t('imageAlt')} key="og-image-alt" />
       <meta name="twitter:card" content="summary_large_image" key="twitter-card" />
       <meta name="twitter:site" content="@ChaynHQ" />
       <meta name="twitter:creator" content="@ChaynHQ" />

--- a/components/head/DefaultHeadMetadata.tsx
+++ b/components/head/DefaultHeadMetadata.tsx
@@ -1,27 +1,29 @@
+import Head from 'next/head';
 import theme from '../../styles/theme';
 
+const titleContent = 'Welcome to Bloom';
 const descriptionContent =
-  'Join us on your healing journey. Bloom is here for you to learn, heal and grow towards a confident future. It is bought to you by Chayn, a global non-profit, run by survivors and allies from around the world.';
-const twitterDescriptionContent =
   'Join us on your healing journey. Bloom is here for you to learn, heal and grow towards a confident future. It is bought to you by Chayn, a global non-profit, run by survivors and allies from around the world.';
 const imageAltContent =
   'An cartoon drawing of a person with almost shoulder length hair against a pink background. They have flowers and leaves coming out of their head. The word "Bloom" hovers above the person.';
 
-const OpenGraphMetadata = () => {
+const DefaultHeadMetadata = () => {
   return (
-    <>
-      <meta property="og:title" content="Welcome to Bloom" key="og-title" />
+    <Head>
+      <meta name="viewport" content="initial-scale=1, width=device-width" />
+      <meta property="og:title" content={titleContent} key="og-title" />
       <meta property="og:description" content={descriptionContent} key="og-description" />
       <meta property="og:image" content="/preview.png" key="og-image" />
       <meta property="og:image:alt" content={imageAltContent} key="og-image-alt" />
       <meta name="twitter:card" content="summary_large_image" key="twitter-card" />
-      <meta name="twitter:description" content={twitterDescriptionContent} key="twitter-desc" />
+      <meta name="twitter:site" content="@ChaynHQ" />
+      <meta name="twitter:creator" content="@ChaynHQ" />
       {/** PWA specific tags **/}
       <link rel="manifest" href="/manifest.json" />
       <link rel="apple-touch-icon" href="/icons/apple/icon-120x120.png"></link>
       <meta name="theme-color" content={theme.palette.primary.main} />
-    </>
+    </Head>
   );
 };
 
-export default OpenGraphMetadata;
+export default DefaultHeadMetadata;

--- a/components/storyblok/StoryblokCoursePage.tsx
+++ b/components/storyblok/StoryblokCoursePage.tsx
@@ -177,7 +177,9 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
       <Head>
         <title>{`${t('course')} • ${name} • Bloom`}</title>
         <meta property="og:title" content={name} key="og-title" />
-        <meta property="og:description" content={seo_description} key="og-description" />
+        {seo_description && (
+          <meta property="og:description" content={seo_description} key="og-description" />
+        )}
       </Head>
       <CourseHeader
         name={name}

--- a/components/storyblok/StoryblokCoursePage.tsx
+++ b/components/storyblok/StoryblokCoursePage.tsx
@@ -40,6 +40,7 @@ export interface StoryblokCoursePageProps {
   _uid: string;
   _editable: string;
   name: string;
+  seo_description: string;
   description: ISbRichtext;
   image: { filename: string; alt: string };
   image_with_background: { filename: string; alt: string };
@@ -61,6 +62,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
     _uid,
     _editable,
     name,
+    seo_description,
     description,
     image,
     image_with_background,
@@ -156,6 +158,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
         _uid,
         _editable,
         name,
+        seo_description,
         description,
         image,
         image_with_background,
@@ -172,7 +175,9 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
       })}
     >
       <Head>
-        <title>{name}</title>
+        <title>{`${name} • Bloom`}</title>
+        <meta property="og:title" content={name} key="og-title" />
+        <meta property="og:description" content={seo_description} key="og-description" />
       </Head>
       <CourseHeader
         name={name}

--- a/components/storyblok/StoryblokCoursePage.tsx
+++ b/components/storyblok/StoryblokCoursePage.tsx
@@ -175,7 +175,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
       })}
     >
       <Head>
-        <title>{`${name} • Bloom`}</title>
+        <title>{`${t('course')} • ${name} • Bloom`}</title>
         <meta property="og:title" content={name} key="og-title" />
         <meta property="og:description" content={seo_description} key="og-description" />
       </Head>

--- a/components/storyblok/StoryblokMeetTheTeamPage.tsx
+++ b/components/storyblok/StoryblokMeetTheTeamPage.tsx
@@ -24,6 +24,7 @@ export interface StoryblokMeetTheTeamPageProps {
   _uid: string;
   _editable: string;
   title: string;
+  seo_description: string;
   description: string;
   header_image: { filename: string; alt: string };
   core_team_title: string;
@@ -42,6 +43,7 @@ const StoryblokMeetTheTeamPage = (props: StoryblokMeetTheTeamPageProps) => {
     _uid,
     _editable,
     title,
+    seo_description,
     description,
     header_image,
     core_team_title,
@@ -64,13 +66,6 @@ const StoryblokMeetTheTeamPage = (props: StoryblokMeetTheTeamPageProps) => {
     logEvent(MEET_THE_TEAM_VIEWED, eventUserData);
   }, []);
 
-  const headerProps = {
-    title: title,
-    introduction: description,
-    imageSrc: header_image.filename,
-    translatedImageAlt: header_image.alt,
-  };
-
   return (
     <Box
       {...storyblokEditable({
@@ -91,13 +86,15 @@ const StoryblokMeetTheTeamPage = (props: StoryblokMeetTheTeamPageProps) => {
       })}
     >
       <Head>
-        <title>{headerProps.title}</title>
+        <title>{`${title} • Bloom`}</title>
+        <meta property="og:title" content={title} key="og-title" />
+        <meta property="og:description" content={seo_description} key="og-description" />
       </Head>
       <Header
-        title={headerProps.title}
-        introduction={headerProps.introduction}
-        imageSrc={headerProps.imageSrc}
-        translatedImageAlt={headerProps.translatedImageAlt}
+        title={title}
+        introduction={description}
+        imageSrc={header_image.filename}
+        translatedImageAlt={header_image.alt}
       />
       {page_section_1?.length > 0 && <StoryblokPageSection {...page_section_1[0]} />}
       <Container sx={coreContainerStyle}>

--- a/components/storyblok/StoryblokMeetTheTeamPage.tsx
+++ b/components/storyblok/StoryblokMeetTheTeamPage.tsx
@@ -88,7 +88,9 @@ const StoryblokMeetTheTeamPage = (props: StoryblokMeetTheTeamPageProps) => {
       <Head>
         <title>{`${title} • Bloom`}</title>
         <meta property="og:title" content={title} key="og-title" />
-        <meta property="og:description" content={seo_description} key="og-description" />
+        {seo_description && (
+          <meta property="og:description" content={seo_description} key="og-description" />
+        )}
       </Head>
       <Header
         title={title}

--- a/components/storyblok/StoryblokPage.tsx
+++ b/components/storyblok/StoryblokPage.tsx
@@ -11,13 +11,15 @@ export interface StoryblokPageProps {
   _uid: string;
   _editable: string;
   title: string;
+  seo_description: string;
   description: ISbRichtext;
   header_image: { filename: string; alt: string };
   page_sections: StoryblokPageSectionProps[];
 }
 
 const StoryblokPage = (props: StoryblokPageProps) => {
-  const { _uid, _editable, title, description, header_image, page_sections } = props;
+  const { _uid, _editable, title, seo_description, description, header_image, page_sections } =
+    props;
 
   const userId = useTypedSelector((state) => state.user.id);
   const router = useRouter();
@@ -34,7 +36,9 @@ const StoryblokPage = (props: StoryblokPageProps) => {
   return (
     <>
       <Head>
-        <title>{title}</title>
+        <title>{`${title} • Bloom`}</title>
+        <meta property="og:title" content={title} key="og-title" />
+        <meta property="og:description" content={seo_description} key="og-description" />
       </Head>
       <main
         {...storyblokEditable({ _uid, _editable, title, description, header_image, page_sections })}

--- a/components/storyblok/StoryblokPage.tsx
+++ b/components/storyblok/StoryblokPage.tsx
@@ -38,7 +38,9 @@ const StoryblokPage = (props: StoryblokPageProps) => {
       <Head>
         <title>{`${title} • Bloom`}</title>
         <meta property="og:title" content={title} key="og-title" />
-        <meta property="og:description" content={seo_description} key="og-description" />
+        {seo_description && (
+          <meta property="og:description" content={seo_description} key="og-description" />
+        )}
       </Head>
       <main
         {...storyblokEditable({ _uid, _editable, title, description, header_image, page_sections })}

--- a/components/storyblok/StoryblokSessionIbaPage.tsx
+++ b/components/storyblok/StoryblokSessionIbaPage.tsx
@@ -239,7 +239,9 @@ const StoryblokSessionIbaPage = (props: StoryblokSessionIbaPageProps) => {
       <Head>
         <title>{`${t('session')} • ${name} • Bloom`}</title>
         <meta property="og:title" content={name} key="og-title" />
-        <meta property="og:description" content={seo_description} key="og-description" />
+        {seo_description && (
+          <meta property="og:description" content={seo_description} key="og-description" />
+        )}
       </Head>
 
       {incorrectAccess ? (

--- a/components/storyblok/StoryblokSessionIbaPage.tsx
+++ b/components/storyblok/StoryblokSessionIbaPage.tsx
@@ -71,6 +71,7 @@ export interface StoryblokSessionIbaPageProps {
   course: ISbStoryData;
   name: string;
   subtitle: string;
+  seo_description: string;
   description: string;
   video: { url: string };
   video_transcript: ISbRichtext;
@@ -89,6 +90,7 @@ const StoryblokSessionIbaPage = (props: StoryblokSessionIbaPageProps) => {
     course,
     name,
     subtitle,
+    seo_description,
     description,
     video,
     video_transcript,
@@ -193,13 +195,6 @@ const StoryblokSessionIbaPage = (props: StoryblokSessionIbaPageProps) => {
     course_storyblok_id: course.id,
   };
 
-  const headerProps = {
-    title: name,
-    introduction: description,
-    imageSrc: illustrationPerson4Peach,
-    imageAlt: 'alt.personTea',
-  };
-
   async function callStartSession() {
     logEvent(SESSION_STARTED_REQUEST, {
       ...eventData,
@@ -242,17 +237,20 @@ const StoryblokSessionIbaPage = (props: StoryblokSessionIbaPageProps) => {
       })}
     >
       <Head>
-        <title>{name}</title>
+        <title>{`${name} • Bloom`}</title>
+        <meta property="og:title" content={name} key="og-title" />
+        <meta property="og:description" content={seo_description} key="og-description" />
       </Head>
+
       {incorrectAccess ? (
         <Container sx={containerStyle}></Container>
       ) : (
         <Box>
           <Header
-            title={headerProps.title}
-            introduction={headerProps.introduction}
-            imageSrc={headerProps.imageSrc}
-            imageAlt={headerProps.imageAlt}
+            title={name}
+            introduction={description}
+            imageSrc={illustrationPerson4Peach}
+            imageAlt={'alt.personTea'}
             progressStatus={sessionProgress}
           >
             <Button

--- a/components/storyblok/StoryblokSessionIbaPage.tsx
+++ b/components/storyblok/StoryblokSessionIbaPage.tsx
@@ -237,7 +237,7 @@ const StoryblokSessionIbaPage = (props: StoryblokSessionIbaPageProps) => {
       })}
     >
       <Head>
-        <title>{`${name} • Bloom`}</title>
+        <title>{`${t('session')} • ${name} • Bloom`}</title>
         <meta property="og:title" content={name} key="og-title" />
         <meta property="og:description" content={seo_description} key="og-description" />
       </Head>

--- a/components/storyblok/StoryblokSessionPage.tsx
+++ b/components/storyblok/StoryblokSessionPage.tsx
@@ -256,7 +256,9 @@ const StoryblokSessionPage = (props: StoryblokSessionPageProps) => {
       <Head>
         <title>{`${t('session')} • ${name} • Bloom`}</title>
         <meta property="og:title" content={name} key="og-title" />
-        <meta property="og:description" content={seo_description} key="og-description" />
+        {seo_description && (
+          <meta property="og:description" content={seo_description} key="og-description" />
+        )}
       </Head>
 
       {incorrectAccess ? (

--- a/components/storyblok/StoryblokSessionPage.tsx
+++ b/components/storyblok/StoryblokSessionPage.tsx
@@ -254,7 +254,7 @@ const StoryblokSessionPage = (props: StoryblokSessionPageProps) => {
       })}
     >
       <Head>
-        <title>{`${name} • Bloom`}</title>
+        <title>{`${t('session')} • ${name} • Bloom`}</title>
         <meta property="og:title" content={name} key="og-title" />
         <meta property="og:description" content={seo_description} key="og-description" />
       </Head>

--- a/components/storyblok/StoryblokSessionPage.tsx
+++ b/components/storyblok/StoryblokSessionPage.tsx
@@ -70,6 +70,7 @@ export interface StoryblokSessionPageProps {
   _editable: string;
   course: ISbStoryData;
   name: string;
+  seo_description: string;
   description: ISbRichtext;
   video: { url: string };
   video_transcript: ISbRichtext;
@@ -89,6 +90,7 @@ const StoryblokSessionPage = (props: StoryblokSessionPageProps) => {
     _editable,
     course,
     name,
+    seo_description,
     description,
     video,
     video_transcript,
@@ -225,13 +227,6 @@ const StoryblokSessionPage = (props: StoryblokSessionPageProps) => {
     course_live_now: courseLiveNow,
   };
 
-  const headerProps = {
-    title: name,
-    introduction: description,
-    imageSrc: illustrationPerson4Peach,
-    imageAlt: 'alt.personTea',
-  };
-
   const Dots = () => {
     return (
       <Box sx={dotsStyle}>
@@ -259,17 +254,20 @@ const StoryblokSessionPage = (props: StoryblokSessionPageProps) => {
       })}
     >
       <Head>
-        <title>{name}</title>
+        <title>{`${name} • Bloom`}</title>
+        <meta property="og:title" content={name} key="og-title" />
+        <meta property="og:description" content={seo_description} key="og-description" />
       </Head>
+
       {incorrectAccess ? (
         <Container sx={containerStyle}></Container>
       ) : (
         <Box>
           <Header
-            title={headerProps.title}
-            introduction={headerProps.introduction}
-            imageSrc={headerProps.imageSrc}
-            imageAlt={headerProps.imageAlt}
+            title={name}
+            introduction={description}
+            imageSrc={illustrationPerson4Peach}
+            imageAlt={'alt.personTea'}
             progressStatus={sessionProgress}
           >
             <Button

--- a/components/storyblok/StoryblokWelcomePage.tsx
+++ b/components/storyblok/StoryblokWelcomePage.tsx
@@ -44,13 +44,23 @@ export interface StoryblokWelcomePageProps {
   _editable: string;
   storySlug: string;
   title: string;
+  seo_description: string;
   introduction: ISbRichtext;
   header_image: { filename: string; alt: string };
   page_sections: StoryblokPageSectionProps[];
 }
 
 const StoryblokWelcomePage = (props: StoryblokWelcomePageProps) => {
-  const { _uid, _editable, storySlug, title, introduction, header_image, page_sections } = props;
+  const {
+    _uid,
+    _editable,
+    storySlug,
+    title,
+    seo_description,
+    introduction,
+    header_image,
+    page_sections,
+  } = props;
 
   const partnerContent = getPartnerContent(storySlug) as PartnerContent;
 
@@ -119,8 +129,11 @@ const StoryblokWelcomePage = (props: StoryblokWelcomePageProps) => {
       })}
     >
       <Head>
-        <title>{title}</title>
+        <title>{`${title} • Bloom`}</title>
+        <meta property="og:title" content={title} key="og-title" />
+        <meta property="og:description" content={seo_description} key="og-description" />
       </Head>
+
       <PartnerHeader
         partnerLogoSrc={headerProps.partnerLogoSrc}
         partnerLogoAlt={headerProps.partnerLogoAlt}

--- a/components/storyblok/StoryblokWelcomePage.tsx
+++ b/components/storyblok/StoryblokWelcomePage.tsx
@@ -131,7 +131,9 @@ const StoryblokWelcomePage = (props: StoryblokWelcomePageProps) => {
       <Head>
         <title>{`${title} • Bloom`}</title>
         <meta property="og:title" content={title} key="og-title" />
-        <meta property="og:description" content={seo_description} key="og-description" />
+        {seo_description && (
+          <meta property="og:description" content={seo_description} key="og-description" />
+        )}
       </Head>
 
       <PartnerHeader

--- a/guards/PartnerAdminGuard.tsx
+++ b/guards/PartnerAdminGuard.tsx
@@ -30,7 +30,7 @@ export function PartnerAdminGuard({ children }: { children: JSX.Element }) {
     return (
       <Container sx={containerStyle}>
         <Head>
-          <title>{t('title')}</title>
+          <title>{`${t('title')} • Bloom`}</title>
         </Head>
         <Box sx={imageContainerStyle}>
           <Image

--- a/guards/SuperAdminGuard.tsx
+++ b/guards/SuperAdminGuard.tsx
@@ -28,7 +28,7 @@ export function SuperAdminGuard({ children }: { children: JSX.Element }) {
     return (
       <Container sx={containerStyle}>
         <Head>
-          <title>{t('title')}</title>
+          <title>{`${t('title')} • Bloom`}</title>
         </Head>
         <Box sx={imageContainerStyle}>
           <Image

--- a/guards/TherapyAccessGuard.tsx
+++ b/guards/TherapyAccessGuard.tsx
@@ -32,7 +32,7 @@ export function TherapyAccessGuard({ children }: { children: JSX.Element }) {
     return (
       <Container sx={containerStyle}>
         <Head>
-          <title>{t('title')}</title>
+          <title>{`${t('title')} • Bloom`}</title>
         </Head>
         <Box sx={imageContainerStyle}>
           <Image

--- a/messages/shared/de.json
+++ b/messages/shared/de.json
@@ -1,6 +1,11 @@
 {
   "Shared": {
     "bloom": "Bloom",
+    "metadata": {
+      "title": "Begleite uns während deines Heilungsprozesses",
+      "description": "Bloom ist dafür da, damit du Lernen, Heilen und Wachsen kannst, hin zu einer selbstbewussten Zukunft. Es wird dir von Chayn angeboten, einer globalen Non-Profit-Organisation, geführt von Überlebenden und Verbündeten aus der ganzen Welt.",
+      "imageAlt": "Illustration eines Gesichts und der Schultern einer Person, mit großen Blättern und Blumen, die über ihnen blühen. Das Bloom-Typografie-Logo ist enthalten."
+    },
     "leaveSite": {
       "button": "Seite verlassen",
       "wikiLink": "https://de.wikipedia.org/wiki/Main_Page",

--- a/messages/shared/en.json
+++ b/messages/shared/en.json
@@ -1,6 +1,11 @@
 {
   "Shared": {
     "bloom": "Bloom",
+    "metadata": {
+      "title": "Join us on your healing journey",
+      "description": "Bloom is here for you to learn, heal and grow towards a confident future. It is bought to you by Chayn, a global non-profit, run by survivors and allies from around the world.",
+      "imageAlt": "Illustration of a person's face and shoulders, with big leaves and flowers blooming above them. The Bloom typography logo is included."
+    },
     "leaveSite": {
       "button": "Leave this site",
       "wikiLink": "https://en.wikipedia.org/wiki/Main_Page",

--- a/messages/shared/es.json
+++ b/messages/shared/es.json
@@ -1,6 +1,11 @@
 {
   "Shared": {
     "bloom": "Bloom",
+    "metadata": {
+      "title": "Acompáñanos en tu viaje de sanación",
+      "description": "Bloom está aquí para que aprendas, sanes y crezcas hacia un futuro seguro. Es traído a ti por Chayn, una organización global sin fines de lucro, dirigida por sobrevivientes y aliados de todo el mundo.",
+      "imageAlt": "Ilustración de la cara y los hombros de una persona, con grandes hojas y flores floreciendo sobre ellos. El logotipo tipográfico Bloom está incluido."
+    },
     "leaveSite": {
       "button": "Salir de este sitio",
       "wikiLink": "https://es.wikipedia.org/wiki/Main_Page",

--- a/messages/shared/fr.json
+++ b/messages/shared/fr.json
@@ -1,6 +1,11 @@
 {
   "Shared": {
     "bloom": "Bloom",
+    "metadata": {
+      "title": "Rejoins-nous sur ton chemin de guérison",
+      "description": "Bloom est là pour te permettre d’apprendre, de guérir et d’évoluer vers un avenir confiant. Il vous est proposé par Chayn, une organisation mondiale à but non lucratif, dirigée par des survivants et des alliés du monde entier.",
+      "imageAlt": "Illustration d'un visage et d'épaules d'une personne, avec de grandes feuilles et des fleurs épanouies au-dessus d'eux. Le logo typographique Bloom est inclus."
+    },
     "leaveSite": {
       "button": "Sortir du site",
       "wikiLink": "https://fr.wikipedia.org/wiki/Main_Page",

--- a/messages/shared/hi.json
+++ b/messages/shared/hi.json
@@ -1,6 +1,11 @@
 {
   "Shared": {
     "bloom": "Bloom",
+    "metadata": {
+      "title": "Apne healing ke safar par humein join kariye",
+      "description": "Bloom aapke sath hai, taki aap apne ghavon se ubhraein, behtar banein aur aagey badein ek behtar future ke liye. Ye aapko Chayn dwara laya gaya hai, jo duniya bhar ke bache logon aur sahyogion dwara chalaya jane wala ek vishv vyaapi gair-laabhkar sanstha hai.",
+      "imageAlt": "Ek insan ke chehre aur kandhon ki tasveer, jiske upar bade patte aur phool khil rahe hain. Bloom ka logo bhi ismein shamil hai."
+    },
     "leaveSite": {
       "button": "Site ko chodiye",
       "wikiLink": "https://hi.wikipedia.org/wiki/Main_Page",

--- a/messages/shared/pt.json
+++ b/messages/shared/pt.json
@@ -1,6 +1,11 @@
 {
   "Shared": {
     "bloom": "Bloom",
+    "metadata": {
+      "title": "Junte-se a nós em sua jornada de recuperação",
+      "description": "Bloom está aqui para que você aprenda, se recupere e se mova em direção a um futuro confiante. É trazido a você por Chayn, uma organização global sem fins lucrativos, dirigida por sobreviventes e aliados de todo o mundo.",
+      "imageAlt": "Ilustração de um rosto e ombros de uma pessoa, com grandes folhas e flores desabrochando acima deles. O logotipo tipográfico Bloom está incluído."
+    },
     "leaveSite": {
       "button": "Sair deste site",
       "wikiLink": "https://pt.wikipedia.org/wiki/Main_Page",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -35,7 +35,7 @@ const Custom404: NextPage = () => {
   return (
     <Container sx={containerStyle}>
       <Head>
-        <title>{t('404.title')}</title>
+        <title>{`${t('404.title')} • Bloom`}</title>
       </Head>
       <Box sx={imageContainerStyle}>
         <Image alt={t('alt.bloomLogo')} src={bloomHead} fill sizes="100vw" />

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -35,7 +35,7 @@ const Custom500: NextPage = () => {
   return (
     <Container sx={containerStyle}>
       <Head>
-        <title>{t('500.title')}</title>
+        <title>{`${t('500.title')} • Bloom`}</title>
       </Head>
       <Box sx={imageContainerStyle}>
         <Image alt={t('alt.bloomHead')} src={bloomHead} fill sizes="100vw" />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,12 +6,12 @@ import { Analytics } from '@vercel/analytics/react';
 import { NextComponentType } from 'next';
 import { IntlError, NextIntlClientProvider } from 'next-intl';
 import type { AppProps } from 'next/app';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { NextPageContext } from 'next/types';
 import { Hotjar } from 'nextjs-hotjar';
 import { useEffect } from 'react';
 import { Provider } from 'react-redux';
+import DefaultHeadMetadata from '../components/head/DefaultHeadMetadata';
 import Consent from '../components/layout/Consent';
 import ErrorBoundary from '../components/layout/ErrorBoundary';
 import Footer from '../components/layout/Footer';
@@ -72,9 +72,7 @@ function MyApp(props: MyAppProps) {
         timeZone="Europe/London"
         onError={onIntlError}
       >
-        <Head>
-          <meta name="viewport" content="initial-scale=1, width=device-width" />
-        </Head>
+        <DefaultHeadMetadata />
         <ThemeProvider theme={theme}>
           <CssBaseline />
           <TopBar />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,7 +4,6 @@ import { AppType } from 'next/app';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 import * as React from 'react';
 import GoogleTagManagerScript from '../components/head/GoogleTagManagerScript';
-import OpenGraphMetadata from '../components/head/OpenGraphMetadata';
 import RollbarScript from '../components/head/RollbarScript';
 import createEmotionCache from '../config/emotionCache';
 import { MyAppProps } from './_app';
@@ -26,7 +25,6 @@ export default class MyDocument extends Document<NewRelicProps> {
             href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Open+Sans:ital,wght@0,300;0,400;0,600;1,300;1,400;1,600&display=swap"
             rel="stylesheet"
           />
-          <OpenGraphMetadata />
           <GoogleTagManagerScript />
           <RollbarScript />
         </Head>

--- a/pages/about-our-courses.tsx
+++ b/pages/about-our-courses.tsx
@@ -43,11 +43,13 @@ const CourseAbout: NextPage<Props> = ({ story }) => {
       <Head>
         <title>{`${story.content.title} • Bloom`}</title>
         <meta property="og:title" content={story.content.title} key="og-title" />
-        <meta
-          property="og:description"
-          content={story.content.seo_description}
-          key="og-description"
-        />
+        {story.content.seo_description && (
+          <meta
+            property="og:description"
+            content={story.content.seo_description}
+            key="og-description"
+          />
+        )}
       </Head>
       <Header
         title={headerProps.title}

--- a/pages/about-our-courses.tsx
+++ b/pages/about-our-courses.tsx
@@ -41,7 +41,13 @@ const CourseAbout: NextPage<Props> = ({ story }) => {
   return (
     <Box>
       <Head>
-        <title>{story.content.title}</title>
+        <title>{`${story.content.title} • Bloom`}</title>
+        <meta property="og:title" content={story.content.title} key="og-title" />
+        <meta
+          property="og:description"
+          content={story.content.seo_description}
+          key="og-description"
+        />
       </Head>
       <Header
         title={headerProps.title}

--- a/pages/account/about-you.tsx
+++ b/pages/account/about-you.tsx
@@ -75,7 +75,7 @@ const AboutYou: NextPage = () => {
   return (
     <Box>
       <Head>
-        <title>{t('title')}</title>
+        <title>{`${t('title')} • Bloom`}</title>
       </Head>
       <PartnerHeader
         partnerLogoSrc={headerProps.partnerLogoSrc}

--- a/pages/account/apply-a-code.tsx
+++ b/pages/account/apply-a-code.tsx
@@ -75,7 +75,7 @@ const ApplyACode: NextPage = () => {
   return (
     <Box>
       <Head>
-        <title>{t('applyCode.title')}</title>
+        <title>{`${t('applyCode.title')} • Bloom`}</title>
       </Head>
       <Header
         title={headerProps.title}

--- a/pages/account/disable-service-emails.tsx
+++ b/pages/account/disable-service-emails.tsx
@@ -57,7 +57,7 @@ const DisableServiceEmails: NextPage = () => {
   return (
     <Box>
       <Head>
-        <title>{t('title')}</title>
+        <title>{`${t('title')} • Bloom`}</title>
       </Head>
       {error && (
         <Container>

--- a/pages/account/settings.tsx
+++ b/pages/account/settings.tsx
@@ -41,7 +41,7 @@ const AccountSettings: NextPage = () => {
   return (
     <Box bgcolor={'secondary.light'}>
       <Head>
-        <title>{t('title')}</title>
+        <title>{`${t('title')} • Bloom`}</title>
       </Head>
       <Header
         title={headerProps.title}

--- a/pages/admin/dashboard.tsx
+++ b/pages/admin/dashboard.tsx
@@ -4,8 +4,8 @@ import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { useEffect } from 'react';
 import CreatePartnerAdminForm from '../../components/forms/CreatePartnerAdminForm';
-import UpdateTherapyAdminForm from '../../components/forms/UpdateTherapyAdminForm';
 import UpdatePartnerAdminForm from '../../components/forms/UpdatePartnerAdminForm';
+import UpdateTherapyAdminForm from '../../components/forms/UpdateTherapyAdminForm';
 import AdminHeader from '../../components/layout/PartnerAdminHeader';
 import { CREATE_PARTNER_ACCESS_VIEWED } from '../../constants/events';
 import { useTypedSelector } from '../../hooks/store';
@@ -40,7 +40,7 @@ const Dashboard: NextPage = () => {
   return (
     <Box>
       <Head>
-        <title>{headerProps.title}</title>
+        <title>{`${headerProps.title} • Bloom`}</title>
       </Head>
       <AdminHeader title={headerProps.title} />
       <Container sx={containerStyle}>

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -131,7 +131,7 @@ const Login: NextPage = () => {
   return (
     <Box>
       <Head>
-        <title>{t('login.title')}</title>
+        <title>{`${t('login.title')} • Bloom`}</title>
       </Head>
       <PartnerHeader
         partnerLogoSrc={headerProps.partnerLogoSrc}

--- a/pages/auth/register.tsx
+++ b/pages/auth/register.tsx
@@ -179,7 +179,7 @@ const Register: NextPage = () => {
   return (
     <Box>
       <Head>
-        <title>{t('register.title')}</title>
+        <title>{`${t('register.title')} • Bloom`}</title>
       </Head>
       <PartnerHeader
         partnerLogoSrc={headerProps.partnerLogoSrc}

--- a/pages/auth/reset-password.tsx
+++ b/pages/auth/reset-password.tsx
@@ -43,7 +43,7 @@ const ResetPassword: NextPage = () => {
   return (
     <Box>
       <Head>
-        <title>{t('resetPassword.title')}</title>
+        <title>{`${t('resetPassword.title')} • Bloom`}</title>
       </Head>
       <PartnerHeader
         partnerLogoSrc={headerProps.partnerLogoSrc}

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -128,7 +128,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
     return (
       <Box>
         <Head>
-          <title>{t('title')}</title>
+          <title>{`${t('title')} • Bloom`}</title>
         </Head>
         <Header
           title={headerProps.title}
@@ -191,7 +191,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
   return (
     <Box>
       <Head>
-        <title>{t('title')}</title>
+        <title>{`${t('title')} • Bloom`}</title>
       </Head>
       <Header
         title={headerProps.title}

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -52,7 +52,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
   const courses = useTypedSelector((state) => state.courses);
 
   const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
-  const liveCourseAccess = partnerAccesses.length === 0 && !partnerAdmin.id;
+  const liveCourseAccess = !!userId; // soon to be retired in issue 1176
   const t = useTranslations('Courses');
 
   const headerProps = {
@@ -123,62 +123,6 @@ const CourseList: NextPage<Props> = ({ stories }) => {
       setCoursesCompleted(courseCoursesCompleted);
     }
   }, [partnerAccesses, partnerAdmin, stories, courses]);
-  // Show sign up banner if user is logged out
-  if (!userId) {
-    return (
-      <Box>
-        <Head>
-          <title>{`${t('title')} • Bloom`}</title>
-        </Head>
-        <Header
-          title={headerProps.title}
-          introduction={headerProps.introduction}
-          imageSrc={headerProps.imageSrc}
-          imageAlt={headerProps.imageAlt}
-        />
-        <Container sx={containerStyle}>
-          {loadedCourses === null ? (
-            <LoadingContainer />
-          ) : loadedCourses.length === 0 ? (
-            // Leaving blank instead of saying no courses are available
-            <Box></Box>
-          ) : (
-            <Box sx={rowStyle}>
-              <Box sx={cardColumnStyle}>
-                {loadedCourses?.map((course, index) => {
-                  if (index % 2 === 1) return;
-                  return (
-                    <CourseCard
-                      key={course.id}
-                      clickable={true}
-                      course={course}
-                      courseProgress={null}
-                      liveCourseAccess={false}
-                    />
-                  );
-                })}
-              </Box>
-              <Box sx={cardColumnStyle}>
-                {loadedCourses?.map((course, index) => {
-                  if (index % 2 === 0) return;
-                  return (
-                    <CourseCard
-                      key={course.id}
-                      clickable={true}
-                      course={course}
-                      courseProgress={null}
-                      liveCourseAccess={false}
-                    />
-                  );
-                })}
-              </Box>
-            </Box>
-          )}
-        </Container>
-        <SignUpBanner />
-      </Box>
-    );
-  }
 
   const getCourseProgress = (courseId: number) => {
     return coursesStarted.includes(courseId)
@@ -192,6 +136,8 @@ const CourseList: NextPage<Props> = ({ stories }) => {
     <Box>
       <Head>
         <title>{`${t('title')} • Bloom`}</title>
+        <meta property="og:title" content={t('courses')} key="og-title" />
+        <meta property="og:description" content={t('introduction')} key="og-description" />
       </Head>
       <Header
         title={headerProps.title}
@@ -211,7 +157,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
             <Box sx={cardColumnStyle}>
               {loadedCourses?.map((course, index) => {
                 if (index % 2 === 1) return;
-                const courseProgress = getCourseProgress(course.id);
+                const courseProgress = userId ? getCourseProgress(course.id) : null;
                 return (
                   <CourseCard
                     key={course.id}
@@ -225,7 +171,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
             <Box sx={cardColumnStyle}>
               {loadedCourses?.map((course, index) => {
                 if (index % 2 === 0) return;
-                const courseProgress = getCourseProgress(course.id);
+                const courseProgress = userId ? getCourseProgress(course.id) : null;
                 return (
                   <CourseCard
                     key={course.id}
@@ -239,7 +185,8 @@ const CourseList: NextPage<Props> = ({ stories }) => {
           </Box>
         )}
       </Container>
-      {!!showEmailRemindersBanner && <EmailRemindersSettingsBanner />}
+      {!userId && <SignUpBanner />}
+      {!!userId && !!showEmailRemindersBanner && <EmailRemindersSettingsBanner />}
     </Box>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -47,11 +47,13 @@ const Index: NextPage<Props> = ({ story, preview }) => {
       <Head>
         <title>{`${story.content.title} • Bloom`}</title>
         <meta property="og:title" content={story.content.title} key="og-title" />
-        <meta
-          property="og:description"
-          content={story.content.seo_description}
-          key="og-description"
-        />
+        {story.content.seo_description && (
+          <meta
+            property="og:description"
+            content={story.content.seo_description}
+            key="og-description"
+          />
+        )}
       </Head>
       <HomeHeader
         title={story.content.title}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,7 +45,13 @@ const Index: NextPage<Props> = ({ story, preview }) => {
   return (
     <Box>
       <Head>
-        <title>{story.content.title}</title>
+        <title>{`${story.content.title} • Bloom`}</title>
+        <meta property="og:title" content={story.content.title} key="og-title" />
+        <meta
+          property="og:description"
+          content={story.content.seo_description}
+          key="og-description"
+        />
       </Head>
       <HomeHeader
         title={story.content.title}

--- a/pages/messaging.tsx
+++ b/pages/messaging.tsx
@@ -52,11 +52,13 @@ const Message: NextPage<Props> = ({ story }) => {
       <Head>
         <title>{`${story.content.title} • Bloom`}</title>
         <meta property="og:title" content={story.content.title} key="og-title" />
-        <meta
-          property="og:description"
-          content={story.content.seo_description}
-          key="og-description"
-        />
+        {story.content.seo_description && (
+          <meta
+            property="og:description"
+            content={story.content.seo_description}
+            key="og-description"
+          />
+        )}
       </Head>
       <Box>
         <Header {...headerProps} />

--- a/pages/messaging.tsx
+++ b/pages/messaging.tsx
@@ -50,8 +50,14 @@ const Message: NextPage<Props> = ({ story }) => {
   return (
     <>
       <Head>
-        <title>{headerProps.title}</title>
-      </Head>{' '}
+        <title>{`${story.content.title} • Bloom`}</title>
+        <meta property="og:title" content={story.content.title} key="og-title" />
+        <meta
+          property="og:description"
+          content={story.content.seo_description}
+          key="og-description"
+        />
+      </Head>
       <Box>
         <Header {...headerProps} />
         {userId ? (

--- a/pages/partner-admin/create-access-code.tsx
+++ b/pages/partner-admin/create-access-code.tsx
@@ -41,7 +41,7 @@ const CreateAccessCode: NextPage = () => {
   return (
     <Box>
       <Head>
-        <title>{t('title')}</title>
+        <title>{`${t('title')} • Bloom`}</title>
       </Head>
       <AdminHeader
         title={headerProps.title}

--- a/pages/subscription/whatsapp.tsx
+++ b/pages/subscription/whatsapp.tsx
@@ -84,11 +84,13 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story }) => {
       <Head>
         <title>{`${story.content.title} • Bloom`}</title>
         <meta property="og:title" content={story.content.title} key="og-title" />
-        <meta
-          property="og:description"
-          content={story.content.seo_description}
-          key="og-description"
-        />
+        {story.content.seo_description && (
+          <meta
+            property="og:description"
+            content={story.content.seo_description}
+            key="og-description"
+          />
+        )}
       </Head>
       <Box>
         <Header {...headerProps} />

--- a/pages/subscription/whatsapp.tsx
+++ b/pages/subscription/whatsapp.tsx
@@ -82,7 +82,13 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story }) => {
   return (
     <>
       <Head>
-        <title>{story.content.title}</title>
+        <title>{`${story.content.title} • Bloom`}</title>
+        <meta property="og:title" content={story.content.title} key="og-title" />
+        <meta
+          property="og:description"
+          content={story.content.seo_description}
+          key="og-description"
+        />
       </Head>
       <Box>
         <Header {...headerProps} />

--- a/pages/therapy/book-session.tsx
+++ b/pages/therapy/book-session.tsx
@@ -120,7 +120,7 @@ const BookSession: NextPage = () => {
   return (
     <Box>
       <Head>
-        <title>{t('title')}</title>
+        <title>{`${t('title')} • Bloom`}</title>
       </Head>
       <Header
         title={headerProps.title}

--- a/pages/therapy/confirmed-session.tsx
+++ b/pages/therapy/confirmed-session.tsx
@@ -65,7 +65,7 @@ const ConfirmedSession: NextPage = () => {
   return (
     <Box>
       <Head>
-        <title>{t('title')}</title>
+        <title>{`${t('title')} • Bloom`}</title>
       </Head>
       <Header
         title={headerProps.title}


### PR DESCRIPTION
### What changes did you make and why did you make them?
Adds SEO description fields to storyblok pages, and also improves title formatting.

**Changes made to SEO text**

- SEO descriptions are now set in a fallback series depending on which fields have been filled.  seo_description -> page header description -> default seo description i.e. “Join us on your healing journey”
- SEO titles are currently set to the page title/heading. We could also consider adding custom seo titles too - e.g. “Bloom courses for survivors” instead of “Courses” and “Message the Bloom team” instead of “Messaging”

**Changes made to browser tab titles**

- added “ • Bloom” to all pages (browser tab). E.g. “Meet the team • Bloom”
- added `Course • Course name • Bloom` to course title (browser tab) and `Session • Session name • Bloom` to session title. See screenshot

Improved title formatting for courses:
<img width="298" alt="Screenshot 2024-11-04 at 16 55 09" src="https://github.com/user-attachments/assets/7c6b771b-e4e5-4b8e-b36d-9646f6b3ef46">
