### PR TITLE
Skip after cypress cleanup

### DIFF
--- a/cypress/integration/after/after.cy.tsx
+++ b/cypress/integration/after/after.cy.tsx
@@ -1,4 +1,4 @@
-describe('Cleanup function for after all cypress tests', () => {
+describe.skip('Cleanup function for after all cypress tests', () => {
   it('Should be triggered', () => {
     const superAdminEmail = Cypress.env('CYPRESS_SUPER_ADMIN_EMAIL');
     const superAdminPassword = Cypress.env('CYPRESS_SUPER_ADMIN_PASSWORD');


### PR DESCRIPTION
### What changes did you make and why did you make them?
Skips the cleanup cypress users test, as superadmin access is broken in cypress for now - see #1317 