### PR TITLE
Fix breadcrumb buttons, prevent german activity related content, rm user research banner

### DIFF
--- a/app/[locale]/shorts/[slug]/page.tsx
+++ b/app/[locale]/shorts/[slug]/page.tsx
@@ -80,14 +80,14 @@ export default async function Page({ params }: { params: Params }) {
     story?.content.related_session[0].content.course,
   );
 
-  if (!story) {
+  if (!story || !relatedCourse) {
     notFound();
   }
 
   return (
     <StoryblokResourceShortPage
       {...(story.content as StoryblokResourceShortPageProps)}
-      related_course={relatedCourse ? relatedCourse[0] : undefined}
+      related_course={relatedCourse[0]}
       storyId={story.id}
     />
   );

--- a/components/course/CourseHeader.tsx
+++ b/components/course/CourseHeader.tsx
@@ -3,18 +3,10 @@
 import Header from '@/components/layout/Header';
 import { Link as i18nLink } from '@/i18n/routing';
 import { PROGRESS_STATUS } from '@/lib/constants/enums';
-import theme from '@/styles/theme';
+import { breadcrumbButtonStyle } from '@/styles/common';
 import { Button } from '@mui/material';
 import { ISbRichtext } from '@storyblok/react/rsc';
 import { useTranslations } from 'next-intl';
-
-const buttonStyle = {
-  background: theme.palette.background.default,
-  boxShadow: 'none !important',
-  ':hover': {
-    background: 'white',
-  },
-} as const;
 
 interface CourseHeaderProps {
   name: string;
@@ -39,7 +31,13 @@ const CourseHeader = (props: CourseHeaderProps) => {
 
   return (
     <Header {...headerProps}>
-      <Button variant="outlined" sx={buttonStyle} href="/courses" component={i18nLink} size="small">
+      <Button
+        variant="contained"
+        sx={breadcrumbButtonStyle}
+        href="/courses"
+        component={i18nLink}
+        size="small"
+      >
         {t('backToCourses')}
       </Button>
     </Header>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import UserResearchBanner from '@/components/banner/UserResearchBanner';
 import ProgressStatus from '@/components/common/ProgressStatus';
 import { useRouter } from '@/i18n/routing';
 import { PROGRESS_STATUS } from '@/lib/constants/enums';
@@ -107,7 +106,6 @@ const Header = (props: HeaderProps) => {
 
   return (
     <Container sx={headerContainerStyle}>
-      <UserResearchBanner />
       <Box sx={textContainerStyle}>
         <IconButton
           sx={backButtonStyle}

--- a/components/layout/HomeHeader.tsx
+++ b/components/layout/HomeHeader.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import UserResearchBanner from '@/components/banner/UserResearchBanner';
 import { getImageSizes } from '@/lib/utils/imageSizes';
 import { RichTextOptions } from '@/lib/utils/richText';
 import { columnStyle, rowStyle } from '@/styles/common';
@@ -75,7 +74,6 @@ const Header = (props: HeaderProps) => {
 
   return (
     <Container sx={headerContainerStyles}>
-      <UserResearchBanner />
       <Box sx={textContainerStyle}>
         <Box sx={textContentStyle}>
           <Typography variant="h1" component="h1" mb={3}>

--- a/components/layout/PartnerHeader.tsx
+++ b/components/layout/PartnerHeader.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import UserResearchBanner from '@/components/banner/UserResearchBanner';
 import { getImageSizes } from '@/lib/utils/imageSizes';
 import { rowStyle } from '@/styles/common';
 import { Box, Container } from '@mui/material';
@@ -43,7 +42,6 @@ const PartnerHeader = (props: HeaderProps) => {
 
   return (
     <Container sx={headerContainerStyles}>
-      <UserResearchBanner />
       <Box sx={logoContainerStyle}>
         <Image
           alt={tS(partnerLogoAlt)}

--- a/components/pages/CoursesPage.tsx
+++ b/components/pages/CoursesPage.tsx
@@ -8,14 +8,12 @@ import { ShortsCard } from '@/components/cards/ShortsCard';
 import Carousel, { getSlideWidth } from '@/components/common/Carousel';
 import Column from '@/components/common/Column';
 import LoadingContainer from '@/components/common/LoadingContainer';
-import PageSection from '@/components/common/PageSection';
 import Row from '@/components/common/Row';
 import Header from '@/components/layout/Header';
 import {
   EMAIL_REMINDERS_FREQUENCY,
   PROGRESS_STATUS,
   RESOURCE_CATEGORIES,
-  STORYBLOK_COLORS,
 } from '@/lib/constants/enums';
 import { COURSE_LIST_VIEWED } from '@/lib/constants/events';
 import { useTypedSelector } from '@/lib/hooks/store';
@@ -23,11 +21,13 @@ import { getDefaultFullSlug } from '@/lib/utils/getDefaultFullSlug';
 import logEvent from '@/lib/utils/logEvent';
 import userHasAccessToPartnerContent from '@/lib/utils/userHasAccessToPartnerContent';
 import illustrationCourses from '@/public/illustration_courses.svg';
-import { Box, Container, Grid, Typography } from '@mui/material';
+import theme from '@/styles/theme';
+import { Box, Container, Grid, Typography, useMediaQuery } from '@mui/material';
 import { ISbStoryData } from '@storyblok/react/rsc';
 import Cookies from 'js-cookie';
 import { useLocale, useTranslations } from 'next-intl';
-import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
 
 const containerStyle = {
   backgroundColor: 'secondary.light',
@@ -57,6 +57,10 @@ export default function CoursesPage({ courseStories, conversations, shorts }: Pr
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
   const partnerAdmin = useTypedSelector((state) => state.partnerAdmin);
   const courses = useTypedSelector((state) => state.courses);
+  const searchParams = useSearchParams();
+  const sectionQueryParam = searchParams.get('section');
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
+  const headerOffset = isSmallScreen ? 48 : 136;
 
   const t = useTranslations('Courses');
 
@@ -70,6 +74,27 @@ export default function CoursesPage({ courseStories, conversations, shorts }: Pr
   useEffect(() => {
     logEvent(COURSE_LIST_VIEWED);
   }, []);
+
+  const setShortsSectionRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) return;
+      if (sectionQueryParam === 'shorts' && node && loadedCourses) {
+        const scrollToY = node.getBoundingClientRect().top + window.scrollY - headerOffset;
+        window.scrollTo({ top: scrollToY, behavior: 'smooth' });
+      }
+    },
+    [sectionQueryParam, headerOffset, loadedCourses],
+  );
+
+  const setConversationsSectionRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (sectionQueryParam === 'conversations' && node && loadedCourses) {
+        const scrollToY = node.getBoundingClientRect().top + window.scrollY - headerOffset;
+        window.scrollTo({ top: scrollToY, behavior: 'smooth' });
+      }
+    },
+    [sectionQueryParam, headerOffset, loadedCourses],
+  );
 
   useEffect(() => {
     if (
@@ -173,7 +198,7 @@ export default function CoursesPage({ courseStories, conversations, shorts }: Pr
         )}
       </Container>
       {conversations.length > 0 && (
-        <PageSection color={STORYBLOK_COLORS.SECONDARY_MAIN} alignment="left">
+        <Container sx={{ backgroundColor: 'secondary.main' }} ref={setConversationsSectionRef}>
           <Row numberOfColumns={1} horizontalAlignment="left" verticalAlignment="center">
             <Column width="full-width">
               <Typography variant="h2" fontWeight={500}>
@@ -211,10 +236,10 @@ export default function CoursesPage({ courseStories, conversations, shorts }: Pr
               />
             </Column>
           </Row>
-        </PageSection>
+        </Container>
       )}
       {loadedShorts && loadedShorts?.length > 0 && (
-        <PageSection color={STORYBLOK_COLORS.SECONDARY_LIGHT} alignment="left">
+        <Container sx={{ backgroundColor: 'secondary.light' }} ref={setShortsSectionRef}>
           <Row numberOfColumns={1} horizontalAlignment="left" verticalAlignment="center">
             <Column width="full-width">
               <Typography variant="h2" fontWeight={500}>
@@ -247,7 +272,7 @@ export default function CoursesPage({ courseStories, conversations, shorts }: Pr
               />
             </Column>
           </Row>
-        </PageSection>
+        </Container>
       )}
 
       {!userId && <SignUpBanner />}

--- a/components/resources/ResourceConversationHeader.tsx
+++ b/components/resources/ResourceConversationHeader.tsx
@@ -6,7 +6,7 @@ import { Link as i18nLink } from '@/i18n/routing';
 import { PROGRESS_STATUS } from '@/lib/constants/enums';
 import { RichTextOptions } from '@/lib/utils/richText';
 import illustrationCourses from '@/public/illustration_courses.svg';
-import theme from '@/styles/theme';
+import { breadcrumbButtonStyle } from '@/styles/common';
 import { Box, Button } from '@mui/material';
 import { ISbRichtext } from '@storyblok/react/rsc';
 import { useTranslations } from 'next-intl';
@@ -15,14 +15,6 @@ import { render } from 'storyblok-rich-text-react-renderer';
 const audioContainerStyle = {
   mt: { xs: 4, md: 6 },
   mb: 3,
-} as const;
-
-const backButtonStyle = {
-  background: theme.palette.background.default,
-  boxShadow: 'none !important',
-  ':hover': {
-    background: 'white',
-  },
 } as const;
 
 interface ResourceConversationHeaderProps {
@@ -71,8 +63,8 @@ export const ResourceConversationHeader = (props: ResourceConversationHeaderProp
       progressStatus={resourceProgress}
     >
       <Button
-        variant="outlined"
-        sx={backButtonStyle}
+        variant="contained"
+        sx={breadcrumbButtonStyle}
         href="/courses?section=conversations"
         component={i18nLink}
         size="small"

--- a/components/resources/ResourceConversationHeader.tsx
+++ b/components/resources/ResourceConversationHeader.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import Header from '@/components/layout/Header';
+import { ResourceConversationAudio } from '@/components/resources/ResourceConversationAudio';
+import { Link as i18nLink } from '@/i18n/routing';
+import { PROGRESS_STATUS } from '@/lib/constants/enums';
+import { RichTextOptions } from '@/lib/utils/richText';
+import illustrationCourses from '@/public/illustration_courses.svg';
+import theme from '@/styles/theme';
+import { Box, Button } from '@mui/material';
+import { ISbRichtext } from '@storyblok/react/rsc';
+import { useTranslations } from 'next-intl';
+import { render } from 'storyblok-rich-text-react-renderer';
+
+const audioContainerStyle = {
+  mt: { xs: 4, md: 6 },
+  mb: 3,
+} as const;
+
+const backButtonStyle = {
+  background: theme.palette.background.default,
+  boxShadow: 'none !important',
+  ':hover': {
+    background: 'white',
+  },
+} as const;
+
+interface ResourceConversationHeaderProps {
+  storyId: number;
+  name: string;
+  description: ISbRichtext;
+  header_image: { filename: string; alt: string };
+  resourceProgress: PROGRESS_STATUS;
+  audio: { filename: string };
+  audio_transcript: ISbRichtext;
+  eventData: { [key: string]: any };
+}
+
+export const ResourceConversationHeader = (props: ResourceConversationHeaderProps) => {
+  const {
+    storyId,
+    name,
+    description,
+    header_image,
+    resourceProgress,
+    audio,
+    audio_transcript,
+    eventData,
+  } = props;
+  const t = useTranslations('Resources');
+
+  return (
+    <Header
+      title={name}
+      introduction={
+        <Box display="flex" flexDirection="column" gap={3}>
+          {render(description, RichTextOptions)}
+          <Box sx={audioContainerStyle}>
+            <ResourceConversationAudio
+              eventData={eventData}
+              resourceProgress={resourceProgress}
+              name={name}
+              storyId={storyId}
+              audio={audio.filename}
+              audio_transcript={audio_transcript}
+            />
+          </Box>
+        </Box>
+      }
+      imageSrc={header_image ? header_image.filename : illustrationCourses}
+      progressStatus={resourceProgress}
+    >
+      <Button
+        variant="outlined"
+        sx={backButtonStyle}
+        href="/courses?section=conversations"
+        component={i18nLink}
+        size="small"
+      >
+        {t('backToConversations')}
+      </Button>
+    </Header>
+  );
+};

--- a/components/resources/ResourceShortsHeader.tsx
+++ b/components/resources/ResourceShortsHeader.tsx
@@ -7,7 +7,7 @@ import { COURSE_CATEGORIES, PROGRESS_STATUS } from '@/lib/constants/enums';
 import { RESOURCE_SHORT_VIDEO_VISIT_SESSION } from '@/lib/constants/events';
 import { getDefaultFullSlug } from '@/lib/utils/getDefaultFullSlug';
 import logEvent from '@/lib/utils/logEvent';
-import { columnStyle, rowStyle } from '@/styles/common';
+import { breadcrumbButtonStyle, columnStyle, rowStyle } from '@/styles/common';
 import theme from '@/styles/theme';
 import { Box, Button, Container, Typography } from '@mui/material';
 import { ISbRichtext, ISbStoryData } from '@storyblok/react/rsc';
@@ -25,26 +25,6 @@ const headerRightStyle = {
 const headerLeftStyles = {
   width: 514, // >515px enables the "watch on youtube" button
   maxWidth: '100%',
-} as const;
-
-const progressStyle = {
-  ...rowStyle,
-  alignItems: 'center',
-  justifyContent: 'flex-start',
-  gap: 3,
-  mt: 2,
-  '.MuiBox-root': {
-    mt: 0,
-  },
-} as const;
-
-const backButtonStyle = {
-  mb: 4,
-  background: theme.palette.background.default,
-  boxShadow: 'none !important',
-  ':hover': {
-    background: 'white',
-  },
 } as const;
 
 interface ResourceShortHeaderProps {
@@ -83,8 +63,8 @@ export const ResourceShortHeader = (props: ResourceShortHeaderProps) => {
   return (
     <Container sx={{ background: theme.palette.bloomGradient }}>
       <Button
-        variant="outlined"
-        sx={backButtonStyle}
+        variant="contained"
+        sx={breadcrumbButtonStyle}
         href="/courses?section=shorts"
         component={i18nLink}
         size="small"
@@ -104,11 +84,7 @@ export const ResourceShortHeader = (props: ResourceShortHeaderProps) => {
             video={video}
             video_transcript={video_transcript}
           />
-          {resourceProgress && (
-            <Box sx={progressStyle}>
-              {resourceProgress && <ProgressStatus status={resourceProgress} />}
-            </Box>
-          )}
+          {resourceProgress && <ProgressStatus status={resourceProgress} />}
         </Box>
         {relatedSession && (
           <Box sx={headerRightStyle}>

--- a/components/resources/ResourceShortsHeader.tsx
+++ b/components/resources/ResourceShortsHeader.tsx
@@ -64,7 +64,7 @@ export const ResourceShortHeader = (props: ResourceShortHeaderProps) => {
     <Container sx={{ background: theme.palette.bloomGradient }}>
       <Button
         variant="contained"
-        sx={breadcrumbButtonStyle}
+        sx={{ ...breadcrumbButtonStyle, mb: 4 }}
         href="/courses?section=shorts"
         component={i18nLink}
         size="small"

--- a/components/resources/ResourceShortsHeader.tsx
+++ b/components/resources/ResourceShortsHeader.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import ProgressStatus from '@/components/common/ProgressStatus';
+import { ResourceShortVideo } from '@/components/resources/ResourceShortVideo';
+import { Link as i18nLink } from '@/i18n/routing';
+import { COURSE_CATEGORIES, PROGRESS_STATUS } from '@/lib/constants/enums';
+import { RESOURCE_SHORT_VIDEO_VISIT_SESSION } from '@/lib/constants/events';
+import { getDefaultFullSlug } from '@/lib/utils/getDefaultFullSlug';
+import logEvent from '@/lib/utils/logEvent';
+import { columnStyle, rowStyle } from '@/styles/common';
+import theme from '@/styles/theme';
+import { Box, Button, Container, Typography } from '@mui/material';
+import { ISbRichtext, ISbStoryData } from '@storyblok/react/rsc';
+import { useLocale, useTranslations } from 'next-intl';
+
+const headerStyle = { ...rowStyle, flexWrap: { xs: 'wrap', md: 'no-wrap' }, gap: 5 } as const;
+const headerRightStyle = {
+  ...columnStyle,
+  justifyContent: 'flex-end',
+  flex: { md: 1 },
+  width: { md: '100%' },
+  height: { md: 290 },
+} as const;
+
+const headerLeftStyles = {
+  width: 514, // >515px enables the "watch on youtube" button
+  maxWidth: '100%',
+} as const;
+
+const progressStyle = {
+  ...rowStyle,
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+  gap: 3,
+  mt: 2,
+  '.MuiBox-root': {
+    mt: 0,
+  },
+} as const;
+
+const backButtonStyle = {
+  mb: 4,
+  background: theme.palette.background.default,
+  boxShadow: 'none !important',
+  ':hover': {
+    background: 'white',
+  },
+} as const;
+
+interface ResourceShortHeaderProps {
+  storyId: number;
+  name: string;
+  resourceProgress: PROGRESS_STATUS;
+  relatedSession: ISbStoryData;
+  relatedCourse: ISbStoryData;
+  video: { url: string };
+  video_transcript: ISbRichtext;
+  eventData: { [key: string]: any };
+}
+
+export const ResourceShortHeader = (props: ResourceShortHeaderProps) => {
+  const {
+    storyId,
+    name,
+    relatedSession,
+    relatedCourse,
+    resourceProgress,
+    video,
+    video_transcript,
+    eventData,
+  } = props;
+  const t = useTranslations('Resources');
+  const locale = useLocale();
+
+  const redirectToSession = () => {
+    logEvent(RESOURCE_SHORT_VIDEO_VISIT_SESSION, {
+      ...eventData,
+      shorts_name: name,
+      session_name: relatedSession?.name,
+    });
+  };
+
+  return (
+    <Container sx={{ background: theme.palette.bloomGradient }}>
+      <Button
+        variant="outlined"
+        sx={backButtonStyle}
+        href="/courses?section=shorts"
+        component={i18nLink}
+        size="small"
+      >
+        {t('backToShorts')}
+      </Button>
+      <Typography variant="h1" maxWidth={600}>
+        {name}
+      </Typography>
+      <Box sx={headerStyle}>
+        <Box sx={headerLeftStyles}>
+          <ResourceShortVideo
+            eventData={eventData}
+            resourceProgress={resourceProgress}
+            name={name}
+            storyId={storyId}
+            video={video}
+            video_transcript={video_transcript}
+          />
+          {resourceProgress && (
+            <Box sx={progressStyle}>
+              {resourceProgress && <ProgressStatus status={resourceProgress} />}
+            </Box>
+          )}
+        </Box>
+        {relatedSession && (
+          <Box sx={headerRightStyle}>
+            {/* Description field is not currently displayed */}
+            {/* {render(description, RichTextOptions)} */}
+
+            <Typography component="h2" mb={2}>
+              {t('sessionDetail', {
+                sessionNumber:
+                  relatedSession.content.component === COURSE_CATEGORIES.COURSE
+                    ? 0
+                    : relatedSession.position / 10 - 1,
+                sessionName: relatedSession.content.name,
+                courseName: relatedCourse?.content.name,
+              })}
+            </Typography>
+            <Button
+              href={getDefaultFullSlug(relatedSession.full_slug, locale)}
+              component={i18nLink}
+              onClick={redirectToSession}
+              variant="contained"
+              color="secondary"
+              sx={{ mr: 'auto' }}
+            >
+              {t('sessionButtonLabel')}
+            </Button>
+          </Box>
+        )}
+      </Box>
+    </Container>
+  );
+};

--- a/components/session/SessionHeader.tsx
+++ b/components/session/SessionHeader.tsx
@@ -5,20 +5,13 @@ import { Link as i18nLink } from '@/i18n/routing';
 import { PROGRESS_STATUS } from '@/lib/constants/enums';
 import { getDefaultFullSlug } from '@/lib/utils/getDefaultFullSlug';
 import illustrationPerson4Peach from '@/public/illustration_person4_peach.svg';
+import { breadcrumbButtonStyle } from '@/styles/common';
 import theme from '@/styles/theme';
 import CircleIcon from '@mui/icons-material/Circle';
-import { Button, Typography } from '@mui/material';
+import { Button, Typography, useMediaQuery } from '@mui/material';
 import { ISbRichtext, ISbStoryData } from '@storyblok/react/rsc';
 import { useLocale, useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
-
-const buttonStyle = {
-  background: theme.palette.background.default,
-  boxShadow: 'none !important',
-  ':hover': {
-    background: 'white',
-  },
-} as const;
 
 const sessionSubtitleStyle = {
   marginTop: '0.75rem !important',
@@ -43,6 +36,7 @@ export const SessionHeader = (props: SessionHeaderProps) => {
 
   const t = useTranslations('Courses');
   const locale = useLocale();
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   const [weekString, setWeekString] = useState<string>('');
 
@@ -63,6 +57,10 @@ export const SessionHeader = (props: SessionHeaderProps) => {
     });
   }, [storyUuid, course.content.weeks]);
 
+  const courseNameEllipses =
+    isSmallScreen && course.content.name.length > 35
+      ? `${course.content.name.substring(0, 35)}...`
+      : course.content.name;
   return (
     <Header
       title={headerProps.title}
@@ -71,20 +69,20 @@ export const SessionHeader = (props: SessionHeaderProps) => {
       imageAlt={headerProps.imageAlt}
       progressStatus={sessionProgress}
     >
-      <Button variant="contained" href="/courses" sx={buttonStyle} size="small">
-        Courses
+      <Button variant="contained" href="/courses" sx={breadcrumbButtonStyle} size="small">
+        {t('courses')}
       </Button>
 
       <CircleIcon color="error" sx={{ ...dotStyle, marginX: 1 }} />
 
       <Button
         variant="contained"
-        sx={buttonStyle}
+        sx={breadcrumbButtonStyle}
         href={getDefaultFullSlug(course.full_slug, locale)}
         component={i18nLink}
         size="small"
       >
-        {course.name}
+        {courseNameEllipses}
       </Button>
       <Typography sx={sessionSubtitleStyle} variant="body2">
         {weekString} -{' '}

--- a/components/storyblok/StoryblokAccordion.tsx
+++ b/components/storyblok/StoryblokAccordion.tsx
@@ -4,20 +4,24 @@ import { ACCORDION_OPENED, generateAccordionEvent } from '@/lib/constants/events
 import { getImageSizes } from '@/lib/utils/imageSizes';
 import logEvent from '@/lib/utils/logEvent';
 import { RichTextOptions } from '@/lib/utils/richText';
+import muiTheme from '@/styles/theme';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { Box } from '@mui/material';
+
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
-  Box,
   Icon,
   Typography,
+  useMediaQuery,
 } from '@mui/material';
 import { storyblokEditable } from '@storyblok/react/rsc';
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { render } from 'storyblok-rich-text-react-renderer';
+
 const containerStyle = {
   width: '100%',
   maxWidth: 725,
@@ -55,6 +59,8 @@ interface StoryblokAccordionProps {
 const StoryblokAccordion = (props: StoryblokAccordionProps) => {
   const { _uid, _editable, accordion_items, theme } = props;
   const searchParams = useSearchParams();
+  const isSmallScreen = useMediaQuery(muiTheme.breakpoints.down('md'));
+  const headerOffset = isSmallScreen ? 48 : 136;
 
   const handleChange =
     (accordionTitle: string) => (_event: React.SyntheticEvent, isExpanded: boolean) => {
@@ -70,10 +76,13 @@ const StoryblokAccordion = (props: StoryblokAccordionProps) => {
 
   useEffect(() => {
     if (accordionInUrl && scrollRef.current) {
+      const scrollToY =
+        // @ts-ignore
+        scrollRef.current.getBoundingClientRect().top + window.scrollY - headerOffset - 16;
+      window.scrollTo({ top: scrollToY, behavior: 'smooth' });
       // @ts-ignore
-      scrollRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
-  }, [searchParams, accordionInUrl]);
+  }, [headerOffset, accordionInUrl]);
 
   return (
     <Box sx={containerStyle} {...storyblokEditable({ _uid, _editable, accordion_items, theme })}>

--- a/components/storyblok/StoryblokRelatedContent.tsx
+++ b/components/storyblok/StoryblokRelatedContent.tsx
@@ -32,18 +32,21 @@ export const StoryblokRelatedContent = (props: StoryblokRelatedContentProps) => 
   const tExerciseNames = useTranslations('Shared.exerciseNames');
   const locale = useLocale();
 
-  const relatedExercisesItems = relatedExercises.map((relatedExerciseId) => {
-    const exerciseCategory: EXERCISE_CATEGORIES = relatedExerciseId.includes('grounding-')
-      ? EXERCISE_CATEGORIES.GROUNDING
-      : EXERCISE_CATEGORIES.ACTIVITIES;
+  const relatedExercisesItems =
+    locale === 'de'
+      ? [] // exercises are not currently available in german so we'll return an empty list for 'de'
+      : relatedExercises.map((relatedExerciseId) => {
+          const exerciseCategory: EXERCISE_CATEGORIES = relatedExerciseId.includes('grounding-')
+            ? EXERCISE_CATEGORIES.GROUNDING
+            : EXERCISE_CATEGORIES.ACTIVITIES;
 
-    return {
-      id: relatedExerciseId,
-      name: tExerciseNames(relatedExerciseId),
-      href: `/${exerciseCategory}?openacc=${relatedExerciseId}`,
-      category: exerciseCategory,
-    };
-  });
+          return {
+            id: relatedExerciseId,
+            name: tExerciseNames(relatedExerciseId),
+            href: `/${exerciseCategory}?openacc=${relatedExerciseId}`,
+            category: exerciseCategory,
+          };
+        });
 
   const disabledCoursesString = process.env.FF_DISABLED_COURSES;
 

--- a/components/storyblok/StoryblokResourceConversationPage.tsx
+++ b/components/storyblok/StoryblokResourceConversationPage.tsx
@@ -2,25 +2,19 @@
 
 import { SignUpBanner } from '@/components/banner/SignUpBanner';
 import PageSection from '@/components/common/PageSection';
-import ProgressStatus from '@/components/common/ProgressStatus';
 import ResourceFeedbackForm from '@/components/forms/ResourceFeedbackForm';
-import Header from '@/components/layout/Header';
-import { ResourceCompleteButton } from '@/components/resources/ResourceCompleteButton';
-import { ResourceConversationAudio } from '@/components/resources/ResourceConversationAudio';
 import { PROGRESS_STATUS, RESOURCE_CATEGORIES, STORYBLOK_COLORS } from '@/lib/constants/enums';
 import { RESOURCE_CONVERSATION_VIEWED } from '@/lib/constants/events';
 import { useTypedSelector } from '@/lib/hooks/store';
 import { Resource } from '@/lib/store/resourcesSlice';
 import logEvent from '@/lib/utils/logEvent';
-import { RichTextOptions } from '@/lib/utils/richText';
 import userHasAccessToPartnerContent from '@/lib/utils/userHasAccessToPartnerContent';
-import illustrationCourses from '@/public/illustration_courses.svg';
 import { rowStyle } from '@/styles/common';
 import { Box, Container, Typography } from '@mui/material';
 import { ISbRichtext, storyblokEditable } from '@storyblok/react/rsc';
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo, useState } from 'react';
-import { render } from 'storyblok-rich-text-react-renderer';
+import { ResourceConversationHeader } from '../resources/ResourceConversationHeader';
 import { StoryblokPageSectionProps } from './StoryblokPageSection';
 import { StoryblokRelatedContent, StoryblokRelatedContentStory } from './StoryblokRelatedContent';
 
@@ -73,7 +67,6 @@ const StoryblokResourceConversationPage = (props: StoryblokResourceConversationP
     related_exercises,
   } = props;
 
-  const t = useTranslations('Resources');
   const tS = useTranslations('Shared');
   const userId = useTypedSelector((state) => state.user.id);
 
@@ -126,38 +119,17 @@ const StoryblokResourceConversationPage = (props: StoryblokResourceConversationP
         related_exercises,
       })}
     >
-      <Header
-        title={name}
-        introduction={
-          <Box display="flex" flexDirection="column" gap={3}>
-            {render(description, RichTextOptions)}
-            <Box sx={audioContainerStyle}>
-              <ResourceConversationAudio
-                eventData={eventData}
-                resourceProgress={resourceProgress}
-                name={name}
-                storyId={storyId}
-                audio={audio.filename}
-                audio_transcript={audio_transcript}
-              />
-            </Box>
-            <Box>
-              {resourceId && (
-                <Box sx={progressStyle}>
-                  {resourceProgress && <ProgressStatus status={resourceProgress} />}
-                  {resourceProgress !== PROGRESS_STATUS.COMPLETED && (
-                    <ResourceCompleteButton
-                      category={RESOURCE_CATEGORIES.SHORT_VIDEO}
-                      storyId={storyId}
-                      eventData={eventData}
-                    />
-                  )}
-                </Box>
-              )}
-            </Box>
-          </Box>
-        }
-        imageSrc={header_image ? header_image.filename : illustrationCourses}
+      <ResourceConversationHeader
+        {...{
+          storyId,
+          name,
+          description,
+          header_image,
+          resourceProgress,
+          audio,
+          audio_transcript,
+          eventData,
+        }}
       />
       {resourceId && (
         <Container sx={{ bgcolor: 'background.paper' }}>

--- a/i18n/messages/resources/de.json
+++ b/i18n/messages/resources/de.json
@@ -1,5 +1,7 @@
 {
   "Resources": {
+    "backToConversations": "Zurück zu den Gesprächen",
+    "backToShorts": "Zurück zu den Kurzfilmen",
     "conversations": "Gespräche",
     "shorts": "Kurzfilme",
     "completed": "Abgeschlossen",

--- a/i18n/messages/resources/en.json
+++ b/i18n/messages/resources/en.json
@@ -1,5 +1,7 @@
 {
   "Resources": {
+    "backToConversations": "Back to conversations",
+    "backToShorts": "Back to shorts",
     "conversations": "Conversations",
     "shorts": "Shorts",
     "completed": "Completed",

--- a/i18n/messages/resources/es.json
+++ b/i18n/messages/resources/es.json
@@ -1,5 +1,7 @@
 {
   "Resources": {
+    "backToConversations": "Ir a las conversaciones",
+    "backToShorts": "Ir a los cortos",
     "conversations": "Conversaciones",
     "shorts": "Cortos",
     "completed": "Completado",

--- a/i18n/messages/resources/fr.json
+++ b/i18n/messages/resources/fr.json
@@ -1,5 +1,7 @@
 {
   "Resources": {
+    "backToConversations": "Revenir aux conversations",
+    "backToShorts": "Revenir aux courtes",
     "conversations": "Conversations",
     "shorts": "Courte",
     "completed": "Terminé",

--- a/i18n/messages/resources/hi.json
+++ b/i18n/messages/resources/hi.json
@@ -1,5 +1,7 @@
 {
   "Resources": {
+    "backToConversations": "Conversations par vaapas jaaen",
+    "backToShorts": "Clips par vaapas jaaen",
     "conversations": "Bātcīt",
     "shorts": "Clips",
     "completed": "Pūra",

--- a/i18n/messages/resources/pt.json
+++ b/i18n/messages/resources/pt.json
@@ -1,5 +1,7 @@
 {
   "Resources": {
+    "backToConversations": "Voltar às conversas",
+    "backToShorts": "Voltar às curtas",
     "conversations": "Conversas",
     "shorts": "Curtas",
     "completed": "Concluído",

--- a/styles/common.ts
+++ b/styles/common.ts
@@ -33,6 +33,14 @@ export const richtextContentStyle = {
   },
 } as const;
 
+export const breadcrumbButtonStyle = {
+  backgroundColor: 'background.default',
+  boxShadow: 'none !important',
+  ':hover': {
+    background: 'white',
+  },
+} as const;
+
 export const scaleTitleStyle = {
   marginBottom: '0.5rem !important',
   fontStyle: 'italic',


### PR DESCRIPTION
### What changes did you make and why did you make them?
- Adds a "Back to conversations" and "Back to shorts" button to resource pages - scrolls to relevant list section on courses 
- Fixes session breadcrumb buttons that were previously only displaying "course" -> "overview" and not being translated. is now translated and shows the course name instead of "overview"
- prevents related content exercises and activities being shown for german, as the pages are not translated
- removes use of user research banner