### PR TITLE
feat: login link on create account page, centre align login header

### DIFF
--- a/components/pages/LoginPage.tsx
+++ b/components/pages/LoginPage.tsx
@@ -43,7 +43,6 @@ const headerContentStyle = {
   alignItems: 'center',
   gap: 3,
   width: '100%',
-  maxWidth: 400,
 };
 
 const backButtonStyle = {
@@ -127,7 +126,7 @@ export default function LoginPage() {
           <KeyboardArrowLeftIcon sx={backIconStyle} />
         </IconButton>
         <Box sx={headerContentStyle}>
-          <Box>
+          <Box textAlign="center">
             <Typography variant="h1" component="h1" marginBottom={0}>
               {t('login.title')}
             </Typography>

--- a/components/pages/RegisterPage.tsx
+++ b/components/pages/RegisterPage.tsx
@@ -204,6 +204,15 @@ export default function RegisterPage() {
               ) : (
                 <RegisterForm />
               )}
+              <Typography variant="body2" component="p" textAlign="center" mb={1}>
+                {t.rich('register.loginRedirect', {
+                  loginLink: (children) => (
+                    <Link component={i18nLink} href="/auth/login">
+                      {children}
+                    </Link>
+                  ),
+                })}
+              </Typography>
 
               <Typography variant="body2" component="p" textAlign="center">
                 {t.rich('terms', {


### PR DESCRIPTION
### Resolves #enter-issue-number
N/A

### What changes did you make and why did you make them?
- New login link on create account page

### Did you run tests? Share screenshot of results:
Yup

<img width="597" alt="Screenshot 2025-02-24 at 16 25 47" src="https://github.com/user-attachments/assets/6eca71d7-1e26-4071-885f-cbb2199c55d5" />
