### PR TITLE
Fix referral partner state fallback

### DIFF
--- a/components/banner/SignUpBanner.tsx
+++ b/components/banner/SignUpBanner.tsx
@@ -16,13 +16,14 @@ const containerStyle = {
 export const SignUpBanner = () => {
   const t = useTranslations('Shared');
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const entryPartnerReferral = useTypedSelector((state) => state.user.entryPartnerReferral);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
   const [registerPath, setRegisterPath] = useState('/auth/register');
 
   useEffect(() => {
-    const referralPartner = Cookies.get('referralPartner');
+    const referralPartner = Cookies.get('referralPartner') || entryPartnerReferral;
 
     if (referralPartner) {
       setRegisterPath(`/auth/register?partner=${referralPartner}`);

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -95,6 +95,7 @@ const Footer = () => {
   const router = useRouter();
 
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const entryPartnerReferral = useTypedSelector((state) => state.user.entryPartnerReferral);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
 
@@ -128,7 +129,7 @@ const Footer = () => {
       addUniquePartner(partnersList, partnerName);
     }
 
-    const referralPartner = Cookies.get('referralPartner');
+    const referralPartner = Cookies.get('referralPartner') || entryPartnerReferral;
 
     if (referralPartner) {
       addUniquePartner(partnersList, referralPartner);

--- a/components/storyblok/StoryblokCoursePage.tsx
+++ b/components/storyblok/StoryblokCoursePage.tsx
@@ -81,6 +81,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
 
   const t = useTranslations('Courses');
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const entryPartnerReferral = useTypedSelector((state) => state.user.entryPartnerReferral);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const courses = useTypedSelector((state) => state.courses);
@@ -92,7 +93,7 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
 
   useEffect(() => {
     const storyPartners = included_for_partners;
-    const referralPartner = Cookies.get('referralPartner');
+    const referralPartner = Cookies.get('referralPartner') || entryPartnerReferral;
 
     setIncorrectAccess(
       !hasAccessToPage(

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -48,6 +48,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
   const userEmailRemindersFrequency = useTypedSelector(
     (state) => state.user.emailRemindersFrequency,
   );
+  const entryPartnerReferral = useTypedSelector((state) => state.user.entryPartnerReferral);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const courses = useTypedSelector((state) => state.courses);
@@ -76,7 +77,7 @@ const CourseList: NextPage<Props> = ({ stories }) => {
   }, [userEmailRemindersFrequency]);
 
   useEffect(() => {
-    const referralPartner = Cookies.get('referralPartner');
+    const referralPartner = Cookies.get('referralPartner') || entryPartnerReferral;
 
     if (partnerAdmin && partnerAdmin.partner) {
       const partnerName = partnerAdmin.partner.name;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,13 +26,14 @@ const Index: NextPage<Props> = ({ story, preview }) => {
   const t = useTranslations('Welcome');
 
   const userCreatedAt = useTypedSelector((state) => state.user.createdAt);
+  const entryPartnerReferral = useTypedSelector((state) => state.user.entryPartnerReferral);
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const eventUserData = getEventUserData(userCreatedAt, partnerAccesses, partnerAdmin);
   const [registerPath, setRegisterPath] = useState('/auth/register');
 
   useEffect(() => {
-    const referralPartner = Cookies.get('referralPartner');
+    const referralPartner = Cookies.get('referralPartner') || entryPartnerReferral;
 
     if (referralPartner) {
       setRegisterPath(`/auth/register?partner=${referralPartner}`);


### PR DESCRIPTION
### What changes did you make and why did you make them?
Followup from recent change to cookies and removing localStorage #1210 
The `referralPartner` local storage is not set if cookies are not accepted by the user - this PR ensures that the fallback state property `entryPartnerReferral` is also checked when the local storage is not available.

Fixes failing tests