### PR TITLE
fix: Ensure consistent course card heights on '/courses' page

### DIFF
--- a/components/cards/CourseCard.tsx
+++ b/components/cards/CourseCard.tsx
@@ -61,7 +61,7 @@ const titleContainerStyle = {
 
 const titleStyle = {
   display: '-webkit-box',
-  WebkitLineClamp: 2,
+  WebkitLineClamp: 3,
   WebkitBoxOrient: 'vertical',
   overflow: 'hidden',
   textOverflow: 'ellipsis',

--- a/components/cards/CourseCard.tsx
+++ b/components/cards/CourseCard.tsx
@@ -26,6 +26,8 @@ const cardStyle = {
   alignSelf: 'flex-start',
   width: '100%',
   backgroundColor: 'background.default',
+  display: 'flex',
+  flexDirection: 'column',
 } as const;
 
 const cardContentStyle = {
@@ -49,6 +51,20 @@ const imageContainerStyle = {
   width: '100%',
   maxHeight: '110px',
   minHeight: '72px',
+} as const;
+
+const titleContainerStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+} as const;
+
+const titleStyle = {
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
 } as const;
 
 const collapseContentStyle = {
@@ -106,8 +122,8 @@ const CourseCard = (props: CourseCardProps) => {
                 }}
               />
             </Box>
-            <Box flex={[3, 2]}>
-              <Typography component="h3" variant="h3">
+            <Box flex={[3, 2]} sx={titleContainerStyle}>
+              <Typography component="h3" variant="h3" sx={expanded ? {} : titleStyle}>
                 {course.content.name}
               </Typography>
             </Box>
@@ -126,8 +142,8 @@ const CourseCard = (props: CourseCardProps) => {
               }}
             />
           </Box>
-          <Box flex={1}>
-            <Typography component="h3" variant="h3">
+          <Box flex={1} sx={titleContainerStyle}>
+            <Typography component="h3" variant="h3" sx={expanded ? {} : titleStyle}>
               {course.content.name}
             </Typography>
             {!!courseProgress && courseProgress !== PROGRESS_STATUS.NOT_STARTED && (


### PR DESCRIPTION
### Resolves #1262 

### What changes did you make and why did you make them?

- Set a uniform height for all course cards on the '/courses' page to address UI inconsistencies caused by varying title lengths.
- Implement responsive design adjustments to maintain consistent card heights across different devices (mobile, browser, tablet, etc).
- Verified that the course card heights remain uniform and responsive on various screen sizes.

### Did you run tests? Share screenshot of results:

Yes
![image](https://github.com/user-attachments/assets/f2c2aa09-7fa2-4c07-8aee-203b625a42d5)

### How did you find us? (GitHub, Google search, social media, etc.):

https://forgoodfirstissue.github.com/

<!---ABOUT RUNNING TESTS :->
- Directions for running tests are in the README.md.
- Tests are not required to pass. 
- Run unit tests
- Run Cypress tests if required for contribution.
- Some tests may require multiple runs before success.
- Some test failures may not be due to your contribution and can be ignored. We are always upgrading testing performance.

<!--- PR CHECKLIST: —>
Before submitting, check that you have completed the following tasks:
- [ ] Answered the questions above.
- [ ] Enabled "Allow edits and access to secrets by maintainers" on this PR.
- [ ] If applicable, include images in the description.
After submitting, please be available for discussion. Thank you!
