### PR TITLE
fix: tests broken by notes from bloom issues

### DIFF
--- a/components/forms/RegisterForm.tsx
+++ b/components/forms/RegisterForm.tsx
@@ -99,6 +99,7 @@ const RegisterForm = (props: RegisterFormProps) => {
       logEvent(VALIDATE_ACCESS_CODE_INVALID, { partner: partnerName, message: error });
     } else {
       logEvent(VALIDATE_ACCESS_CODE_SUCCESS, { partner: partnerName });
+      return true;
     }
     return false;
   };

--- a/cypress/integration/tests/therapy-usage.cy.tsx
+++ b/cypress/integration/tests/therapy-usage.cy.tsx
@@ -70,6 +70,7 @@ describe('Therapy Usage', () => {
 
   it('Should open the booking modal and display the Simplybook widget iframe', () => {
     cy.visit('/therapy/book-session');
+    cy.wait(4000); // wait for the page to load as there are issues with page rerendering in cypress tests
 
     cy.get('button').contains('Begin booking').click();
 

--- a/i18n/messages/auth/fr.json
+++ b/i18n/messages/auth/fr.json
@@ -25,6 +25,7 @@
       "emailLabel": "E-mail",
       "passwordLabel": "Mot de passe",
       "contactPermissionLabel": "Recevez des e-mails concernant les nouvelles ressources et les opportunités de partager vos commentaires avec nous.",
+      "registerSubmit": "Créer un compte",
       "resetPasswordStep1": "Nous vous enverrons un lien pour réinitialiser votre mot de passe.",
       "resetPasswordStep2": "Vous y êtes presque ! Vous pouvez maintenant créer un nouveau mot de passe.",
       "resetPasswordSubmit": "Réinitialiser le mot de passe",


### PR DESCRIPTION
This pull request introduces changes across three areas: functionality updates in the `RegisterForm` component, improvements to Cypress tests, and localization updates for French language support. Below is a summary of the most important changes grouped by theme.

### Functionality Updates:
* Added a return value (`true`) to the `validateAccessCode` function in `RegisterForm` to indicate successful validation. (`components/forms/RegisterForm.tsx`, [components/forms/RegisterForm.tsxR102](diffhunk://#diff-974d25db2b14be7deac45ae68d57458f11199898554484c589c65f80a28f9ab3R102))

### Test Improvements:
* Added a `cy.wait(4000)` command in the Cypress test for therapy booking to address page rerendering issues during testing. (`cypress/integration/tests/therapy-usage.cy.tsx`, [cypress/integration/tests/therapy-usage.cy.tsxR73](diffhunk://#diff-c69c077f9f56e1ec128cedaa9c63f957f227cb06bd996219cf2702cd29fdf746R73))

### Localization Updates:
* Added a new French translation for the "registerSubmit" button label: "Créer un compte." (`i18n/messages/auth/fr.json`, [i18n/messages/auth/fr.jsonR28](diffhunk://#diff-1c08cd45fe38d1ba76f0955950618dc91253db710d77ccb923eb158dd9944d7eR28))
