### PR TITLE
refactor: replace deprecated images.domains with images.remotePatterns

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -45,7 +45,7 @@ module.exports = withBundleAnalyzer(
         emotion: true,
       },
       images: {
-        domains: ['a.storyblok.com'],
+        remotePatterns: [{ protocol: 'https', hostname: 'a.storyblok.com' }],
       },
       serverExternalPackages: ['newrelic'],
       async redirects() {


### PR DESCRIPTION
### Deprecated Image Configuration in Next.js #1439

### What changes did you make and why did you make them?
Replace images.domains with images.remotePatterns in next.config.js.

<!--- PR CHECKLIST: —>
- [x] Answered the questions above.
- [x] Enabled "Allow edits and access to secrets by maintainers" on this PR.
- [ ] If applicable, include images in the description.
