### PR TITLE
Fix: define window in usePWA.ts

### DIFF
--- a/lib/hooks/usePwa.ts
+++ b/lib/hooks/usePwa.ts
@@ -29,6 +29,9 @@ export default function usePWA() {
   const userCookiesAccepted = user.cookiesAccepted || Cookies.get('analyticsConsent') === 'true';
 
   const getPwaMetaData = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return { browser: 'Unknown Browser', platform: 'Unknown OS' };
+    }
     const userAgent = window.navigator.userAgent;
     const platform = userAgent.includes('Win')
       ? 'Windows'
@@ -85,7 +88,8 @@ export default function usePWA() {
     const isStandalone =
       typeof window !== 'undefined' && window.matchMedia('(display-mode: standalone)').matches;
     const isIos =
-      typeof window !== 'undefined' && /iphone|ipad|ipod/.test(window?.navigator.userAgent.toLowerCase());
+      typeof window !== 'undefined' &&
+      /iphone|ipad|ipod/.test(window?.navigator.userAgent.toLowerCase());
 
     const isHidden =
       pwaBannerDismissedCookie ||

--- a/lib/hooks/usePwa.ts
+++ b/lib/hooks/usePwa.ts
@@ -27,7 +27,7 @@ export default function usePWA() {
   const dispatch = useAppDispatch();
   const user = useTypedSelector((state) => state.user);
   const userCookiesAccepted = user.cookiesAccepted || Cookies.get('analyticsConsent') === 'true';
-
+  const isWindowDefined = typeof window !== 'undefined';
   const getPwaMetaData = useMemo(() => {
     if (typeof window === 'undefined') {
       return { browser: 'Unknown Browser', platform: 'Unknown OS' };
@@ -54,7 +54,7 @@ export default function usePWA() {
               : 'Unknown Browser';
 
     return { browser, platform };
-  }, []);
+  }, [isWindowDefined]);
 
   const declineInstallation = async () => {
     if (userCookiesAccepted) {
@@ -85,8 +85,7 @@ export default function usePWA() {
 
   useEffect(() => {
     const pwaBannerDismissedCookie = Boolean(Cookies.get(PWA_BANNER_DISMISSED));
-    const isStandalone =
-      typeof window !== 'undefined' && window.matchMedia('(display-mode: standalone)').matches;
+    const isStandalone = isWindowDefined && window.matchMedia('(display-mode: standalone)').matches;
     const isIos =
       typeof window !== 'undefined' &&
       /iphone|ipad|ipod/.test(window?.navigator.userAgent.toLowerCase());


### PR DESCRIPTION
### Resolves #enter-issue-number
N/A

Checks typeof window, if undefined returns unknown browser stats. 
Window is a global, client-side object from the browser. Therefore cannot be defined in a server-side hook or a dependency of useMemo(). This PR prevents errors due to undefined window on app initialization. Even with use-client, this does not ensure it won't run on server-side first: https://github.com/vercel/next.js/discussions/42319#discussioncomment-4033667.

Given the hook is called when the header is loaded and browser information is accessible after initialization, ie: if a user navigates anywhere, we should gain valuable metrics if 1 - users download the app after navigating anywhere on the site and 2 - if the browser is unknown, indicates users downloaded PWA upon first visit.

Future contributor issue: since window.userAgent is unreliable, we should migrate to identifying browser features instead. This is why: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgent

See exact code example here:  https://react.dev/learn/you-might-not-need-an-effect#initializing-the-application
