### PR TITLE
Fix image sizes

### DIFF
--- a/components/banner/MaintenanceBanner.tsx
+++ b/components/banner/MaintenanceBanner.tsx
@@ -2,6 +2,7 @@ import { Box, Container, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import illustrationChange from '../../public/illustration_change_peach.svg';
+import { getImageSizes } from '../../utils/imageSizes';
 
 const containerStyle = {
   textAlign: 'center',
@@ -25,7 +26,7 @@ export const MaintenanceBanner = () => {
           alt={t('alt.personTea')}
           src={illustrationChange}
           fill
-          sizes="100vw"
+          sizes={getImageSizes(imageContainerStyle.width)}
           style={{
             objectFit: 'contain',
           }}

--- a/components/cards/CourseCard.tsx
+++ b/components/cards/CourseCard.tsx
@@ -16,6 +16,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { PROGRESS_STATUS } from '../../constants/enums';
 import { iconTextRowStyle, rowStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 import Link from '../common/Link';
 import ProgressStatus from '../common/ProgressStatus';
 
@@ -54,8 +55,10 @@ const collapseContentStyle = {
 } as const;
 
 const cardActionsStyle = {
+  paddingLeft: 4,
   paddingTop: 0,
-  alignItems: 'end',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
 } as const;
 
 const statusRowStyle = {
@@ -96,7 +99,7 @@ const CourseCard = (props: CourseCardProps) => {
                 alt={course.content.image_with_background.alt}
                 src={course.content.image_with_background.filename}
                 fill
-                sizes="100vw"
+                sizes={getImageSizes(imageContainerStyle.width)}
                 style={{
                   objectFit: 'contain',
                 }}
@@ -106,9 +109,6 @@ const CourseCard = (props: CourseCardProps) => {
               <Typography component="h3" variant="h3">
                 {course.content.name}
               </Typography>
-              {!!courseProgress && courseProgress !== PROGRESS_STATUS.NOT_STARTED && (
-                <ProgressStatus status={courseProgress} />
-              )}
             </Box>
           </CardContent>
         </CardActionArea>
@@ -119,7 +119,7 @@ const CourseCard = (props: CourseCardProps) => {
               alt={course.content.image.alt}
               src={course.content.image.filename}
               fill
-              sizes="100vw"
+              sizes={getImageSizes(imageContainerStyle.width)}
               style={{
                 objectFit: 'contain',
               }}
@@ -141,6 +141,10 @@ const CourseCard = (props: CourseCardProps) => {
             <PendingOutlined color="error" />
             <Typography>{t('comingSoon')}</Typography>
           </Box>
+        )}
+
+        {!!courseProgress && courseProgress !== PROGRESS_STATUS.NOT_STARTED && (
+          <ProgressStatus status={courseProgress} />
         )}
 
         <IconButton

--- a/components/cards/RelatedContentCard.tsx
+++ b/components/cards/RelatedContentCard.tsx
@@ -6,7 +6,6 @@ import { RELATED_CONTENT_CATEGORIES } from '../../constants/enums';
 const cardStyle = {
   mt: 0,
   width: '100%',
-  height: '100%',
   mb: { xs: '1rem', sm: '1.5rem' },
   backgroundColor: 'paleSecondaryLight',
 } as const;
@@ -39,7 +38,7 @@ export const RelatedContentCard = (props: RelatedContentProps) => {
   return (
     <Card sx={cardStyle}>
       <CardActionArea href={href}>
-        <CardContent>
+        <CardContent sx={{ minHeight: 238 }}>
           <Box position="relative" width="100%" paddingRight={3}>
             <Box>
               <Typography sx={categoryStyle}>
@@ -48,7 +47,9 @@ export const RelatedContentCard = (props: RelatedContentProps) => {
                   <span className="before-dot">{` ${duration} ${t('minuteLabel')}`}</span>
                 )}
               </Typography>
-              <Typography variant="h3">{title}</Typography>
+              <Typography variant="h3" mb={0}>
+                {title}
+              </Typography>
             </Box>
             <ArrowForwardIos
               color="error"

--- a/components/cards/ShortsCard.tsx
+++ b/components/cards/ShortsCard.tsx
@@ -7,9 +7,9 @@ import Link from '../common/Link';
 const cardStyle = {
   mt: 0,
   width: '250px',
-  height: '100%',
   mb: { xs: '1rem', sm: '1.5rem' },
   backgroundColor: 'paleSecondaryLight',
+  flex: 0,
 } as const;
 
 interface ShortsCardProps {
@@ -40,9 +40,12 @@ export const ShortsCard = (props: ShortsCardProps) => {
 
   return (
     <Card sx={cardStyle}>
-      <CardActionArea component={Link} href={`/${href}`}>
+      <CardActionArea component={Link} href={`/${href}`} sx={{ height: '100%' }}>
         <CardContent
-          sx={{ padding: '0 !important', display: 'flex', flexDirection: 'column', gap: '1' }}
+          sx={{
+            minHeight: 335,
+            padding: '0 !important',
+          }}
         >
           <Box height="130px" position="relative" width="100%" overflow="hidden">
             <Image

--- a/components/common/ContentUnavailable.tsx
+++ b/components/common/ContentUnavailable.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import illustrationPerson4Peach from '../../public/illustration_person4_peach.svg';
 import { columnStyle } from '../../styles/common';
 import { TextNode } from '../../utils/helper-types/translations';
+import { getImageSizes } from '../../utils/imageSizes';
 
 const accessContainerStyle = {
   ...columnStyle,
@@ -32,7 +33,7 @@ export const ContentUnavailable = ({ title, message }: ContentUnavailableProps) 
           alt={t('alt.personTea')}
           src={illustrationPerson4Peach}
           fill
-          sizes="100vw"
+          sizes={getImageSizes(imageContainerStyle.width)}
           style={{
             objectFit: 'contain',
           }}

--- a/components/common/ImageTextColumn.tsx
+++ b/components/common/ImageTextColumn.tsx
@@ -1,6 +1,7 @@
 import { Box, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Image, { StaticImageData } from 'next/image';
+import { getImageSizes } from '../../utils/imageSizes';
 
 export interface ImageTextItem {
   text: string;
@@ -28,7 +29,7 @@ const itemContainerStyle = {
 } as const;
 
 const imageContainerStyle = {
-  position: 'relative', // needed for next/image to fill the container
+  position: 'relative',
   width: 100,
   height: 100,
   paddingX: 5,
@@ -55,7 +56,7 @@ const ImageTextColumn = (props: ImageTextGridProps) => {
               alt={tS(item.illustrationAlt)}
               src={item.illustrationSrc}
               fill
-              sizes="100vw"
+              sizes={getImageSizes(imageContainerStyle.width)}
               style={{
                 objectFit: 'contain',
               }}

--- a/components/common/ImageTextGrid.tsx
+++ b/components/common/ImageTextGrid.tsx
@@ -2,6 +2,7 @@ import { Box, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Image, { StaticImageData } from 'next/image';
 import { richtextContentStyle, rowStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 
 export interface ImageTextItem {
   text: string;
@@ -52,7 +53,7 @@ const ImageTextGrid = (props: ImageTextGridProps) => {
               alt={tS(item.illustrationAlt)}
               src={item.illustrationSrc}
               fill
-              sizes="100vw"
+              sizes={getImageSizes(imageContainerStyle.width)}
               style={{
                 objectFit: 'contain',
               }}

--- a/components/common/ProgressStatus.tsx
+++ b/components/common/ProgressStatus.tsx
@@ -15,7 +15,7 @@ const ProgressStatus = (props: ProgressStatusProps) => {
 
   if (status === PROGRESS_STATUS.STARTED) {
     return (
-      <Box sx={iconTextRowStyle}>
+      <Box sx={{ ...iconTextRowStyle, marginTop: '0 !important' }}>
         <DonutLargeIcon color="error" />
         <Typography>{tS('started')}</Typography>
       </Box>
@@ -23,7 +23,7 @@ const ProgressStatus = (props: ProgressStatusProps) => {
   }
   if (status === PROGRESS_STATUS.COMPLETED) {
     return (
-      <Box sx={iconTextRowStyle}>
+      <Box sx={{ ...iconTextRowStyle, marginTop: '0 !important' }}>
         <CheckCircleIcon color="error" />
         <Typography>{tS('completed')}</Typography>
       </Box>

--- a/components/forms/ResourceFeedbackForm.tsx
+++ b/components/forms/ResourceFeedbackForm.tsx
@@ -19,6 +19,7 @@ import illustrationPerson4Peach from '../../public/illustration_person4_peach.sv
 import { useCreateResourceFeedbackMutation } from '../../store/api';
 import { ResourceFeedback } from '../../store/resourcesSlice';
 import { staticFieldLabelStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 
 const fieldBoxStyle: SxProps<Theme> = {
   ...staticFieldLabelStyle,
@@ -102,7 +103,7 @@ const ResourceFeedbackForm = (props: ResourceFeedbackFormProps) => {
           alt={tS('alt.personTea')}
           src={illustrationPerson4Peach}
           fill
-          sizes="100vw"
+          sizes={getImageSizes(imageContainerStyle.width)}
           style={{
             objectFit: 'contain',
           }}

--- a/components/forms/SessionFeedbackForm.tsx
+++ b/components/forms/SessionFeedbackForm.tsx
@@ -19,6 +19,7 @@ import illustrationPerson4Peach from '../../public/illustration_person4_peach.sv
 import { useCreateSessionFeedbackMutation } from '../../store/api';
 import { SessionFeedback } from '../../store/coursesSlice';
 import { staticFieldLabelStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 
 const fieldBoxStyle: SxProps<Theme> = {
   ...staticFieldLabelStyle,
@@ -99,7 +100,7 @@ const SessionFeedbackForm = (props: SessionFeedbackFormProps) => {
           alt={tS('alt.personTea')}
           src={illustrationPerson4Peach}
           fill
-          sizes="100vw"
+          sizes={getImageSizes(imageContainerStyle.width)}
           style={{
             objectFit: 'contain',
           }}

--- a/components/layout/Consent.tsx
+++ b/components/layout/Consent.tsx
@@ -8,6 +8,7 @@ import { COOKIES_ACCEPTED, COOKIES_REJECTED } from '../../constants/events';
 import { useAppDispatch, useTypedSelector } from '../../hooks/store';
 import IllustrationCookieCat from '../../public/illustration_cookie_cat.svg';
 import { setCookiesAccepted } from '../../store/userSlice';
+import { getImageSizes } from '../../utils/imageSizes';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 import Link from '../common/Link';
 
@@ -111,7 +112,7 @@ const Consent = (props: {}) => {
         <Image
           alt={tS('alt.cookieCat')}
           src={IllustrationCookieCat}
-          sizes="100vw"
+          sizes={getImageSizes(70)}
           style={{
             width: '100%',
             height: 'auto',

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -18,6 +18,7 @@ import tiktokLogo from '../../public/tiktok.svg';
 
 import Cookies from 'js-cookie';
 import { rowStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 import Link from '../common/Link';
 
@@ -142,16 +143,7 @@ const Footer = () => {
     <>
       <Container sx={footerContainerStyle} component="footer">
         <Box width="100%" mb={3}>
-          <Image
-            alt={tS('alt.bloomLogo')}
-            src={bloomLogo}
-            width={140}
-            height={60}
-            style={{
-              maxWidth: '100%',
-              height: 'auto',
-            }}
-          />
+          <Image alt={tS('alt.bloomLogo')} src={bloomLogo} width={140} height={60} />
         </Box>
         <Box sx={footerContentRowStyle}>
           <Box sx={getDescriptionContainerStyle(partners.length)}>
@@ -190,7 +182,7 @@ const Footer = () => {
                       alt={tS(partner.logoAlt)}
                       src={partner.logo}
                       fill
-                      sizes="300px"
+                      sizes={getImageSizes(logoContainerStyle.width)}
                       style={{
                         objectFit: 'contain',
                         objectPosition: 'left',
@@ -272,14 +264,7 @@ const Footer = () => {
                           })
                         }
                       >
-                        <Image
-                          alt={tS('alt.tiktokLogo')}
-                          src={tiktokLogo}
-                          style={{
-                            maxWidth: '100%',
-                            height: 'auto',
-                          }}
-                        />
+                        <Image alt={tS('alt.tiktokLogo')} src={tiktokLogo} width={24} height={24} />
                       </IconButton>
                     )}
                     {partner.github && (
@@ -310,16 +295,7 @@ const Footer = () => {
         </Typography>
         <Box sx={fundingLogosContainerStyle}>
           <Link href="https://www.comicrelief.com/" position="relative" target="_blank">
-            <Image
-              alt={tS('alt.comicReliefLogo')}
-              src={comicReliefLogo}
-              width={88}
-              height={64}
-              style={{
-                maxWidth: '100%',
-                height: 'auto',
-              }}
-            />
+            <Image alt={tS('alt.comicReliefLogo')} src={comicReliefLogo} width={88} height={64} />
           </Link>
           <Link href="https://www.tnlcommunityfund.org.uk/" position="relative" target="_blank">
             <Image
@@ -327,10 +303,6 @@ const Footer = () => {
               src={communityFundLogo}
               width={170}
               height={50}
-              style={{
-                maxWidth: '100%',
-                height: 'auto',
-              }}
             />
           </Link>
         </Box>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -8,6 +8,7 @@ import { render } from 'storyblok-rich-text-react-renderer';
 import { PROGRESS_STATUS } from '../../constants/enums';
 import { columnStyle, rowStyle } from '../../styles/common';
 import { TextNode } from '../../utils/helper-types/translations';
+import { getImageSizes } from '../../utils/imageSizes';
 import { RichTextOptions } from '../../utils/richText';
 import UserResearchBanner from '../banner/UserResearchBanner';
 import ProgressStatus from '../common/ProgressStatus';
@@ -58,6 +59,7 @@ const childrenContentStyle = {
 
 const textContentStyle = {
   marginTop: 'auto',
+  mb: 2,
 } as const;
 
 const backButtonStyle = {
@@ -127,7 +129,7 @@ const Header = (props: HeaderProps) => {
           alt={imageAltText}
           src={imageSrc}
           fill
-          sizes="100vw"
+          sizes={getImageSizes(imageContainerStyle.width)}
           style={{
             objectFit: 'contain',
           }}

--- a/components/layout/HomeHeader.tsx
+++ b/components/layout/HomeHeader.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { render } from 'storyblok-rich-text-react-renderer';
 import { columnStyle, rowStyle } from '../../styles/common';
 import theme from '../../styles/theme';
+import { getImageSizes } from '../../utils/imageSizes';
 import { RichTextOptions } from '../../utils/richText';
 import UserResearchBanner from '../banner/UserResearchBanner';
 
@@ -87,7 +88,7 @@ const Header = (props: HeaderProps) => {
           alt={imageAltText}
           src={imageSrc}
           fill
-          sizes="100vw"
+          sizes={getImageSizes(imageContainerStyle.width)}
           style={{
             objectFit: 'contain',
           }}

--- a/components/layout/PartnerAdminHeader.tsx
+++ b/components/layout/PartnerAdminHeader.tsx
@@ -2,6 +2,7 @@ import { Container, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Image, { StaticImageData } from 'next/image';
 import * as React from 'react';
+import { getImageSizes } from '../../utils/imageSizes';
 
 const headerContainerStyles = {
   backgroundColor: 'common.white',
@@ -36,6 +37,7 @@ const PartnerAdminHeader = (props: PartnerAdminHeaderProps) => {
           alt={tS(partnerLogoAlt)}
           src={partnerLogoSrc}
           width={200}
+          sizes={getImageSizes(200)}
           style={{
             maxWidth: '100%',
             height: 'auto',

--- a/components/layout/PartnerHeader.tsx
+++ b/components/layout/PartnerHeader.tsx
@@ -2,6 +2,7 @@ import { Box, Container } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Image, { StaticImageData } from 'next/image';
 import { rowStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 import UserResearchBanner from '../banner/UserResearchBanner';
 
 const headerContainerStyles = {
@@ -46,7 +47,7 @@ const PartnerHeader = (props: HeaderProps) => {
           alt={tS(partnerLogoAlt)}
           src={partnerLogoSrc}
           fill
-          sizes="100vw"
+          sizes={getImageSizes(logoContainerStyle.width)}
           style={{
             objectFit: 'contain',
           }}
@@ -57,7 +58,7 @@ const PartnerHeader = (props: HeaderProps) => {
           alt={tS(imageAlt)}
           src={imageSrc}
           fill
-          sizes="100vw"
+          sizes={getImageSizes(imageContainerStyle.width)}
           style={{
             objectFit: 'contain',
           }}

--- a/components/layout/SecondaryNav.tsx
+++ b/components/layout/SecondaryNav.tsx
@@ -23,6 +23,7 @@ import { HTMLAttributes } from 'react';
 import theme from '../../styles/theme';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 import { NextLinkComposed } from '../common/Link';
+import { getImageSizes } from '../../utils/imageSizes';
 
 interface LinkTabProps {
   label?: string;
@@ -72,7 +73,7 @@ export const SecondaryNavIcon = ({ alt, src }: SecondaryNavIconType) => (
       alt={alt}
       src={src}
       fill
-      sizes="100vw"
+      sizes={getImageSizes(35)}
       style={{
         objectFit: 'contain',
       }}

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -7,6 +7,7 @@ import { HEADER_HOME_LOGO_CLICKED, HEADER_LOGIN_CLICKED } from '../../constants/
 import { useTypedSelector } from '../../hooks/store';
 import bloomLogo from '../../public/bloom_logo_white.svg';
 import { rowStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 import { getIsMaintenanceMode } from '../../utils/maintenanceMode';
 import Link from '../common/Link';
@@ -82,7 +83,7 @@ const TopBar = () => {
               alt={tS('alt.bloomLogo')}
               src={bloomLogo}
               fill
-              sizes="250px"
+              sizes={getImageSizes(logoContainerStyle.width)}
               style={{
                 objectFit: 'contain',
               }}

--- a/components/storyblok/StoryblokAccordion.tsx
+++ b/components/storyblok/StoryblokAccordion.tsx
@@ -14,6 +14,7 @@ import { useEffect, useRef } from 'react';
 import { render } from 'storyblok-rich-text-react-renderer';
 import { ACCORDION_OPENED, generateAccordionEvent } from '../../constants/events';
 import { useTypedSelector } from '../../hooks/store';
+import { getImageSizes } from '../../utils/imageSizes';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 import { RichTextOptions } from '../../utils/richText';
 const containerStyle = {
@@ -107,7 +108,7 @@ const StoryblokAccordion = (props: StoryblokAccordionProps) => {
                   alt={ai.icon.alt}
                   src={ai.icon.filename}
                   fill
-                  sizes="100vw"
+                  sizes={getImageSizes(32)}
                   style={{
                     objectFit: 'contain',
                   }}

--- a/components/storyblok/StoryblokCard.tsx
+++ b/components/storyblok/StoryblokCard.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import { useState } from 'react';
 import { render } from 'storyblok-rich-text-react-renderer';
+import { getImageSizes } from '../../utils/imageSizes';
 import { RichTextOptions } from '../../utils/richText';
 import Link from '../common/Link';
 
@@ -35,19 +36,6 @@ const cardActionsStyle = {
   right: 1,
   bottom: 3,
 } as const;
-
-const slimImageStyle = {
-  width: { xs: 80, sm: 80, md: 80 },
-  height: { xs: 80, sm: 80, md: 80 },
-  minWidth: { xs: 80, sm: 80, md: 80 },
-  minHeight: { xs: 80, sm: 80, md: 80 },
-};
-const defaultStyle = {
-  width: { xs: 80, md: 100 },
-  height: { xs: 80, md: 100 },
-  minWidth: { xs: 80, md: 100 },
-  minHeight: { xs: 80, md: 100 },
-};
 
 const cardStyle = {
   '&:first-of-type': {
@@ -77,6 +65,8 @@ const StoryblokCard = (props: StoryblokCardProps) => {
     setExpanded(!expanded);
   };
 
+  const isSlimStyle = style === 'slim';
+
   const arrowStyle = {
     transform: expanded ? 'rotate(180deg)' : 'none',
   } as const;
@@ -92,7 +82,7 @@ const StoryblokCard = (props: StoryblokCardProps) => {
   };
 
   const cardContentStyle = {
-    ...(style == 'slim' ? slimPadding : {}),
+    ...(isSlimStyle && slimPadding),
     display: 'flex',
     flexDirection:
       alignment === 'right' ? 'row-reverse' : alignment === 'center' ? 'column' : 'row',
@@ -103,8 +93,11 @@ const StoryblokCard = (props: StoryblokCardProps) => {
   } as const;
 
   const imageContainerStyle = {
-    ...(style == 'slim' ? slimImageStyle : defaultStyle),
     position: 'relative',
+    width: { xs: 80, ...(isSlimStyle && { md: 100 }) },
+    height: { xs: 80, ...(isSlimStyle && { md: 100 }) },
+    minWidth: { xs: 80, ...(isSlimStyle && { md: 100 }) },
+    minHeight: { xs: 80, ...(isSlimStyle && { md: 100 }) },
   } as const;
 
   const collapseContentStyle = {
@@ -117,7 +110,13 @@ const StoryblokCard = (props: StoryblokCardProps) => {
     <CardContent sx={cardContentStyle}>
       {image && image.filename && (
         <Box sx={imageContainerStyle}>
-          <Image src={image.filename} alt={image.alt} className="image" fill sizes="100vw"></Image>
+          <Image
+            src={image.filename}
+            alt={image.alt}
+            className="image"
+            fill
+            sizes={getImageSizes(imageContainerStyle.width)}
+          ></Image>
         </Box>
       )}
       <Box maxWidth={700}>{render(content, RichTextOptions)}</Box>

--- a/components/storyblok/StoryblokFaqs.tsx
+++ b/components/storyblok/StoryblokFaqs.tsx
@@ -45,16 +45,7 @@ const StoryblokFaqs = (props: StoryblokFaqsProps) => {
         {title}
       </Typography>
       <Box textAlign="center">
-        <Image
-          alt={'alt'}
-          src={illustrationLeafMix}
-          width={125}
-          height={100}
-          style={{
-            maxWidth: '100%',
-            height: 'auto',
-          }}
-        />
+        <Image alt={'alt'} src={illustrationLeafMix} width={125} height={100} />
       </Box>
       {faqs.map((faq, i) => (
         <Accordion

--- a/components/storyblok/StoryblokImage.tsx
+++ b/components/storyblok/StoryblokImage.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/material';
 import { storyblokEditable } from '@storyblok/react';
 import Image from 'next/image';
 import { richtextContentStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 
 interface StoryblokImageProps {
   _uid: string;
@@ -60,7 +61,16 @@ const StoryblokImage = (props: StoryblokImageProps) => {
       {...storyblokEditable({ _uid, _editable, image, size, alignment })}
       sx={imageContainerStyle}
     >
-      <Image src={image.filename} alt={image.alt} className="image" fill sizes="100vw"></Image>
+      <Image
+        src={image.filename}
+        alt={image.alt}
+        className="image"
+        fill
+        sizes={getImageSizes(imageContainerStyle.width)}
+        style={{
+          objectFit: 'contain',
+        }}
+      />
     </Box>
   );
 };

--- a/components/storyblok/StoryblokQuote.tsx
+++ b/components/storyblok/StoryblokQuote.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import { ISbRichtext, storyblokEditable } from '@storyblok/react';
 import Image from 'next/image';
+import { getImageSizes } from '../../utils/imageSizes';
 import Quote from '../common/Quote';
 
 const containerStyle = {
@@ -47,7 +48,16 @@ const StoryblokQuote = (props: StoryblokQuoteProps) => {
     >
       {image && (
         <Box sx={imageContainerStyle}>
-          <Image src={image.filename} alt={image.alt} className="image" fill sizes="520px" />
+          <Image
+            src={image.filename}
+            alt={image.alt}
+            className="image"
+            fill
+            sizes={getImageSizes(imageContainerStyle.maxWidth)}
+            style={{
+              objectFit: 'contain',
+            }}
+          />
         </Box>
       )}
       <Quote text={text} textSize={text_size} iconColor={icon_color} />

--- a/components/storyblok/StoryblokResourceConversationPage.tsx
+++ b/components/storyblok/StoryblokResourceConversationPage.tsx
@@ -37,6 +37,7 @@ const progressStyle = {
   alignItems: 'center',
   justifyContent: 'flex-start',
   gap: 3,
+  mt: 2,
   '.MuiBox-root': {
     mt: 0,
   },
@@ -194,7 +195,7 @@ const StoryblokResourceConversationPage = (props: StoryblokResourceConversationP
         imageSrc={header_image ? header_image.filename : illustrationCourses}
       />
       <PageSection color={STORYBLOK_COLORS.SECONDARY_MAIN} alignment="left">
-        <Typography variant="h2" fontWeight={600}>
+        <Typography variant="h2" fontWeight={500}>
           {tS('relatedContent.title')}
         </Typography>
         <StoryblokRelatedContent

--- a/components/storyblok/StoryblokResourceShortPage.tsx
+++ b/components/storyblok/StoryblokResourceShortPage.tsx
@@ -52,6 +52,7 @@ const progressStyle = {
   alignItems: 'center',
   justifyContent: 'flex-start',
   gap: 3,
+  mt: 2,
   '.MuiBox-root': {
     mt: 0,
   },
@@ -302,7 +303,7 @@ const StoryblokResourceShortPage = (props: StoryblokResourceShortPageProps) => {
       )}
 
       <PageSection alignment="flex-start" color={STORYBLOK_COLORS.SECONDARY_MAIN}>
-        <Typography variant="h2" fontWeight={600}>
+        <Typography variant="h2" fontWeight={500}>
           {tS('relatedContent.title')}
         </Typography>
         <StoryblokRelatedContent

--- a/components/storyblok/StoryblokTeamMemberCard.tsx
+++ b/components/storyblok/StoryblokTeamMemberCard.tsx
@@ -7,6 +7,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { render } from 'storyblok-rich-text-react-renderer';
 import { columnStyle, rowStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 import { RichTextOptions } from '../../utils/richText';
 
 const cardStyle = {
@@ -99,7 +100,7 @@ const StoryblokTeamMemberCard = (props: StoryblokTeamMemberCardProps) => {
               alt={image.alt}
               src={image.filename}
               fill
-              sizes="100vw"
+              sizes={getImageSizes(imageContainerStyle.width)}
               style={{
                 objectFit: 'cover',
               }}

--- a/guards/PartnerAdminGuard.tsx
+++ b/guards/PartnerAdminGuard.tsx
@@ -6,6 +6,7 @@ import Link from '../components/common/Link';
 import { useTypedSelector } from '../hooks/store';
 import illustrationPerson4Peach from '../public/illustration_person4_peach.svg';
 import { columnStyle } from '../styles/common';
+import { getImageSizes } from '../utils/imageSizes';
 
 const containerStyle = {
   ...columnStyle,
@@ -37,7 +38,7 @@ export function PartnerAdminGuard({ children }: { children: JSX.Element }) {
             alt={tS('alt.personTea')}
             src={illustrationPerson4Peach}
             fill
-            sizes="100vw"
+            sizes={getImageSizes(imageContainerStyle.width)}
             style={{
               objectFit: 'contain',
             }}

--- a/guards/SuperAdminGuard.tsx
+++ b/guards/SuperAdminGuard.tsx
@@ -6,6 +6,7 @@ import Link from '../components/common/Link';
 import { useTypedSelector } from '../hooks/store';
 import illustrationPerson4Peach from '../public/illustration_person4_peach.svg';
 import { columnStyle } from '../styles/common';
+import { getImageSizes } from '../utils/imageSizes';
 
 const containerStyle = {
   ...columnStyle,
@@ -35,7 +36,7 @@ export function SuperAdminGuard({ children }: { children: JSX.Element }) {
             alt={tS('alt.personTea')}
             src={illustrationPerson4Peach}
             fill
-            sizes="100vw"
+            sizes={getImageSizes(imageContainerStyle.width)}
             style={{
               objectFit: 'contain',
             }}

--- a/guards/TherapyAccessGuard.tsx
+++ b/guards/TherapyAccessGuard.tsx
@@ -6,6 +6,7 @@ import Link from '../components/common/Link';
 import { useTypedSelector } from '../hooks/store';
 import illustrationPerson4Peach from '../public/illustration_person4_peach.svg';
 import { columnStyle } from '../styles/common';
+import { getImageSizes } from '../utils/imageSizes';
 
 const containerStyle = {
   ...columnStyle,
@@ -39,7 +40,7 @@ export function TherapyAccessGuard({ children }: { children: JSX.Element }) {
             alt={tS('alt.personTea')}
             src={illustrationPerson4Peach}
             fill
-            sizes="100vw"
+            sizes={getImageSizes(imageContainerStyle.width)}
             style={{
               objectFit: 'contain',
             }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "NODE_OPTIONS='-r @newrelic/next' next start",
-    "https:proxy": "local-ssl-proxy --source 3010 --target 3001 --cert localhost.pem --key localhost-key.pem",
+    "https:proxy": "local-ssl-proxy --source 3010 --target 3000 --cert localhost.pem --key localhost-key.pem",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "type-check": "tsc -p tsconfig.json",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -8,6 +8,7 @@ import LoadingContainer from '../components/common/LoadingContainer';
 import { useTypedSelector } from '../hooks/store';
 import bloomHead from '../public/illustration_bloom_head.svg';
 import { columnStyle } from '../styles/common';
+import { getImageSizes } from '../utils/imageSizes';
 
 const containerStyle = {
   ...columnStyle,
@@ -38,7 +39,12 @@ const Custom404: NextPage = () => {
         <title>{`${t('404.title')} • Bloom`}</title>
       </Head>
       <Box sx={imageContainerStyle}>
-        <Image alt={t('alt.bloomLogo')} src={bloomHead} fill sizes="100vw" />
+        <Image
+          alt={t('alt.bloomLogo')}
+          src={bloomHead}
+          fill
+          sizes={getImageSizes(imageContainerStyle.width)}
+        />
       </Box>
       <Typography variant="h1" component="h1">
         {t('404.title')}

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -8,6 +8,7 @@ import LoadingContainer from '../components/common/LoadingContainer';
 import { useTypedSelector } from '../hooks/store';
 import bloomHead from '../public/illustration_bloom_head.svg';
 import { columnStyle } from '../styles/common';
+import { getImageSizes } from '../utils/imageSizes';
 
 const Custom500: NextPage = () => {
   const t = useTranslations('Shared');
@@ -38,7 +39,12 @@ const Custom500: NextPage = () => {
         <title>{`${t('500.title')} • Bloom`}</title>
       </Head>
       <Box sx={imageContainerStyle}>
-        <Image alt={t('alt.bloomHead')} src={bloomHead} fill sizes="100vw" />
+        <Image
+          alt={t('alt.bloomHead')}
+          src={bloomHead}
+          fill
+          sizes={getImageSizes(imageContainerStyle.width)}
+        />
       </Box>
       <Typography variant="h1" component="h1">
         {t('500.title')}

--- a/pages/account/apply-a-code.tsx
+++ b/pages/account/apply-a-code.tsx
@@ -12,6 +12,7 @@ import { PartnerContent, getAllPartnersContent } from '../../constants/partners'
 import { useTypedSelector } from '../../hooks/store';
 import illustrationPerson4Peach from '../../public/illustration_person4_peach.svg';
 import { rowStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 
 const containerStyle = {
@@ -110,7 +111,7 @@ const ApplyACode: NextPage = () => {
                       alt={tS(partner.logoAlt)}
                       src={partner.logo}
                       fill
-                      sizes="100vw"
+                      sizes={getImageSizes(logoContainerStyle.maxWidth)}
                       style={{
                         objectFit: 'contain',
                       }}

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -28,6 +28,7 @@ import illustrationBloomHeadYellow from '../../public/illustration_bloom_head_ye
 import illustrationLeafMix from '../../public/illustration_leaf_mix.svg';
 import welcomeToBloom from '../../public/welcome_to_bloom.svg';
 import { rowStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 
 const containerStyle = {
@@ -95,7 +96,12 @@ const Login: NextPage = () => {
     return (
       <>
         <Box sx={imageContainerStyle}>
-          <Image alt={tS('alt.leafMix')} src={illustrationLeafMix} fill sizes="100vw" />
+          <Image
+            alt={tS('alt.leafMix')}
+            src={illustrationLeafMix}
+            fill
+            sizes={getImageSizes(imageContainerStyle.width)}
+          />
         </Box>
         <Typography variant="h3" component="h3">
           {t('login.newUserTitle')}

--- a/pages/auth/register.tsx
+++ b/pages/auth/register.tsx
@@ -24,6 +24,7 @@ import illustrationBloomHeadYellow from '../../public/illustration_bloom_head_ye
 import illustrationLeafMixDots from '../../public/illustration_leaf_mix_dots.svg';
 import welcomeToBloom from '../../public/welcome_to_bloom.svg';
 import { rowStyle } from '../../styles/common';
+import { getImageSizes } from '../../utils/imageSizes';
 import logEvent, { getEventUserData } from '../../utils/logEvent';
 
 const containerStyle = {
@@ -131,7 +132,12 @@ const Register: NextPage = () => {
     return (
       <>
         <Box sx={imageContainerStyle}>
-          <Image alt={tS('alt.leafMixDots')} src={illustrationLeafMixDots} fill sizes="100vw" />
+          <Image
+            alt={tS('alt.leafMixDots')}
+            src={illustrationLeafMixDots}
+            fill
+            sizes={getImageSizes(imageContainerStyle.width)}
+          />
         </Box>
         {!partnerContent && (
           // Show the public bloom and all other partner's welcome page links
@@ -160,7 +166,7 @@ const Register: NextPage = () => {
                         alt={tS(partner.logoAlt)}
                         src={partner.logo}
                         fill
-                        sizes="100vw"
+                        sizes={getImageSizes(logoContainerStyle.maxWidth)}
                         style={{
                           objectFit: 'contain',
                         }}

--- a/pages/courses/index.tsx
+++ b/pages/courses/index.tsx
@@ -167,8 +167,8 @@ const CourseList: NextPage<Props> = ({ stories, conversations, shorts }) => {
                   item
                   xs={12}
                   sm={6}
-                  md={4}
-                  lg={4}
+                  md={6}
+                  lg={6}
                   height="100%"
                   maxWidth="400px"
                   key={course.id}

--- a/pages/maintenance.tsx
+++ b/pages/maintenance.tsx
@@ -4,6 +4,7 @@ import { Box, Container, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import illustrationChange from '../public/illustration_change_peach.svg';
+import { getImageSizes } from '../utils/imageSizes';
 
 const containerStyle = {
   textAlign: 'center',
@@ -27,7 +28,7 @@ const Maintenance: NextPage = () => {
           alt={t('alt.change')}
           src={illustrationChange}
           fill
-          sizes="100vw"
+          sizes={getImageSizes(imageContainerStyle.width)}
           style={{
             objectFit: 'contain',
           }}

--- a/pages/messaging.tsx
+++ b/pages/messaging.tsx
@@ -13,6 +13,7 @@ import { useTypedSelector } from '../hooks/store';
 import IllustrationCourseDBR from '../public/illustration_course_dbr.svg';
 import { rowStyle } from '../styles/common';
 import { getStoryblokPageProps } from '../utils/getStoryblokPageProps';
+import { getImageSizes } from '../utils/imageSizes';
 
 const messageRowStyle = {
   ...rowStyle,
@@ -21,7 +22,7 @@ const messageRowStyle = {
 } as const;
 
 const imageContainerStyle = {
-  position: 'relative', // needed for next/image to fill the container
+  position: 'relative',
   width: { xs: '40%', md: 260 },
   height: { xs: '40%', md: 260 },
 } as const;
@@ -76,7 +77,7 @@ const Message: NextPage<Props> = ({ story }) => {
                   <Image
                     alt={tS('alt.personSitting')}
                     src={IllustrationCourseDBR}
-                    sizes="50vw"
+                    sizes={getImageSizes(imageContainerStyle.width)}
                     style={{
                       width: '100%',
                       height: 'auto',

--- a/pages/therapy/book-session.tsx
+++ b/pages/therapy/book-session.tsx
@@ -161,16 +161,7 @@ const BookSession: NextPage = () => {
           {t('faqHeader')}
         </Typography>
         <Box textAlign="center">
-          <Image
-            alt={tS('alt.leafMix')}
-            src={illustrationLeafMix}
-            width={125}
-            height={100}
-            style={{
-              maxWidth: '100%',
-              height: 'auto',
-            }}
-          />
+          <Image alt={tS('alt.leafMix')} src={illustrationLeafMix} width={125} height={100} />
         </Box>
 
         <Box sx={faqsContainerStyle}>

--- a/pages/therapy/confirmed-session.tsx
+++ b/pages/therapy/confirmed-session.tsx
@@ -86,16 +86,7 @@ const ConfirmedSession: NextPage = () => {
           {t('faqHeader')}
         </Typography>
         <Box textAlign="center">
-          <Image
-            alt={tS('alt.leafMix')}
-            src={illustrationLeafMix}
-            width={100}
-            height={100}
-            style={{
-              maxWidth: '100%',
-              height: 'auto',
-            }}
-          />
+          <Image alt={tS('alt.leafMix')} src={illustrationLeafMix} width={100} height={100} />
         </Box>
         <Box sx={faqsContainerStyle}>
           <Faqs

--- a/utils/imageSizes.ts
+++ b/utils/imageSizes.ts
@@ -1,0 +1,33 @@
+import { Breakpoint } from '@mui/material';
+
+type WidthSxProps =
+  | string
+  | number
+  | {
+      [key in Breakpoint]?: string | number;
+    };
+
+export const getImageSizes = (width: WidthSxProps): string => {
+  const breakpoints: Record<Breakpoint, number> = {
+    xs: 0,
+    sm: 600,
+    md: 900,
+    lg: 1200,
+    xl: 1536,
+  };
+
+  const getSizes = (width: WidthSxProps): string[] => {
+    if (typeof width === 'object') {
+      return Object.entries(breakpoints)
+        .filter(([breakpoint]) => width[breakpoint as Breakpoint] !== undefined)
+        .map(
+          ([breakpoint, maxWidth]) =>
+            `(max-width: ${maxWidth}px) ${width[breakpoint as Breakpoint]}`,
+        );
+    } else {
+      return [`${width}`];
+    }
+  };
+
+  return getSizes(width).join(', ');
+};


### PR DESCRIPTION
### What changes did you make and why did you make them?
As part of next migration, addressed fixing all images being loaded at 100vw. This was impacting performance and potentially increasing users download sizes for images (unclear if next.js was compensating for our 100vw values).

Image sizes have now been set correctly across the app consistently and according to the acutal size it's rendered at.