### PR TITLE
added GA4 detection of events PWA_DISMISSED and PWA_INSTALLED

### DIFF
--- a/lib/hooks/usePWA.test.ts
+++ b/lib/hooks/usePWA.test.ts
@@ -5,6 +5,14 @@ import { setPwaDismissed } from '../store/userSlice';
 import { useAppDispatch, useTypedSelector } from './store';
 import usePWA from './usePwa';
 
+// Mocking track functions for vercel and GA4
+jest.mock('@vercel/analytics/react', () => ({
+  track: jest.fn(),
+}));
+jest.mock('@next/third-parties/google', () => ({
+  sendGAEvent: jest.fn(),
+}));
+
 jest.mock('js-cookie');
 jest.mock('./store', () => ({
   useTypedSelector: jest.fn(),

--- a/lib/hooks/usePwa.ts
+++ b/lib/hooks/usePwa.ts
@@ -1,9 +1,11 @@
 'use client';
 
+import { useAppDispatch, useTypedSelector } from '@/lib/hooks/store';
+import { setPwaDismissed } from '@/lib/store/userSlice';
+import logEvent from '@/lib/utils/logEvent';
 import Cookies from 'js-cookie';
 import { useEffect, useMemo, useState } from 'react';
-import { setPwaDismissed } from '@/lib/store/userSlice';
-import { useAppDispatch, useTypedSelector } from '@/lib/hooks/store';
+import { PWA_DISMISSED, PWA_INSTALLED } from '../constants/events';
 
 type UserChoice = Promise<{
   outcome: 'accepted' | 'dismissed';
@@ -17,7 +19,7 @@ interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
 }
 
-const PWA_DISMISSED = 'pwaBannerDismissed';
+const PWA_BANNER_DISMISSED = 'pwaBannerDismissed';
 
 export default function usePWA() {
   const [bannerState, setBannerState] = useState<PwaBannerState>('Generic');
@@ -31,9 +33,35 @@ export default function usePWA() {
     [],
   );
 
+  const getPwaMetaData = useMemo(() => {
+    const userAgent = window.navigator.userAgent;
+    const platform = userAgent.includes('Win')
+      ? 'Windows'
+      : userAgent.includes('Mac')
+        ? 'MacOS'
+        : userAgent.includes('Linux')
+          ? 'Linux'
+          : 'Unknown OS';
+
+    const browser = userAgent.includes('Chrome')
+      ? 'Chrome'
+      : userAgent.includes('Firefox')
+        ? 'Firefox'
+        : userAgent.includes('Safari')
+          ? 'Safari'
+          : userAgent.includes('Edge')
+            ? 'Edge'
+            : userAgent.includes('Edge')
+              ? 'Opera'
+              : 'Unknown Browser';
+
+    return { browser, platform };
+  }, []);
+
   const declineInstallation = async () => {
     if (userCookiesAccepted) {
-      Cookies.set(PWA_DISMISSED, 'true');
+      Cookies.set(PWA_BANNER_DISMISSED, 'true');
+      logEvent(PWA_DISMISSED, getPwaMetaData);
     }
     setBannerState('Hidden');
     await dispatch(setPwaDismissed(true));
@@ -50,12 +78,15 @@ export default function usePWA() {
      * immediately after installation. In some cases, isStandalone might
      * still return false momentarily, causing the banner to reappear.
      */
+    if (userCookiesAccepted) {
+      logEvent(PWA_INSTALLED, getPwaMetaData);
+    }
     window.beforeinstallpromptEvent = undefined;
     setBannerState('Hidden');
   };
 
   useEffect(() => {
-    const pwaBannerDismissedCookie = Boolean(Cookies.get(PWA_DISMISSED));
+    const pwaBannerDismissedCookie = Boolean(Cookies.get(PWA_BANNER_DISMISSED));
     const isStandalone =
       typeof window !== 'undefined' && window.matchMedia('(display-mode: standalone)').matches;
     const isHidden =


### PR DESCRIPTION
### Resolves #1470

### What changes did you make and why did you make them?
I used the logEvent method to add the events to GA4. 
I changed the local variable PWA_DISMISSED to PWA_BANNER_DISMISSED (this was the one used to set the cookie). This way I could use the PWA_DISMISSED and PWA_INSTALLED from /constants/events.
created a memoized function getPwaMetaData in usePwa.ts that extracts **browser** and **platform** from **navigator.userAgent**. Another alternative was to add this somewhere in the **lib/utils/pwaDetection**. I can do that upon request. 
Added mock functions for the test file for sending events to vercel and GA4

### Did you run tests? Share screenshot of results
Yes, they ran
![unit_tests_running](https://github.com/user-attachments/assets/ef5ff911-2f9b-4960-8a09-3cc83b9c5ce4)

Steps to check and troubleshoot this in GA4:-
- First navigate to the "Debug View" by clicking on 
Settings (Gear Icon) -> Data-Display -> Debug View
![directions to debug view](https://github.com/user-attachments/assets/a98b5037-9ee3-4969-8f77-56059afc335b)

- while debugView is open, run localhost on your browser and ensure that the cookie called "analyticsConsent" is set to true
![consent cookie](https://github.com/user-attachments/assets/961713bd-ea06-4291-a0b5-b0ef4e708d55)


- in the localhost, click on the hamburger menu and then click on either of the PWA buttons and wait for about a minute while keeping an eye on debugView. You should see the event.
![event shows up in debug View](https://github.com/user-attachments/assets/794191c1-1194-4850-be42-e05f4edc1c3a)

- click on the event to look at the metadata
![click to look at metadata](https://github.com/user-attachments/assets/900b11e4-292e-46ea-8120-f890a9a2e670)

If this is not working, check if there are any blockers, delete the cookies that were saved and refresh to test again.
