### PR TITLE
Improve Setup MFA Flow for Superusers

### DIFF
--- a/components/guards/SetupMFA.tsx
+++ b/components/guards/SetupMFA.tsx
@@ -29,9 +29,12 @@ const SetupMFA = () => {
   const userVerifiedEmail = useTypedSelector((state) => state.user.verifiedEmail);
 
   const [phoneNumber, setPhoneNumber] = useState('');
+  const [storedPhoneNumber, setStoredPhoneNumber] = useState('');
   const [verificationId, setVerificationId] = useState('');
   const [verificationCode, setVerificationCode] = useState('');
   const [error, setError] = useState('');
+  const [emailVerificationSent, setEmailVerificationSent] = useState(false);
+  const [emailVerificationSuccess, setEmailVerificationSuccess] = useState('');
   const [showReauth, setShowReauth] = useState(false);
   const [password, setPassword] = useState('');
   const [isReauthenticating, setIsReauthenticating] = useState(false);
@@ -51,6 +54,20 @@ const SetupMFA = () => {
     };
   }, []);
 
+  // Store phone number when user enters it
+  useEffect(() => {
+    if (phoneNumber && !storedPhoneNumber) {
+      setStoredPhoneNumber(phoneNumber);
+    }
+  }, [phoneNumber, storedPhoneNumber]);
+
+  // Restore phone number after reauthentication
+  useEffect(() => {
+    if (!showReauth && storedPhoneNumber && !phoneNumber) {
+      setPhoneNumber(storedPhoneNumber);
+    }
+  }, [showReauth, storedPhoneNumber, phoneNumber]);
+
   const handleReauthentication = async () => {
     if (!password.trim()) {
       setError(t('form.passwordRequired'));
@@ -67,7 +84,7 @@ const SetupMFA = () => {
       // Reset the MFA setup process
       setVerificationId('');
       setVerificationCode('');
-      setPhoneNumber('');
+      // Don't reset phone number - it will be restored from storedPhoneNumber
     } catch (error: any) {
       rollbar.error('Reauthentication error:', error);
       if (error.code === 'auth/wrong-password') {
@@ -81,6 +98,7 @@ const SetupMFA = () => {
       setIsReauthenticating(false);
     }
   };
+
   const handleEnrollMFA = async () => {
     if (!userVerifiedEmail) {
       setError(t('form.emailNotVerified'));
@@ -126,16 +144,20 @@ const SetupMFA = () => {
 
   const handleSendVerificationEmail = async () => {
     setError('');
+    setEmailVerificationSuccess('');
     const user = auth.currentUser;
     if (user) {
       const { error } = await sendVerificationEmail(user);
       if (error) {
+        if (error.code === 'auth/too-many-requests') {
+          setError(t('form.firebase.tooManyAttempts'));
+        } else {
+          setError(t('form.emailVerificationError'));
+        }
         rollbar.error('Send verification email error:', error);
-        setError(t('form.emailVerificationError'));
       } else {
-        // Show success message instead of error
-        setError('');
-        // You might want to show a success state here instead
+        setEmailVerificationSent(true);
+        setEmailVerificationSuccess(t('form.emailVerificationSent'));
       }
     }
   };
@@ -188,19 +210,29 @@ const SetupMFA = () => {
       </Box>
     );
   }
+
   return (
     <Box>
       <Typography variant="h3">{t('setupMFA.title')}</Typography>
       {!userVerifiedEmail ? (
         <Box>
           <Typography>{t('form.emailNotVerified')}</Typography>
+          {emailVerificationSuccess && (
+            <Alert severity="success" sx={{ mt: 2, mb: 2 }}>
+              {emailVerificationSuccess}
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                {t('form.emailVerificationSpamCheck')}
+              </Typography>
+            </Alert>
+          )}
           <Button
             variant="contained"
             color="secondary"
             sx={{ ...buttonStyle, mt: 2 }}
             onClick={handleSendVerificationEmail}
+            disabled={emailVerificationSent}
           >
-            {t('form.sendVerificationEmail')}
+            {emailVerificationSent ? t('form.resendVerificationEmail') : t('form.sendVerificationEmail')}
           </Button>
         </Box>
       ) : !verificationId ? (

--- a/i18n/messages/auth/de.json
+++ b/i18n/messages/auth/de.json
@@ -61,7 +61,9 @@
       "emailNotVerified": "Bitte verifiziere deine E-Mail-Adresse, bevor du die Zwei-Faktor-Authentifizierung einrichtest.",
       "emailVerificationError": "Fehler beim Senden der Verifizierungs-E-Mail. Bitte versuche es erneut.",
       "emailVerificationSent": "Verifizierungs-E-Mail wurde gesendet. Bitte überprüfe deinen Posteingang.",
+      "emailVerificationSpamCheck": "Wenn du die E-Mail nicht siehst, überprüfe bitte deinen Spam-Ordner.",
       "sendVerificationEmail": "Verifizierungs-E-Mail senden",
+      "resendVerificationEmail": "Verifizierungs-E-Mail erneut senden",
       "passwordRequired": "Passwort ist für die erneute Authentifizierung erforderlich.",
       "reauthenticationError": "Erneute Authentifizierung fehlgeschlagen. Bitte versuche es erneut."
     },

--- a/i18n/messages/auth/en.json
+++ b/i18n/messages/auth/en.json
@@ -61,7 +61,9 @@
       "emailNotVerified": "Please verify your email before setting up 2FA.",
       "emailVerificationError": "Error sending verification email. Please try again.",
       "emailVerificationSent": "Verification email sent. Please check your inbox.",
+      "emailVerificationSpamCheck": "If you don't see the email, please check your spam folder.",
       "sendVerificationEmail": "Send Verification Email",
+      "resendVerificationEmail": "Resend Verification Email",
       "passwordRequired": "Password is required for reauthentication.",
       "reauthenticationError": "Failed to reauthenticate. Please try again."
     },

--- a/i18n/messages/auth/es.json
+++ b/i18n/messages/auth/es.json
@@ -61,7 +61,9 @@
       "emailNotVerified": "Por favor, verifica tu email antes de configurar la autenticación de dos factores.",
       "emailVerificationError": "Error al enviar el email de verificación. Por favor, inténtalo de nuevo.",
       "emailVerificationSent": "Email de verificación enviado. Por favor, revisa tu bandeja de entrada.",
+      "emailVerificationSpamCheck": "Si no ves el email, por favor revisa tu carpeta de spam.",
       "sendVerificationEmail": "Enviar email de verificación",
+      "resendVerificationEmail": "Reenviar email de verificación",
       "passwordRequired": "Se requiere contraseña para la reautenticación.",
       "reauthenticationError": "Error al reautenticar. Por favor, inténtalo de nuevo."
     },

--- a/i18n/messages/auth/fr.json
+++ b/i18n/messages/auth/fr.json
@@ -61,7 +61,9 @@
       "emailNotVerified": "Veuillez vérifier votre email avant de configurer l'authentification à deux facteurs.",
       "emailVerificationError": "Erreur lors de l'envoi de l'email de vérification. Veuillez réessayer.",
       "emailVerificationSent": "Email de vérification envoyé. Veuillez vérifier votre boîte de réception.",
+      "emailVerificationSpamCheck": "Si vous ne voyez pas l'email, veuillez vérifier votre dossier spam.",
       "sendVerificationEmail": "Envoyer l'email de vérification",
+      "resendVerificationEmail": "Renvoyer l'email de vérification",
       "passwordRequired": "Le mot de passe est requis pour la réauthentification.",
       "reauthenticationError": "Échec de la réauthentification. Veuillez réessayer."
     },

--- a/i18n/messages/auth/hi.json
+++ b/i18n/messages/auth/hi.json
@@ -61,7 +61,9 @@
       "emailNotVerified": "2FA setup karne se pehle kripya apne email ki pushti karein.",
       "emailVerificationError": "Satyaapan email bhejne mein truti. Kripya punah prayaas karein.",
       "emailVerificationSent": "Satyaapan email bhej diya gaya hai. Kripya apne inbox ki jaanch karein.",
+      "emailVerificationSpamCheck": "Agar aapko email nahi dikh raha, kripya apne spam folder ki jaanch karein.",
       "sendVerificationEmail": "Satyaapan Email Bhejein",
+      "resendVerificationEmail": "Satyaapan Email Punah Bhejein",
       "passwordRequired": "Punah praman ke liye password aavashyak hai.",
       "reauthenticationError": "Punah praman mein asafalta. Kripya punah prayaas karein."
     },

--- a/i18n/messages/auth/pt.json
+++ b/i18n/messages/auth/pt.json
@@ -61,7 +61,9 @@
       "emailNotVerified": "Por favor, verifique seu e-mail antes de configurar a autenticação de dois fatores.",
       "emailVerificationError": "Erro ao enviar e-mail de verificação. Por favor, tente novamente.",
       "emailVerificationSent": "E-mail de verificação enviado. Por favor, verifique sua caixa de entrada.",
+      "emailVerificationSpamCheck": "Se você não vir o e-mail, verifique sua pasta de spam.",
       "sendVerificationEmail": "Enviar e-mail de verificação",
+      "resendVerificationEmail": "Reenviar e-mail de verificação",
       "passwordRequired": "Senha é necessária para reautenticação.",
       "reauthenticationError": "Falha na reautenticação. Por favor, tente novamente."
     },


### PR DESCRIPTION
Minor fixes to superadmin 2FA setup, improves user feedback

Fixes the following issues:

- when the user clicks the `sendVerificationEmail` button, there is no feedback to the user that the email is sent. Added success messaging to say an email has been sent, and asks the user to check spam if they can’t see the email. 
- on successful email verification sent, show a “sent verification email” button but ensure that the firebase error `auth/too-many-requests` is handled and show messaging to the user
- if the user is asked to reauthenticate their password, they then have to re-enter their phone number on the setupMFA step again. Store the users phone number in component state during the setupMFA flow so it can be reused when they reach this step again. keep this implementation clean and simple
