### PR TITLE
feat: retire fruitz banner

### DIFF
--- a/components/banner/FruitzRetirementBanner.tsx
+++ b/components/banner/FruitzRetirementBanner.tsx
@@ -10,12 +10,6 @@ import Cookies from 'js-cookie';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 
-const containerStyle = {
-  backgroundColor: 'primary.main',
-  pt: '2rem !important',
-  pb: '0 !important',
-} as const;
-
 const alertStyle = {
   backgroundColor: 'secondary.light',
   color: 'text.primary',
@@ -44,15 +38,23 @@ export const FruitzRetirementBanner = () => {
   });
 
   const isTargetPage = !pathname.includes('auth');
+  const isFruitzWelcomePage = pathname.includes('fruitz');
 
   const showBanner =
-    isBannerFeatureEnabled && isFruitzUser && isTargetPage && isBannerNotInteracted;
+    (isBannerFeatureEnabled && isFruitzUser && isTargetPage && isBannerNotInteracted) ||
+    isFruitzWelcomePage;
 
   const handleClickDeclined = () => {
     Cookies.set(FRUITZ_RETIREMENT_BANNER_INTERACTED, 'true');
     logEvent(FRUITZ_RETIREMENT_BANNER_DISMISSED);
     setOpen(false);
   };
+  const containerStyle = {
+    backgroundColor: isFruitzWelcomePage ? 'white' : 'primary.main',
+    pt: '2rem !important',
+    pb: '0 !important',
+  } as const;
+
   if (!showBanner) return null;
 
   return (

--- a/i18n/messages/shared/de.json
+++ b/i18n/messages/shared/de.json
@@ -32,7 +32,7 @@
     },
     "fruitzRetirementBanner": {
       "title": "Änderung bei deinen Kursen",
-      "description": "Die Fruitz-App wird nächsten Monat eingestellt, aber deine Unterstützung über Bloom bleibt bestehen. Ab dem 22. April wird der Kurs „Dating, Grenzen und Beziehungen“ nicht mehr verfügbar sein, aber alle anderen Dienste, einschließlich 1:1-Nachrichten, bleiben unverändert.",
+      "description": "Die Partnerschaft zwischen Fruitz und Bloom geht zu Ende, aber deine Unterstützung über Bloom bleibt bestehen. Ab dem 19. August wird der Kurs „Dating, Grenzen und Beziehungen“ nicht mehr verfügbar sein, aber alle anderen Dienste, einschließlich 1:1-Nachrichten, bleiben unverändert.",
       "dismiss": "Schließen"
     },
     "videoTranscript": {

--- a/i18n/messages/shared/en.json
+++ b/i18n/messages/shared/en.json
@@ -32,7 +32,7 @@
     },
     "fruitzRetirementBanner": {
       "title": "Change to your courses",
-      "description": "The Fruitz app is sunsetting next month, but your Bloom support remains. From April 22nd, the course ‘Dating, Boundaries, and Relationships’ will no longer be available, but all other services, including 1:1 messaging, will stay the same.",
+      "description": "The Fruitz x Bloom partnership is coming to an end, but your Bloom support remains. From August 19th, the course ‘Dating, Boundaries, and Relationships’ will no longer be available, but all other services, including 1:1 messaging, will stay the same.",
       "dismiss": "Dismiss"
     },
     "videoTranscript": {

--- a/i18n/messages/shared/es.json
+++ b/i18n/messages/shared/es.json
@@ -32,7 +32,7 @@
     },
     "fruitzRetirementBanner": {
       "title": "Cambio en tus cursos",
-      "description": "La aplicación Fruitz dejará de estar disponible el próximo mes, pero tu apoyo en Bloom continúa. A partir del 22 de abril, el curso ‘Citas, límites y relaciones’ ya no estará disponible, pero todos los demás servicios, incluido el envío de mensajes 1:1, seguirán funcionando con normalidad.",
+      "description": "La colaboración Fruitz x Bloom llega a su fin, pero tu apoyo en Bloom continúa. A partir del 19 de agosto, el curso ‘Citas, límites y relaciones’ ya no estará disponible, pero todos los demás servicios, incluido el envío de mensajes 1:1, seguirán funcionando con normalidad.",
       "dismiss": "Cerrar"
     },
     "videoTranscript": {

--- a/i18n/messages/shared/fr.json
+++ b/i18n/messages/shared/fr.json
@@ -32,7 +32,7 @@
     },
     "fruitzRetirementBanner": {
       "title": "Changement concernant vos cours",
-      "description": "L'application Fruitz sera retirée le mois prochain, mais votre accompagnement avec Bloom reste disponible. À partir du 22 avril, le cours « Rencontres, limites et relations » ne sera plus accessible, mais tous les autres services, y compris la messagerie 1:1, resteront inchangés.",
+      "description": "Le partenariat Fruitz x Bloom touche à sa fin, mais votre accompagnement avec Bloom reste disponible. À partir du 19 août, le cours « Rencontres, limites et relations » ne sera plus accessible, mais tous les autres services, y compris la messagerie 1:1, resteront inchangés.",
       "dismiss": "Fermer"
     },
     "videoTranscript": {

--- a/i18n/messages/shared/hi.json
+++ b/i18n/messages/shared/hi.json
@@ -32,7 +32,7 @@
     },
     "fruitzRetirementBanner": {
       "title": "Aapke course mein badlaav",
-      "description": "Fruitz app agle mahine band ho raha hai, lekin aapka Bloom support jaari rahega. 22 April se, ‘Dating, Boundaries, aur Relationships’ course uplabdh nahi rahega, lekin anya sabhi services, jismein 1:1 messaging shamil hai, pehle ki tarah chalu rahengi.",
+      "description": "Fruitz app x Bloom saajhedaaree samaapt ho rahee hai, lekin aapka Bloom support jaari rahega. 19 agast se, ‘Dating, Boundaries, aur Relationships’ course uplabdh nahi rahega, lekin anya sabhi services, jismein 1:1 messaging shamil hai, pehle ki tarah chalu rahengi.",
       "dismiss": "Band karein"
     },
     "videoTranscript": {

--- a/i18n/messages/shared/pt.json
+++ b/i18n/messages/shared/pt.json
@@ -32,7 +32,7 @@
     },
     "fruitzRetirementBanner": {
       "title": "Alteração nos seus cursos",
-      "description": "O aplicativo Fruitz será descontinuado no próximo mês, mas o seu suporte com a Bloom continua. A partir de 22 de abril, o curso ‘Namoro, Limites e Relacionamentos’ não estará mais disponível, mas todos os outros serviços, incluindo as mensagens 1:1, continuarão funcionando normalmente.",
+      "description": "A parceria Fruitz x Bloom está chegando ao fim, mas o seu suporte com a Bloom continua. A partir de 19 de agosto, o curso ‘Namoro, Limites e Relacionamentos’ não estará mais disponível, mas todos os outros serviços, incluindo as mensagens 1:1, continuarão funcionando normalmente.",
       "dismiss": "Fechar"
     },
     "videoTranscript": {


### PR DESCRIPTION
This pull request updates the `FruitzRetirementBanner` component to improve its functionality and modifies the associated translations to reflect updated messaging about the Fruitz x Bloom partnership. Key changes include adjustments to the banner's display logic, styling, and multilingual content updates.

### Functional and Styling Updates
* Updated the `showBanner` logic in `FruitzRetirementBanner.tsx` to include a new condition (`isFruitzWelcomePage`) that ensures the banner is displayed on Fruitz-specific welcome pages.
* Moved the `containerStyle` definition into the component and modified it to dynamically set the background color based on the `isFruitzWelcomePage` condition.
* Removed the unused `containerStyle` constant from the top of the file.

### Translation Updates
* Updated the `fruitzRetirementBanner.description` in all supported languages to reflect the new end date (August 19th) for the Fruitz x Bloom partnership and revised the messaging for clarity. [[1]](diffhunk://#diff-bc31fb39c48f2494572d9703665e0ea87a5716babaffb2626d8f5c42ce15cfe4L35-R35) [[2]](diffhunk://#diff-d1424499835ac71a6ffc30da13549f44df687231c82c43bef014b61dd913ce24L35-R35) [[3]](diffhunk://#diff-0e6cabf50533aee453792f0929aab6beeec81475f33ce7437ddfb5d61dd300c2L35-R35) [[4]](diffhunk://#diff-27a33e0c991fc32c202625620b27f26f240e33eed5d948d41d5a388ef71d4299L35-R35) [[5]](diffhunk://#diff-0b1403b4cdc52c484aa14ddba46044acbaab512839aa0c8360593779b98f5757L35-R35) [[6]](diffhunk://#diff-75d80c73ad63adde8b185b82bdeba5d82f0eb0eee91101ccdaaf9af6efceef8eL35-R35)

