### PR TITLE
Fix carousel page bug

### DIFF
--- a/components/cards/ResourceCard.tsx
+++ b/components/cards/ResourceCard.tsx
@@ -7,12 +7,12 @@ import { Box, Card, CardActionArea, CardContent, IconButton, Typography } from '
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 
-export const resourceCardWidth = '317px';
-
 const cardStyle = {
-  mt: 0,
-  width: resourceCardWidth,
+  width: { xs: '100%' },
+  maxWidth: { xs: '360px' },
   minHeight: 340,
+  mx: 'auto',
+  mt: 0,
   mb: { xs: '1rem', sm: '1.5rem' },
   backgroundColor: 'paleSecondaryLight',
   '&:hover .overlay': {

--- a/components/common/Carousel.tsx
+++ b/components/common/Carousel.tsx
@@ -47,8 +47,8 @@ const CustomDots = ({ carouselTheme = 'primary' }: { carouselTheme: 'primary' | 
   // In the case that the scroll width is less than 1.5 times the screen width, it will round down the number of pages
   // and cause the dot count to be incorrect.
   // If you go into useMeasurements hook in nuka-carousel, you can see that it calculates the total pages and rounds down the number of pages.
-  // This is particularly an issue if you have 1.4 pages, this means the dots will not render!
-  // Deciding to park this issue for now as it needs a bug report to nuka-carousel.
+  // This requires a bug report to nuka-carousel
+  // In the meantime we do a workaround below `items.length % 3 === 2 &&` to add an extra slide when required
   const { currentPage, totalPages, goBack, goForward, goToPage } = useCarousel();
   if (totalPages < 2) return <></>;
 
@@ -128,6 +128,7 @@ const CustomDots = ({ carouselTheme = 'primary' }: { carouselTheme: 'primary' | 
 const Carousel = (props: CarouselProps) => {
   const { items, title = 'carousel', theme = 'primary' } = props;
 
+  console.log('calc', items.length % 3 === 1);
   return (
     <Box sx={{ mx: -1 }}>
       <NukaCarousel
@@ -139,6 +140,11 @@ const Carousel = (props: CarouselProps) => {
         scrollDistance={'screen'}
       >
         {items}
+        {items.length % 3 === 1 && (
+          <CarouselItemContainer>
+            <></>
+          </CarouselItemContainer>
+        )}
       </NukaCarousel>
     </Box>
   );

--- a/components/common/ResourceCarousel.tsx
+++ b/components/common/ResourceCarousel.tsx
@@ -51,7 +51,6 @@ const ResourceCarousel = ({
   }, [userId, partnerAccesses, locale]);
 
   if (resources.length < 1 || carouselStories.length === 0) {
-    console.error('ResourceCarousel: resources must be provided');
     return <div></div>;
   }
 
@@ -85,7 +84,7 @@ const ResourceCarousel = ({
               </CarouselItemContainer>
             )) ||
             (story.content.component === 'resource_conversation' && (
-              <CarouselItemContainer slidesPerScreen={[1, 2, 3]} key={index}>
+              <CarouselItemContainer key={index}>
                 <RelatedContentCard
                   title={story.name}
                   href={getDefaultFullSlug(story.full_slug, locale)}


### PR DESCRIPTION
### What changes did you make and why did you make them?
Fixes/adds workaround for bug with nuka-carousel.

The issue: if a carousel slide only had <0.5 of the slide filled, its not recognised as a page, and the dots are hidden. Fixed by adding a calculation to add an extra ghost item for now.