### PR TITLE
fix: Improve accordion styling and default state

### DIFF
--- a/components/storyblok/StoryblokAccordion.tsx
+++ b/components/storyblok/StoryblokAccordion.tsx
@@ -25,19 +25,45 @@ import { render } from 'storyblok-rich-text-react-renderer';
 const containerStyle = {
   width: '100%',
   maxWidth: 725,
-  marginBottom: 5,
+  marginBottom: 0,
   marginX: 'auto',
 } as const;
 
 const accordionDetail = {
   textAlign: 'left',
+  backgroundColor: 'rgba(0, 0, 0, 0.09)',
 } as const;
 
 const themes = {
-  primary: {}, // uses default styling
+  primary: {
+    '&.MuiAccordion-root': {
+      margin: 0,
+      '&:before': {
+        display: 'none',
+      },
+    },
+    '&.Mui-expanded': {
+      '& .MuiAccordionDetails-root': {
+        borderTop: '1px solid rgba(0, 0, 0, 0.08)',
+      }
+    },
+
+  }, // uses default styling
   secondary: {
     '& .MuiAccordionSummary-expandIconWrapper': { color: 'primary.dark' },
     backgroundColor: 'paleSecondaryLight',
+    '&.MuiAccordion-root': {
+      margin: 0,
+      '&:before': {
+        display: 'none',
+      },
+    },
+    '&.Mui-expanded': {
+      '& .MuiAccordionDetails-root': {
+        backgroundColor: 'rgba(0, 0, 0, 0.09)',
+        borderTop: '1px solid rgba(0, 0, 0, 0.08)',
+      }
+    }
   },
 };
 
@@ -91,7 +117,7 @@ const StoryblokAccordion = (props: StoryblokAccordionProps) => {
           id={ai.accordion_id ?? undefined}
           ref={ai.accordion_id === accordionInUrl ? scrollRef : undefined}
           key={`panel${i}`}
-          defaultExpanded={accordionInUrl === ai.accordion_id ? true : false}
+          defaultExpanded={false}
           onChange={handleChange(ai.title)}
           sx={themes[theme]}
         >


### PR DESCRIPTION
### Resolves #1372

### What changes did you make and why did you make them?
Made several improvements to the accordion component in the messaging page:
1. Set accordions to be closed by default to improve initial page load experience
2. Removed unwanted spacing that appeared between accordions when opened
3. Added subtle background color (rgba(0, 0, 0, 0.09)) to accordion content for better visual distinction

### UI Changes:
![Screenshot 2025-03-26 180320](https://github.com/user-attachments/assets/ea413c44-3b72-4fe0-9ef5-5e0597fab667)


These changes improve the user experience by:
- Reducing cognitive load on initial page load
- Creating better visual hierarchy between header and content
- Maintaining consistent spacing between elements
- Improving overall readability

### Test Results:
![Screenshot 2025-03-29 202017](https://github.com/user-attachments/assets/20ae28de-5a2a-40c3-87e1-aa400744c533)


### How did you find us? (GitHub, Google search, social media, etc.):
 I found you through For Good First Issue (https://forgoodfirstissue.github.com/).

<!--- PR CHECKLIST: —>
Before submitting, check that you have completed the following tasks:
- [x] Answered the questions above.
- [x] Enabled "Allow edits and access to secrets by maintainers" on this PR.
- [x] If applicable, include images in the description.