### PR TITLE
Fix notes from bloom cypress test

### DIFF
--- a/cypress/integration/tests/notes.cy.tsx
+++ b/cypress/integration/tests/notes.cy.tsx
@@ -10,7 +10,7 @@ describe('Notes from Bloom page', () => {
     });
 
     it('should display the page header and title', () => {
-      cy.get('h1').should('contain', 'Sign up to Notes from Bloom');
+      cy.get('h1').should('contain', 'Subscribe to Notes from Bloom');
       cy.get('p').should('contain', 'The path to healing can be lonely and sometimes thorny');
     });
 


### PR DESCRIPTION
This pull request updates the text in the header of the "Notes from Bloom" page for better clarity and alignment with the subscription process.

Text update:

* [`cypress/integration/tests/notes.cy.tsx`](diffhunk://#diff-394590a7dbfac3dc1408725f9887887324c073583122706b358338491d8cfcd6L13-R13): Changed the header text from "Sign up to Notes from Bloom" to "Subscribe to Notes from Bloom" in the test that verifies the page header and title.
