### PR TITLE
Fix global font weights

### DIFF
--- a/components/cards/RelatedContentCard.tsx
+++ b/components/cards/RelatedContentCard.tsx
@@ -19,7 +19,7 @@ const cardStyle = {
 const categoryStyle = {
   fontFamily: 'Montserrat, sans-serif',
   fontSize: '0.875rem !important',
-  fontWeight: 600,
+  fontweight: 500,
   textTransform: 'uppercase',
   mb: '0.5rem !important',
   '& .before-dot:before': {

--- a/components/cards/ShortsCard.tsx
+++ b/components/cards/ShortsCard.tsx
@@ -2,10 +2,10 @@
 
 import { Link as i18nLink } from '@/i18n/routing';
 import { RELATED_CONTENT_CATEGORIES } from '@/lib/constants/enums';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { Box, Card, CardActionArea, CardContent, IconButton, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 
 const cardStyle = {
   mt: 0,
@@ -46,7 +46,7 @@ interface ShortsCardProps {
 const categoryStyle = {
   fontFamily: 'Montserrat, sans-serif',
   fontSize: '0.875rem !important',
-  fontWeight: 600,
+  fontweight: 500,
   textTransform: 'uppercase',
   mb: '0.5rem !important',
   '& .before-dot:before': {

--- a/components/layout/BaseLayout.tsx
+++ b/components/layout/BaseLayout.tsx
@@ -28,7 +28,7 @@ import { FruitzRetirementBanner } from '../banner/FruitzRetirementBanner';
 
 const openSans = Open_Sans({
   subsets: ['latin'],
-  weight: ['300', '400', '600'],
+  weight: ['300', '400', '500'],
   variable: '--font-open-sans',
   display: 'swap',
 });

--- a/components/layout/PrimaryNavigationDrawerLinks.tsx
+++ b/components/layout/PrimaryNavigationDrawerLinks.tsx
@@ -34,7 +34,7 @@ const listItemStyle = {
 const listItemTextStyle = {
   span: {
     fontSize: 16,
-    fontWeight: 600,
+    fontweight: 500,
   },
 } as const;
 

--- a/components/layout/SecondaryNav.tsx
+++ b/components/layout/SecondaryNav.tsx
@@ -48,7 +48,7 @@ const tabStyle = {
   flexDirection: 'row',
   textTransform: 'none',
   fontSize: theme.typography.body1.fontSize,
-  fontWeight: 600,
+  fontweight: 500,
   padding: 0.25,
   color: 'text.primary',
   '& .material-icons ': { mb: 0, mr: 1.5 },

--- a/components/layout/SecondaryNavigationDrawerLinks.tsx
+++ b/components/layout/SecondaryNavigationDrawerLinks.tsx
@@ -43,7 +43,7 @@ const listItemStyle = {
 const listItemTextStyle = {
   span: {
     fontSize: 16,
-    fontWeight: 600,
+    fontweight: 600,
   },
 } as const;
 

--- a/components/resources/ResourceCompleteButton.tsx
+++ b/components/resources/ResourceCompleteButton.tsx
@@ -21,7 +21,7 @@ import { useRollbar } from '@rollbar/react';
 const errorStyle = {
   color: 'primary.dark',
   marginTop: 2,
-  fontWeight: 600,
+  fontweight: 500,
 } as const;
 
 interface ResourceCompleteButtonProps {

--- a/components/session/SessionCompleteButton.tsx
+++ b/components/session/SessionCompleteButton.tsx
@@ -18,7 +18,7 @@ import { useRollbar } from '@rollbar/react';
 const errorStyle = {
   color: 'primary.dark',
   marginTop: 2,
-  fontWeight: 600,
+  fontweight: 500,
 } as const;
 
 interface SessionCompleteButtonProps {

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -57,7 +57,7 @@ let theme = createTheme({
       fontFamily: 'var(--font-montserrat)',
       fontSize: '1.875rem',
       fontWeight: 400,
-      marginBottom: '1rem',
+      marginBottom: '1.25rem',
     },
     h3: {
       fontFamily: 'var(--font-montserrat)',
@@ -112,11 +112,21 @@ theme = createTheme(theme, {
             paddingLeft: '5% !important',
             paddingRight: '5% !important',
           },
-          [theme.breakpoints.up('lg')]: {
+          [theme.breakpoints.up('md')]: {
             paddingTop: 100,
             paddingBottom: 100,
+            paddingLeft: '2rem !important',
+            paddingRight: '2rem !important',
+          },
+          [theme.breakpoints.up('lg')]: {
+            paddingTop: 120,
+            paddingBottom: 120,
             paddingLeft: 'calc((100vw - 1000px) / 2) !important',
             paddingRight: 'calc((100vw - 1000px) / 2) !important',
+            ':first-of-type': {
+              paddingTop: 100,
+              paddingBottom: 100,
+            },
           },
         },
       },
@@ -314,6 +324,7 @@ theme = createTheme(theme, {
       styleOverrides: {
         root: {
           backgroundColor: theme.palette.common.white,
+          boxShadow: '0px 1px 3px 0px rgba(0, 0, 0, 0.12);',
           marginTop: 20,
 
           [theme.breakpoints.up('md')]: {


### PR DESCRIPTION
Our style guide and designs use font weight 400 by default, with 500 being used sparingly.

Our theme was using too heavy a weight for some headings and components, these have now been reduced.

The `Open_Sans` used to import `600` weight and this is now replaced with `500` so it will fall back to 500 even if 600 was used. 500 was previously missing.