### PR TITLE
fix resource card image position

### DIFF
--- a/components/cards/ResourceCard.tsx
+++ b/components/cards/ResourceCard.tsx
@@ -69,10 +69,11 @@ export const ResourceCard = (props: ResourceCardProps) => {
     <Card sx={cardStyle}>
       <CardActionArea href={href} sx={{ height: '100%' }} component={i18nLink}>
         <CardContent sx={cardContentStyle}>
-          <Box height="130px" position="relative" width="100%" overflow="hidden">
+          <Box height="140px" position="relative" width="100%" overflow="hidden">
             <Image
               src={image?.filename || '/bloom_shorts.png'}
               objectFit="cover"
+              objectPosition="top"
               fill
               alt={image?.alt || 'Bloom shorts default image'} // TODO create a message for this image
             />


### PR DESCRIPTION
### What changes did you make and why did you make them?
Fixes ResourceCard image position which was cutting off the image at the top