### PR TITLE
Add cookiesAccepted state + refactor set cookies

### DIFF
--- a/.github/workflows/community-slackpost-repo-activity.yml
+++ b/.github/workflows/community-slackpost-repo-activity.yml
@@ -10,7 +10,7 @@ name: Contributor Activity Slack Bot
 on:
   workflow_dispatch: # enables manual trigger
   schedule:
-    - cron: "0 0 1,15 * *" # Runs at 00:00 on the 1st and 15th of every month
+    - cron: '0 0 1,15 * *' # Runs at 00:00 on the 1st and 15th of every month
 
 jobs:
   gather-gh-activity:
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4 # https://github.com/actions/setup-node
         with:
-          node-version: "20"
+          node-version: '20'
 
       - name: Install dependencies
         run: |

--- a/components/banner/SignUpBanner.tsx
+++ b/components/banner/SignUpBanner.tsx
@@ -1,4 +1,5 @@
 import { Button, Container, Typography } from '@mui/material';
+import Cookies from 'js-cookie';
 import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 import { SIGN_UP_TODAY_BANNER_BUTTON_CLICKED } from '../../constants/events';
@@ -21,7 +22,7 @@ export const SignUpBanner = () => {
   const [registerPath, setRegisterPath] = useState('/auth/register');
 
   useEffect(() => {
-    const referralPartner = window.localStorage.getItem('referralPartner');
+    const referralPartner = Cookies.get('referralPartner');
 
     if (referralPartner) {
       setRegisterPath(`/auth/register?partner=${referralPartner}`);

--- a/components/banner/UserResearchBanner.tsx
+++ b/components/banner/UserResearchBanner.tsx
@@ -24,6 +24,7 @@ export default function UserResearchBanner() {
   const [open, setOpen] = React.useState(true);
 
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const userCookiesAccepted = useTypedSelector((state) => state.user.cookiesAccepted);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
@@ -41,6 +42,21 @@ export default function UserResearchBanner() {
   );
 
   const showBanner = isBannerFeatureEnabled && isBadooUser && isTargetPage && isBannerNotInteracted;
+
+  const handleClickAccepted = () => {
+    if (userCookiesAccepted) Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
+    logEvent(USER_BANNER_INTERESTED, eventUserData);
+    setOpen(false);
+
+    window.open(USER_RESEARCH_FORM_LINK, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleClickDeclined = () => {
+    if (userCookiesAccepted) Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
+    logEvent(USER_BANNER_DISMISSED, eventUserData);
+    setOpen(false);
+  };
+
   return showBanner ? (
     <Stack sx={{ width: '100%' }} spacing={2}>
       <Collapse in={open}>
@@ -49,30 +65,10 @@ export default function UserResearchBanner() {
           sx={alertStyle}
           action={
             <>
-              <Button
-                color="inherit"
-                size="medium"
-                onClick={() => {
-                  Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
-                  logEvent(USER_BANNER_INTERESTED, eventUserData);
-
-                  setOpen(false);
-
-                  window.open(USER_RESEARCH_FORM_LINK, '_blank', 'noopener,noreferrer');
-                }}
-              >
+              <Button color="inherit" size="medium" onClick={handleClickAccepted}>
                 I’m interested
               </Button>
-              <Button
-                color="inherit"
-                size="medium"
-                onClick={() => {
-                  Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
-                  logEvent(USER_BANNER_DISMISSED, eventUserData);
-
-                  setOpen(false);
-                }}
-              >
+              <Button color="inherit" size="medium" onClick={handleClickDeclined}>
                 Dismiss
               </Button>
             </>

--- a/components/cards/CourseCard.tsx
+++ b/components/cards/CourseCard.tsx
@@ -145,7 +145,6 @@ const CourseCard = (props: CourseCardProps) => {
             <Typography>{t('comingSoon')}</Typography>
           </Box>
         )}
-       
 
         <IconButton
           sx={{ marginLeft: 'auto' }}

--- a/components/cards/CourseCard.tsx
+++ b/components/cards/CourseCard.tsx
@@ -13,7 +13,6 @@ import {
 import { ISbStoryData } from '@storyblok/react';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { PROGRESS_STATUS } from '../../constants/enums';
 import { iconTextRowStyle, rowStyle } from '../../styles/common';
@@ -74,12 +73,8 @@ const CourseCard = (props: CourseCardProps) => {
   const { course, courseProgress, clickable = true } = props;
   const [expanded, setExpanded] = useState<boolean>(false);
   const t = useTranslations('Courses');
-  const router = useRouter();
-  const locale = router.locale || 'en';
 
   const courseComingSoon: boolean = course.content.coming_soon;
-
-  const courseLiveSoon = course.content.live_soon || false;
 
   const handleExpandClick = () => {
     setExpanded(!expanded);

--- a/components/cards/CourseCard.tsx
+++ b/components/cards/CourseCard.tsx
@@ -17,7 +17,6 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { PROGRESS_STATUS } from '../../constants/enums';
 import { iconTextRowStyle, rowStyle } from '../../styles/common';
-import { formatDateToString } from '../../utils/dateTime';
 import Link from '../common/Link';
 import ProgressStatus from '../common/ProgressStatus';
 
@@ -139,7 +138,7 @@ const CourseCard = (props: CourseCardProps) => {
         </CardContent>
       )}
       <CardActions sx={cardActionsStyle}>
-        {courseComingSoon && !courseLiveSoon && (
+        {courseComingSoon && (
           <Box sx={statusRowStyle}>
             <PendingOutlined color="error" />
             <Typography>{t('comingSoon')}</Typography>

--- a/components/layout/Consent.tsx
+++ b/components/layout/Consent.tsx
@@ -2,16 +2,18 @@ import { getAnalytics } from '@firebase/analytics';
 import { Box, Button, alpha, useMediaQuery, useTheme } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
-import React from 'react';
-import CookieConsent from 'react-cookie-consent';
+import React, { useEffect } from 'react';
+import CookieConsent, { getCookieConsentValue } from 'react-cookie-consent';
 import { COOKIES_ACCEPTED, COOKIES_REJECTED } from '../../constants/events';
-import { useTypedSelector } from '../../hooks/store';
+import { useAppDispatch, useTypedSelector } from '../../hooks/store';
 import IllustrationCookieCat from '../../public/illustration_cookie_cat.svg';
+import { setCookiesAccepted } from '../../store/userSlice';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 import Link from '../common/Link';
 
 const Consent = (props: {}) => {
   const theme = useTheme();
+  const dispatch = useAppDispatch();
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
@@ -67,6 +69,13 @@ const Consent = (props: {}) => {
     });
     logEvent(COOKIES_ACCEPTED, eventUserData);
   };
+
+  useEffect(() => {
+    const cookieConsent = getCookieConsentValue('analyticsConsent');
+    if (cookieConsent && cookieConsent === 'true') {
+      dispatch(setCookiesAccepted(true));
+    }
+  }, [dispatch]);
 
   return (
     <CookieConsent

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -16,6 +16,7 @@ import comicReliefLogo from '../../public/comic_relief_logo.png';
 import communityFundLogo from '../../public/community_fund_logo.svg';
 import tiktokLogo from '../../public/tiktok.svg';
 
+import Cookies from 'js-cookie';
 import { rowStyle } from '../../styles/common';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 import Link from '../common/Link';
@@ -127,7 +128,7 @@ const Footer = () => {
       addUniquePartner(partnersList, partnerName);
     }
 
-    const referralPartner = window.localStorage.getItem('referralPartner');
+    const referralPartner = Cookies.get('referralPartner');
 
     if (referralPartner) {
       addUniquePartner(partnersList, referralPartner);

--- a/components/storyblok/StoryblokCoursePage.tsx
+++ b/components/storyblok/StoryblokCoursePage.tsx
@@ -1,5 +1,6 @@
 import { Box, Container, Typography } from '@mui/material';
 import { ISbRichtext, storyblokEditable } from '@storyblok/react';
+import Cookies from 'js-cookie';
 import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import { useEffect, useState } from 'react';
@@ -91,7 +92,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
 
   useEffect(() => {
     const storyPartners = included_for_partners;
-    const referralPartner = window.localStorage.getItem('referralPartner');
+    const referralPartner = Cookies.get('referralPartner');
 
     setIncorrectAccess(
       !hasAccessToPage(

--- a/hooks/store.ts
+++ b/hooks/store.ts
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie';
 import { useCallback } from 'react';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { api } from '../store/api';
@@ -19,7 +20,7 @@ export const useStateUtils = () => {
     await dispatch(clearCoursesSlice());
     await dispatch(clearUserSlice());
     await dispatch(api.util.resetApiState());
-    window.localStorage.removeItem('referralPartner');
+    Cookies.remove('referralPartner');
   }, [dispatch]);
 
   return { clearState };

--- a/hooks/useReferralPartner.ts
+++ b/hooks/useReferralPartner.ts
@@ -1,17 +1,19 @@
+import Cookies from 'js-cookie';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { setEntryPartnerAccessCode, setEntryPartnerReferral } from '../store/userSlice';
-import { useAppDispatch } from './store';
+import { useAppDispatch, useTypedSelector } from './store';
 
 // Check if entry path is from a partner referral and if so, store referring partner and code in state and local storage
 // This enables us to redirect a user to the correct sign up page later (e.g. in SignUpBanner)
 export default function useReferralPartner() {
   const router = useRouter();
   const dispatch = useAppDispatch();
+  const userCookiesAccepted = useTypedSelector((state) => state.user.cookiesAccepted);
 
   useEffect(() => {
     async function setReferralPartner(referralPartner: string) {
-      window.localStorage.setItem('referralPartner', referralPartner);
+      if (userCookiesAccepted) Cookies.set('referralPartner', referralPartner);
       await dispatch(setEntryPartnerReferral(referralPartner));
     }
     async function setReferralCode(referralCode: string) {

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -75,7 +75,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
   }, [userEmailRemindersFrequency]);
 
   useEffect(() => {
-    const referralPartner = window.localStorage.getItem('referralPartner');
+    const referralPartner = Cookies.get('referralPartner');
 
     if (partnerAdmin && partnerAdmin.partner) {
       const partnerName = partnerAdmin.partner.name;
@@ -158,11 +158,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
                 if (index % 2 === 1) return;
                 const courseProgress = userId ? getCourseProgress(course.id) : null;
                 return (
-                  <CourseCard
-                    key={course.id}
-                    course={course}
-                    courseProgress={courseProgress}
-                  />
+                  <CourseCard key={course.id} course={course} courseProgress={courseProgress} />
                 );
               })}
             </Box>
@@ -171,11 +167,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
                 if (index % 2 === 0) return;
                 const courseProgress = userId ? getCourseProgress(course.id) : null;
                 return (
-                  <CourseCard
-                    key={course.id}
-                    course={course}
-                    courseProgress={courseProgress}
-                  />
+                  <CourseCard key={course.id} course={course} courseProgress={courseProgress} />
                 );
               })}
             </Box>

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Container, Typography } from '@mui/material';
 import { ISbStoriesParams, ISbStoryData, getStoryblokApi } from '@storyblok/react';
+import Cookies from 'js-cookie';
 import { GetStaticPropsContext, NextPage } from 'next';
 import { useTranslations } from 'next-intl';
 import Head from 'next/head';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Button } from '@mui/material';
 import { ISbStoryData, useStoryblokState } from '@storyblok/react';
+import Cookies from 'js-cookie';
 import type { NextPage } from 'next';
 import { GetStaticPropsContext } from 'next';
 import { useTranslations } from 'next-intl';
@@ -31,7 +32,7 @@ const Index: NextPage<Props> = ({ story, preview }) => {
   const [registerPath, setRegisterPath] = useState('/auth/register');
 
   useEffect(() => {
-    const referralPartner = window.localStorage.getItem('referralPartner');
+    const referralPartner = Cookies.get('referralPartner');
 
     if (referralPartner) {
       setRegisterPath(`/auth/register?partner=${referralPartner}`);

--- a/store/userSlice.tsx
+++ b/store/userSlice.tsx
@@ -25,6 +25,7 @@ export interface User {
   authStateLoading: boolean;
   entryPartnerAccessCode: string | null;
   entryPartnerReferral: string | null;
+  cookiesAccepted: boolean;
 }
 
 // GetUserDto is the response format of the Get User endpoint
@@ -84,6 +85,7 @@ const initialState: User = {
   authStateLoading: true,
   entryPartnerAccessCode: null,
   entryPartnerReferral: null,
+  cookiesAccepted: false,
 };
 
 const slice = createSlice({
@@ -95,6 +97,9 @@ const slice = createSlice({
     },
     setUserToken(state, action: PayloadAction<string>) {
       state.token = action.payload;
+    },
+    setCookiesAccepted(state, action: PayloadAction<boolean>) {
+      state.cookiesAccepted = action.payload;
     },
     setEntryPartnerReferral(state, action: PayloadAction<string>) {
       state.entryPartnerReferral = action.payload;
@@ -163,6 +168,7 @@ export const {
   setUserToken,
   setUserLoading,
   setAuthStateLoading,
+  setCookiesAccepted,
   setLoadError,
   setEntryPartnerAccessCode,
   setEntryPartnerReferral,


### PR DESCRIPTION
### Resolves prep for issue #1207 

### What changes did you make and why did you make them?
Adds `cookiesAccepted` state property to `userSlice`. This can now be used to determine whether to set cookies, as required in upcoming task #1207 

Also refactors existing use of cookies to ensure all cookies use the `Cookies` package instead of `window.localStorage.setItem`

