### PR TITLE
Fix intl redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -56,8 +56,18 @@ module.exports = withBundleAnalyzer(
             permanent: false,
           },
           {
+            source: '/:locale(en|es|de|fr|pt|hi)/welcome',
+            destination: '/:locale/courses',
+            permanent: false,
+          },
+          {
             source: '/login',
             destination: '/courses',
+            permanent: false,
+          },
+          {
+            source: '/:locale(en|es|de|fr|pt|hi)/login',
+            destination: '/:locale/courses',
             permanent: false,
           },
           {
@@ -66,8 +76,18 @@ module.exports = withBundleAnalyzer(
             permanent: true,
           },
           {
+            source: '/:locale(en|es|de|fr|pt|hi)/partnership/:path*',
+            destination: '/:locale/welcome/:path*',
+            permanent: true,
+          },
+          {
             source: '/chat',
             destination: '/messaging',
+            permanent: true,
+          },
+          {
+            source: '/:locale(en|es|de|fr|pt|hi)/chat',
+            destination: '/:locale/messaging',
             permanent: true,
           },
         ];


### PR DESCRIPTION
### What changes did you make and why did you make them?
Fixes intl/locale redirects leading to 404. 

The issue was next-intl routing was not being applied to the `next.config.js` redirects, so we need to add additional locale matchers for redirects