### PR TITLE
Remove fruitz from partner content

### DIFF
--- a/cypress/integration/tests/user-apply-a-code.cy.tsx
+++ b/cypress/integration/tests/user-apply-a-code.cy.tsx
@@ -32,7 +32,6 @@ describe('User apply a code page should display', () => {
     cy.get('p').should('contain', 'Read more about our partnerships by clicking on their logo.');
     cy.checkImage('Bumble logo', 'bumble_logo');
     cy.checkImage('Badoo logo', 'badoo_logo');
-    cy.checkImage('Fruitz logo', 'fruitz_logo');
   });
 
   it('apply a code panel', () => {

--- a/lib/constants/partners.ts
+++ b/lib/constants/partners.ts
@@ -98,5 +98,5 @@ export const getPartnerContent = (partnerName: string) => {
 };
 
 export const getAllPartnersContent = () => {
-  return [bumbleContent, badooContent, fruitzContent];
+  return [bumbleContent, badooContent];
 };


### PR DESCRIPTION

### What changes did you make and why did you make them?
Removes fruitz from all partners content (banner) but doesnt completely remove fruitz content from constants in case required in future.