### PR TITLE
fix: link on ntoes from bloom promo

### DIFF
--- a/components/banner/NotesFromBloomPromo.tsx
+++ b/components/banner/NotesFromBloomPromo.tsx
@@ -63,7 +63,7 @@ const NotesFromBloomPromo = () => {
           </Box>
           <Box display={['flex', 'flex', 'none']} justifyContent="flex-end">
             <Button
-              link="/subscribe/whatsapp"
+              link="/subscription/whatsapp"
               color={STORYBLOK_COLORS.PRIMARY_DARK}
               text={t('buttonText')}
               size="medium"
@@ -76,7 +76,7 @@ const NotesFromBloomPromo = () => {
         </Box>
         <Box display={['none', 'none', 'flex']} justifyContent="flex-end">
           <Button
-            link="/subscribe/whatsapp"
+            link="/subscription/whatsapp"
             color={STORYBLOK_COLORS.PRIMARY_DARK}
             text={t('buttonText')}
             size="small"


### PR DESCRIPTION
This pull request updates the `NotesFromBloomPromo` component in `components/banner/NotesFromBloomPromo.tsx` to modify the subscription link for WhatsApp. 

Changes to subscription links:

* Updated the `link` property in two `Button` components to use `/subscription/whatsapp` instead of `/subscribe/whatsapp` for consistency and accuracy. [[1]](diffhunk://#diff-6c12b492be55fdd3e661fd174e5072f32e2088719cf625c2036dc93040cffbb6L66-R66) [[2]](diffhunk://#diff-6c12b492be55fdd3e661fd174e5072f32e2088719cf625c2036dc93040cffbb6L79-R79)
