### PR TITLE
Fix therapy richtext link

### DIFF
--- a/app/[locale]/therapy/book-session/BookTherapyPage.tsx
+++ b/app/[locale]/therapy/book-session/BookTherapyPage.tsx
@@ -136,19 +136,27 @@ export default function BookTherapyPage({ story }: Props) {
 
   function replacePartnerName(partnerName: string) {
     const accordionDetailsElements = document.querySelectorAll('.MuiAccordionDetails-root');
-    const introductionElement = document.querySelector('h1 + .MuiTypography-root');
+    const introductionElement: HTMLParagraphElement | null = document.querySelector('h1 + p');
 
     accordionDetailsElements.forEach((detailsElement) => {
       const paragraphElements = detailsElement.querySelectorAll('p');
 
-      [...paragraphElements, introductionElement].forEach((paragraph) => {
-        if (!paragraph) return;
-        const currentText = paragraph.textContent;
+      const allElementsToProcess = [...paragraphElements];
+      if (introductionElement) {
+        allElementsToProcess.push(introductionElement);
+      }
+
+      allElementsToProcess.forEach((element) => {
+        if (!element) return;
+
+        // Use innerHTML to preserve embedded HTML elements
+        const currentHtml = element.innerHTML;
 
         // Replace all instances of '{partnerName}' with the provided partnerName
-        const newText = currentText?.replace(/\{partnerName\}/g, partnerName);
+        const escapedPartnerName = partnerName.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const newHtml = currentHtml.replace(/\{partnerName\}/g, escapedPartnerName);
 
-        paragraph.textContent = newText || null;
+        element.innerHTML = newHtml;
       });
     });
   }

--- a/lib/utils/richText.tsx
+++ b/lib/utils/richText.tsx
@@ -76,9 +76,9 @@ export const RichTextOptions: RenderOptions = {
       if (href)
         return (
           <Link
-            component={href.includes(BASE_URL) ? i18nLink : 'a'}
+            component={href.includes(BASE_URL) || href.startsWith('/') ? i18nLink : 'a'}
             href={href}
-            target={href?.match(/^(https?:)?\/\//) && '_blank'}
+            target={target || '_blank'}
           >
             {children}
           </Link>


### PR DESCRIPTION
Fixes issue with richtext links not rendering on the therapy page, due to paragraph content being replaced in `replacePartnerName` function