### PR TITLE
Fix crisp email connection

### DIFF
--- a/components/crisp/CrispIframe.tsx
+++ b/components/crisp/CrispIframe.tsx
@@ -71,7 +71,7 @@ export const CrispIframe = () => {
       // Acts as a trigger to overwrite the initial message - see AI automations -> chatbox triggers
       crisp.push(['set', 'session:event', 'widget:loaded']);
       // Set user email to set the contact
-      crisp.push(['set', 'user:email', [userEmail]]);
+      crisp.push(['set', 'user:email', userEmail]);
 
       crisp.push([
         'on',


### PR DESCRIPTION
### What changes did you make and why did you make them?
Fixes issue with crisp not sending email to widget correctly, resulting in the user account not being connected to the chat in our crisp UI. 

The `[email]` was causing an issue although that's the formatting in the crisp [docs](https://docs.crisp.chat/guides/chatbox-sdks/web-sdk/dollar-crisp/#change-user-email)