### PR TITLE
fix shorts french messages and related content

### DIFF
--- a/components/storyblok/StoryblokRelatedContent.tsx
+++ b/components/storyblok/StoryblokRelatedContent.tsx
@@ -51,9 +51,12 @@ export const StoryblokRelatedContent = (props: StoryblokRelatedContentProps) => 
       const storyAvailableForLocale =
         story.content?.languages?.length > 0 ? story.content.languages.includes(locale) : true;
       const storyDisabled = disabledCoursesString?.includes(`${router.locale}/${story.full_slug}`);
-      const storyIncludedForUserPartners = userContentPartners.some((partner) =>
-        story.content?.included_for_partners?.map((p) => p.toLowerCase()).includes(partner),
-      );
+      const storyIncludedForUserPartners =
+        story.content?.included_for_partners?.length > 0
+          ? userContentPartners.some((partner) =>
+              story.content?.included_for_partners?.map((p) => p.toLowerCase()).includes(partner),
+            )
+          : true;
       return storyAvailableForLocale && storyIncludedForUserPartners && !storyDisabled;
     });
   }, [relatedContent, disabledCoursesString, router.locale]);

--- a/messages/resources/fr.json
+++ b/messages/resources/fr.json
@@ -1,25 +1,27 @@
 {
-  "completed": "Terminé",
-  "sessionDetail": "Ce clip provient de la session {sessionNumber}, {sessionName}, de notre cours {courseName}.",
-  "sessionButtonLabel": "Regarder la session complète",
-  "videoTranscriptLink": "Regardez la vidéo ou lisez la <link>transcription</link>.",
-  "conversationTranscriptLink": "Écoutez la conversation ou lisez la <link>transcription</link>.",
-  "resourceFeedback": {
-    "title": "Comment s’est déroulée la session? ",
-    "subtitle": "Nous aimerions connaître votre avis sur cette session. Vos retours nous aident à améliorer nos cours.",
-    "feedbackTags": {
-      "relatable": "Réaliste",
-      "useful": "Utile",
-      "inspiring": "Inspirant",
-      "too long": "Trop long",
-      "too complicated": "Trop compliqué",
-      "not useful": "Inutile"
-    },
-    "textboxDefaultText": "Ajouter un commentaire...",
-    "sendButtonText": "Envoyer",
-    "submissionText": "Merci d'avoir envoyé votre avis",
-    "errors": {
-      "feedbackTagError": "Veuillez sélectionner une note avant d'envoyer."
+  "Resources": {
+    "completed": "Terminé",
+    "sessionDetail": "Ce clip provient de la session {sessionNumber}, {sessionName}, de notre cours {courseName}.",
+    "sessionButtonLabel": "Regarder la session complète",
+    "videoTranscriptLink": "Regardez la vidéo ou lisez la <link>transcription</link>.",
+    "conversationTranscriptLink": "Écoutez la conversation ou lisez la <link>transcription</link>.",
+    "resourceFeedback": {
+      "title": "Comment s’est déroulée la session? ",
+      "subtitle": "Nous aimerions connaître votre avis sur cette session. Vos retours nous aident à améliorer nos cours.",
+      "feedbackTags": {
+        "relatable": "Réaliste",
+        "useful": "Utile",
+        "inspiring": "Inspirant",
+        "too long": "Trop long",
+        "too complicated": "Trop compliqué",
+        "not useful": "Inutile"
+      },
+      "textboxDefaultText": "Ajouter un commentaire...",
+      "sendButtonText": "Envoyer",
+      "submissionText": "Merci d'avoir envoyé votre avis",
+      "errors": {
+        "feedbackTagError": "Veuillez sélectionner une note avant d'envoyer."
+      }
     }
   }
 }

--- a/messages/shared/fr.json
+++ b/messages/shared/fr.json
@@ -131,7 +131,7 @@
       "title": "Contenu associé",
       "resource_short_video": "Montre",
       "resource_conversation": "Écouter",
-      "short_video": "",
+      "short_video": "Montre",
       "course": "Cours",
       "session": "Session",
       "session_iba": "Session",

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -167,7 +167,7 @@ const CourseList: NextPage<Props> = ({ stories, conversations, shorts }) => {
                   item
                   xs={12}
                   sm={6}
-                  md={6}
+                  md={4}
                   lg={4}
                   height="100%"
                   maxWidth="400px"


### PR DESCRIPTION
### Resolves #enter-issue-number
N/A

### What changes did you make and why did you make them?
Fix french text on shorts pages
Related Content should show courses by default if they haven't been tagged

### Did you run tests? Share screenshot of results:


