### PR TITLE
Add crisp event trigger

### DIFF
--- a/components/crisp/CrispIframe.tsx
+++ b/components/crisp/CrispIframe.tsx
@@ -5,7 +5,7 @@ import logEvent, { getEventUserData } from '../../utils/logEvent';
 
 const iframeContainerStyle = {
   width: '100%',
-  height: '400px',
+  height: '450px',
   marginTop: { md: -2 },
   marginBottom: 3,
   maxHeight: '70vh',
@@ -16,7 +16,7 @@ const iframeContainerStyle = {
 } as const;
 
 const iframeStyle = {
-  marginTop: -158,
+  marginTop: -110,
   borderRadius: 16,
   maxHeight: 'calc(70vh + 158px)',
 } as const;
@@ -66,6 +66,11 @@ export const CrispIframe = () => {
       if (process.env.NEXT_PUBLIC_ENV === 'production') {
         crisp.push(['safe', true]); // Turns on safe mode = turns off errors in production
       }
+
+      // Send custom event widget:loaded each time the widget is loaded
+      // Acts as a trigger to overwrite the initial message - see AI automations -> chatbox triggers
+      crisp.push(['set', 'session:event', 'widget:loaded']);
+      // Set user email to set the contact
       crisp.push(['set', 'user:email', [userEmail]]);
 
       crisp.push([


### PR DESCRIPTION
### What changes did you make and why did you make them?
Added crisp event `widget:loaded` which triggers our AI automations -> chatbox triggers. The chatbox trigger is responsible for sending/replacing the first crisp message with a translated one

<img width="1618" alt="Screenshot 2024-11-26 at 21 17 13" src="https://github.com/user-attachments/assets/05dac057-fa6e-4f42-bd14-ba40e7c8ad64">
