### PR TITLE
Fix user messaging test string

### DIFF
--- a/cypress/integration/tests/user-messaging.cy.tsx
+++ b/cypress/integration/tests/user-messaging.cy.tsx
@@ -16,7 +16,7 @@ describe('A logged in public user can', () => {
   it('see the More about section', () => {
     cy.visit('/messaging');
     cy.get('h2').contains('Tell us what’s on your mind');
-    cy.get('h2').contains('Meet the Bloom team');
+    cy.get('h2').contains('Meet the Bloom messaging team');
     cy.get('h2').contains('More about how Bloom’s Messaging works');
     cy.checkImage('Illustration of a person sitting', 'illustration_course_dbr');
     cy.get('h3').contains('Who is 1-1 Messaging for?');


### PR DESCRIPTION
### What changes did you make and why did you make them?
Fixes failing user messaging test following the heading string being updated in storyblok by the team.

### Did you run tests? Share screenshot of results:
Yes see below
