### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -10,6 +10,8 @@ jobs:
   wait-for-vercel-deployment:
     name: Wait for vercel deployment
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       preview_url: ${{ steps.waitForVercelDeployment.outputs.url }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/chaynHQ/bloom-frontend/security/code-scanning/27](https://github.com/chaynHQ/bloom-frontend/security/code-scanning/27)

To fix the issue, we need to add a `permissions` block to the `wait-for-vercel-deployment` job. Since this job only interacts with the Vercel API and does not perform any write operations on the repository, it likely only requires `contents: read` permissions. This ensures that the job has the minimal permissions necessary to function correctly.

The `permissions` block should be added directly under the `wait-for-vercel-deployment` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
