### PR TITLE
Fix course image background

### DIFF
--- a/components/cards/CourseCard.tsx
+++ b/components/cards/CourseCard.tsx
@@ -93,8 +93,8 @@ const CourseCard = (props: CourseCardProps) => {
           <CardContent sx={cardContentStyle}>
             <Box flex={[2, 1]} sx={imageContainerStyle}>
               <Image
-                alt={course.content.image.alt}
-                src={course.content.image.filename}
+                alt={course.content.image_with_background.alt}
+                src={course.content.image_with_background.filename}
                 fill
                 sizes="100vw"
                 style={{


### PR DESCRIPTION
### What changes did you make and why did you make them?
Minor design update to use the course images with a background instead of the primary image without a background.
