### PR TITLE
Revert "Refactor: optimize Cypress config for speed (#1497)"

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -13,9 +13,6 @@ jobs:
     permissions:
       deployments: read
       statuses: read
-      contents: read
-      pull-requests: read
-      checks: read
     outputs:
       preview_url: ${{ steps.waitForVercelDeployment.outputs.url }}
     steps:

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -22,9 +22,5 @@ export default defineConfig({
     experimentalRunAllSpecs: true,
     experimentalMemoryManagement: true,
     chromeWebSecurity: false,
-    video: false,
-    screenshotOnRunFailure: false,
-    numTestsKeptInMemory: 0,
-    modifyObstructiveCode: false,
   },
 });


### PR DESCRIPTION
This reverts commit 7896ca84bac5ff617483ff4958a9ba05659b24d9.
See PR: https://github.com/chaynHQ/bloom-frontend/pull/1497 

The wait-for-vercel job in cypress-release-test.yml did not resolve after implementing fixes recommended in the linked issue from the wait-for-vercel workflow's repository. Rechecking Vercel permissions next.

Reverting and opening a new PR with another fix. Note: testing workflows on dependabot PRs requires pushing to default branch.