### PR TITLE
Superadmin 2FA flow minors

### DIFF
--- a/components/guards/SetupMFA.tsx
+++ b/components/guards/SetupMFA.tsx
@@ -78,22 +78,27 @@ const SetupMFA = () => {
     setError('');
 
     try {
-      await reauthenticateUser(password);
+      const reauthenticateResponse = await reauthenticateUser(password);
+      if (reauthenticateResponse.error) {
+        rollbar.error('Reauthentication error:', error);
+        if (reauthenticateResponse.error.code === 'auth/wrong-password') {
+          setError(t('form.firebase.wrongPassword'));
+        } else if (reauthenticateResponse.error.code === 'auth/too-many-requests') {
+          setError(t('form.firebase.tooManyAttempts'));
+        } else {
+          setError(t('form.reauthenticationError'));
+        }
+        return;
+      }
+      // Reauthenticate success
       setShowReauth(false);
       setPassword('');
       // Reset the MFA setup process
       setVerificationId('');
       setVerificationCode('');
-      // Don't reset phone number - it will be restored from storedPhoneNumber
     } catch (error: any) {
       rollbar.error('Reauthentication error:', error);
-      if (error.code === 'auth/wrong-password') {
-        setError(t('form.firebase.wrongPassword'));
-      } else if (error.code === 'auth/too-many-requests') {
-        setError(t('form.firebase.tooManyAttempts'));
-      } else {
-        setError(t('form.reauthenticationError'));
-      }
+      setError(t('form.reauthenticationError'));
     } finally {
       setIsReauthenticating(false);
     }


### PR DESCRIPTION
This PR solves two minor issues on the setup 2FA flow for superadmins, following fixes in #1545 

- prevent resend verification email button from being disabled once the email has been sent once
- fix error messages not being shown correctly for incorrect password on reauthenticate 