### PR TITLE
Add Cypress integration test for new Conversations feature

### DIFF
--- a/cypress/integration/tests/conversations.cy.tsx
+++ b/cypress/integration/tests/conversations.cy.tsx
@@ -1,0 +1,48 @@
+describe('Conversations Flow', () => {
+  const email = `cypresstestemail+${Date.now()}@chayn.co`;
+  const password = 'testtesttest';
+
+  before(() => {
+    cy.cleanUpTestState();
+    cy.createUser({ emailInput: email, passwordInput: password });
+  });
+
+  it('Should allow a user to navigate to Courses, select a conversation, log in, play audio, and submit feedback.', () => {
+    // User visits the home page
+    cy.visit('/');
+
+    // User clicks on Courses
+    cy.get(`[qa-id=secondary-nav-courses-button]`, { timeout: 10000 }).should('exist').click();
+
+    // User clicks on a conversation
+    cy.contains('Stolen faces: How fake images leave real scars', {
+      timeout: 10000,
+    })
+      .should('exist')
+      .click();
+
+    // User is prompted to login
+    cy.get('a[qa-id="dialogLoginButton"]').click();
+
+    // User logs in
+    cy.get('#email').type(email);
+    cy.get('#password').type(password);
+    cy.get('button[type=submit]').click();
+    cy.wait(2000); // wait to ensure user is redirected to the session
+
+    // User plays the conversation
+    cy.get('audio')
+      .should('exist')
+      .invoke('attr', 'src')
+      .then((audiofile) => {
+        const audio = new Audio(audiofile);
+        audio.playbackRate = 6;
+        audio.play();
+      });
+    cy.wait(2000); // wait to ensure user plays the session
+  });
+
+  after(() => {
+    cy.logout();
+  });
+});


### PR DESCRIPTION
### Resolves #1436 

I created a new test file in cypress/integration/tests called conversations.cy.tsx. It's an end-to-end Cypress test for the Conversations features to ensure users can navigate to Courses, select a conversation, log in, play audio, and submit feedback.

This test passed all user flows for Conversations except the feedback form part. I got the error is that the feedback form doesn't appear after the user plays a conversation in the test, so I'm unable to test if the user can fill out the feedback form.

<img width="852" alt="conversations" src="https://github.com/user-attachments/assets/6d3ece7d-a4d5-4965-9a3d-cef1adef9577" />

