### PR TITLE
added Cypress test to ensure partner users exclusively see partner-specific requests

### DIFF
--- a/cypress/integration/tests/partner-content-access.cy.tsx
+++ b/cypress/integration/tests/partner-content-access.cy.tsx
@@ -21,7 +21,6 @@ describe('users signing up through partner channels can properly access partner-
     cy.get('button[type="submit"]').contains('Create account').click();
     cy.wait(4000); // Waiting for dom to rerender
 
-    // cy.get('a', { timeout: 8000 }).should('contain',/Skip to courses/i);
     cy.visit('/courses');
 
     cy.wait(4000); // Waiting for dom to rerender

--- a/cypress/integration/tests/partner-content-access.cy.tsx
+++ b/cypress/integration/tests/partner-content-access.cy.tsx
@@ -1,0 +1,42 @@
+describe('users signing up through partner channels can properly access partner-specific course content', () => {
+  let username_partner = `cypresstestemailpartner+${Date.now()}@chayn.co`;
+  let username_regular = `cypresstestemailRegular+${Date.now()}@chayn.co`;
+  const password = 'testtesttest';
+
+  const bumbleSpecificCourseName = /Dating, boundaries, and Relationships/i;
+
+  beforeEach(() => {
+    cy.cleanUpTestState();
+  });
+
+  it('Bumble-specific courses and resources exclusively exist on the /courses page for Bumble users.', () => {
+    //log in as a Bumble user and see if the course appears
+    cy.visit('/welcome/bumble');
+    cy.get('a', { timeout: 8000 }).contains('Get started').click();
+    cy.wait(2000); // waiting for dom to rerender
+    cy.get('h2', { timeout: 8000 }).should('contain', 'Create account');
+    cy.get('#name').type('Cypress test');
+    cy.get('#email').type(username_partner);
+    cy.get('#password').type('testpassword');
+    cy.get('button[type="submit"]').contains('Create account').click();
+    cy.wait(4000); // Waiting for dom to rerender
+
+    // cy.get('a', { timeout: 8000 }).should('contain',/Skip to courses/i);
+    cy.visit('/courses');
+
+    cy.wait(4000); // Waiting for dom to rerender
+    cy.get('h3').contains(bumbleSpecificCourseName).should('exist');
+  });
+
+  it('Non-parter users should not see Partner-specific courses and resources', () => {
+    cy.createUser({ emailInput: username_regular, passwordInput: password });
+    cy.logInWithEmailAndPassword(username_regular, password);
+    cy.visit('/courses');
+    cy.wait(4000); // Waiting for dom to rerender
+    cy.get('h3').contains(bumbleSpecificCourseName).should('not.exist');
+  });
+
+  afterEach(() => {
+    cy.logout();
+  });
+});


### PR DESCRIPTION

### Resolves #1471 

### What changes did you make and why did you make them?
I made the new file partner-content-access.cy.tsx 
Before each block, the command cleanUpTestState() is run
It has 2 it blocks
Block - 1. Registers a Bumble user. Once the user is logged in, the browser navigates to /courses and asserts the existence of the specific course "Dating, boundaries, and Relationships" on the page
Block -2. Registers a regular user and navigates to /courses and asserts that the above course does NOT exist.
After each block cypress logs out.

Currently there's nothing "Badoo" specific that I found. Happy to add another it block with the exact same test for Badoo on request. (or something else)

### Did you run tests? Share screenshot of results:
Yes they ran
![unit tests run successfully](https://github.com/user-attachments/assets/72cdb47a-49af-4efb-a4dd-1f5a0d3c0013)
![cypress runs successfully on local](https://github.com/user-attachments/assets/8b1b22f5-ca1b-4e86-a0b4-2ace18ecb4ec)


