### PR TITLE
Fix: remove permissions for vercel preview job

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -10,9 +10,6 @@ jobs:
   wait-for-vercel-deployment:
     name: Wait for vercel deployment
     runs-on: ubuntu-24.04
-    permissions:
-      deployments: read
-      statuses: read
     outputs:
       preview_url: ${{ steps.waitForVercelDeployment.outputs.url }}
     steps:


### PR DESCRIPTION
### Resolves #enter-issue-number
N/A

See internal docs
This pull request includes a small change to the `.github/workflows/cypress-release-test.yml` file. The change removes the `permissions` block from the `wait-for-vercel-deployment` job, simplifying the workflow configuration.
