### PR TITLE
Actions: Remove Cypress parallelization from cypress-release-test.yml

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -32,16 +32,6 @@ jobs:
       contents: read
       checks: write
       deployments: read
-    strategy:
-      # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
-      # leaving Cypress Cloud hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
-      fail-fast: false
-      matrix:
-        # run 3 copies of the current job in parallel
-        # this will automatically load balance
-        containers: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,7 +49,6 @@ jobs:
           config-file: cypress.config.ts
           headed: false
           record: true # send results to cypress dashboard
-          parallel: true
         env:
           NEXT_PUBLIC_ROLLBAR_ENV: CI
           NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: ci


### PR DESCRIPTION
### Resolves #enter-issue-number N/A

### What changes did you make and why did you make them?

Currently, Cypress parallelization is non-functional in the GHA environment due to Cypress Cloud free tier limits.
Since we have decided to move forward without purchasing the paid tier, parallelization is being removed.

Removes parallelization from `cypress-release-test.yml`, keeping parallelization on `cypress-test.yml` for reference as its mainly run by staff. When the paid tier is purchased, parallelization will work as it is with dynamic distribution.
See internal notes for more information & links.
