### PR TITLE
Add description meta for SEO

### DIFF
--- a/components/head/DefaultHeadMetadata.tsx
+++ b/components/head/DefaultHeadMetadata.tsx
@@ -8,6 +8,7 @@ const DefaultHeadMetadata = () => {
   return (
     <Head>
       <meta name="viewport" content="initial-scale=1, width=device-width" />
+      <meta property="description" content={t('description')} key="description" />
       <meta property="og:title" content={t('title')} key="og-title" />
       <meta property="og:description" content={t('description')} key="og-description" />
       <meta property="og:image" content="/preview.png" key="og-image" />

--- a/components/storyblok/StoryblokCoursePage.tsx
+++ b/components/storyblok/StoryblokCoursePage.tsx
@@ -178,7 +178,10 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
         <title>{`${t('course')} • ${name} • Bloom`}</title>
         <meta property="og:title" content={name} key="og-title" />
         {seo_description && (
-          <meta property="og:description" content={seo_description} key="og-description" />
+          <>
+            <meta property="description" content={seo_description} key="description" />
+            <meta property="og:description" content={seo_description} key="og-description" />
+          </>
         )}
       </Head>
       <CourseHeader

--- a/components/storyblok/StoryblokMeetTheTeamPage.tsx
+++ b/components/storyblok/StoryblokMeetTheTeamPage.tsx
@@ -88,8 +88,19 @@ const StoryblokMeetTheTeamPage = (props: StoryblokMeetTheTeamPageProps) => {
       <Head>
         <title>{`${title} • Bloom`}</title>
         <meta property="og:title" content={title} key="og-title" />
-        {seo_description && (
-          <meta property="og:description" content={seo_description} key="og-description" />
+        {(seo_description || description) && (
+          <>
+            <meta
+              property="description"
+              content={seo_description || description}
+              key="description"
+            />
+            <meta
+              property="og:description"
+              content={seo_description || description}
+              key="og-description"
+            />
+          </>
         )}
       </Head>
       <Header

--- a/components/storyblok/StoryblokPage.tsx
+++ b/components/storyblok/StoryblokPage.tsx
@@ -39,7 +39,10 @@ const StoryblokPage = (props: StoryblokPageProps) => {
         <title>{`${title} • Bloom`}</title>
         <meta property="og:title" content={title} key="og-title" />
         {seo_description && (
-          <meta property="og:description" content={seo_description} key="og-description" />
+          <>
+            <meta property="description" content={seo_description} key="description" />
+            <meta property="og:description" content={seo_description} key="og-description" />
+          </>
         )}
       </Head>
       <main

--- a/components/storyblok/StoryblokSessionPage.tsx
+++ b/components/storyblok/StoryblokSessionPage.tsx
@@ -158,8 +158,19 @@ const StoryblokSessionPage = (props: StoryblokSessionPageProps) => {
       <Head>
         <title>{`${t('session')} • ${name} • Bloom`}</title>
         <meta property="og:title" content={name} key="og-title" />
-        {seo_description && (
-          <meta property="og:description" content={seo_description} key="og-description" />
+        {(seo_description || description) && (
+          <>
+            <meta
+              property="description"
+              content={seo_description || description}
+              key="description"
+            />
+            <meta
+              property="og:description"
+              content={seo_description || description}
+              key="og-description"
+            />
+          </>
         )}
       </Head>
 

--- a/components/storyblok/StoryblokWelcomePage.tsx
+++ b/components/storyblok/StoryblokWelcomePage.tsx
@@ -132,7 +132,10 @@ const StoryblokWelcomePage = (props: StoryblokWelcomePageProps) => {
         <title>{`${title} • Bloom`}</title>
         <meta property="og:title" content={title} key="og-title" />
         {seo_description && (
-          <meta property="og:description" content={seo_description} key="og-description" />
+          <>
+            <meta property="description" content={seo_description} key="description" />
+            <meta property="og:description" content={seo_description} key="og-description" />
+          </>
         )}
       </Head>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -48,11 +48,18 @@ const Index: NextPage<Props> = ({ story, preview }) => {
         <title>{`${story.content.title} • Bloom`}</title>
         <meta property="og:title" content={story.content.title} key="og-title" />
         {story.content.seo_description && (
-          <meta
-            property="og:description"
-            content={story.content.seo_description}
-            key="og-description"
-          />
+          <>
+            <meta
+              property="description"
+              content={story.content.seo_description}
+              key="description"
+            />
+            <meta
+              property="og:description"
+              content={story.content.seo_description}
+              key="og-description"
+            />
+          </>
         )}
       </Head>
       <HomeHeader

--- a/pages/messaging.tsx
+++ b/pages/messaging.tsx
@@ -53,11 +53,18 @@ const Message: NextPage<Props> = ({ story }) => {
         <title>{`${story.content.title} • Bloom`}</title>
         <meta property="og:title" content={story.content.title} key="og-title" />
         {story.content.seo_description && (
-          <meta
-            property="og:description"
-            content={story.content.seo_description}
-            key="og-description"
-          />
+          <>
+            <meta
+              property="description"
+              content={story.content.seo_description}
+              key="description"
+            />
+            <meta
+              property="og:description"
+              content={story.content.seo_description}
+              key="og-description"
+            />
+          </>
         )}
       </Head>
       <Box>

--- a/pages/subscription/whatsapp.tsx
+++ b/pages/subscription/whatsapp.tsx
@@ -85,11 +85,18 @@ const ManageWhatsappSubscription: NextPage<Props> = ({ story }) => {
         <title>{`${story.content.title} • Bloom`}</title>
         <meta property="og:title" content={story.content.title} key="og-title" />
         {story.content.seo_description && (
-          <meta
-            property="og:description"
-            content={story.content.seo_description}
-            key="og-description"
-          />
+          <>
+            <meta
+              property="description"
+              content={story.content.seo_description}
+              key="description"
+            />
+            <meta
+              property="og:description"
+              content={story.content.seo_description}
+              key="og-description"
+            />
+          </>
         )}
       </Head>
       <Box>


### PR DESCRIPTION
### What changes did you make and why did you make them?
Adds base `description` meta tag following #1185  to improve SEO. 
Previously thought `og:description` was the required meta, but both are required.