### PR TITLE
Fix mobile nav / cookie banner positioning

### DIFF
--- a/components/layout/BaseLayout.tsx
+++ b/components/layout/BaseLayout.tsx
@@ -1,8 +1,8 @@
 import { AuthGuard } from '@/components/guards/AuthGuard';
-import Consent from '@/components/layout/CookieConsent';
+import CookieBanner from '@/components/layout/CookieBanner';
 import Footer from '@/components/layout/Footer';
 import LeaveSiteButton from '@/components/layout/LeaveSiteButton';
-import MobileBottomNav from '@/components/layout/MobileBottomNav';
+import MobileBottomNav, { mobileBottomNavHeight } from '@/components/layout/MobileBottomNav';
 import TopBar from '@/components/layout/TopBar';
 import { ReduxProvider } from '@/components/providers/ReduxProvider';
 import StoryblokProvider from '@/components/providers/StoryblokProvider';
@@ -10,7 +10,6 @@ import { ENVIRONMENT } from '@/lib/constants/common';
 import { ENVIRONMENTS } from '@/lib/constants/enums';
 import firebase from '@/lib/firebase';
 import { clientConfig } from '@/lib/rollbar';
-import { mobileBottomNavSpacerStyle } from '@/styles/common';
 import '@/styles/globals.css';
 import '@/styles/hotjarNPS.css';
 import theme from '@/styles/theme';
@@ -99,9 +98,9 @@ export default async function BaseLayout({ children, locale }: BaseLayoutProps) 
                       <AuthGuard>{children}</AuthGuard>
                     </main>
                     <Footer />
-                    <Box sx={mobileBottomNavSpacerStyle} />
+                    <Box sx={{ height: { xs: mobileBottomNavHeight, md: 0 } }} />
                     <MobileBottomNav />
-                    <Consent />
+                    <CookieBanner />
                     {!!process.env.NEXT_PUBLIC_HOTJAR_ID && ENVIRONMENT !== ENVIRONMENTS.LOCAL && (
                       <Hotjar id={process.env.NEXT_PUBLIC_HOTJAR_ID} sv={6} strategy="lazyOnload" />
                     )}

--- a/components/layout/CookieBanner.tsx
+++ b/components/layout/CookieBanner.tsx
@@ -12,45 +12,49 @@ import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import React, { useEffect } from 'react';
 import CookieConsent, { getCookieConsentValue } from 'react-cookie-consent';
+import { mobileBottomNavHeight } from './MobileBottomNav';
 
-const Consent = () => {
+const CookieBanner = () => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
   const tS = useTranslations('Shared');
   const isMobileScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTabletScreen = useMediaQuery(theme.breakpoints.down('md'));
 
   const consentBoxStyle: React.CSSProperties = {
     backgroundColor: theme.palette.secondary.light,
-    maxWidth: theme.spacing(50),
+    maxWidth: isMobileScreen ? 'none' : theme.spacing(50),
     maxHeight: theme.spacing(35),
     position: 'fixed',
-    left: isMobileScreen ? theme.spacing(1) : theme.spacing(2),
-    bottom: isMobileScreen ? theme.spacing(1) : theme.spacing(2),
-    borderRadius: theme.spacing(2),
+    left: isMobileScreen ? 0 : theme.spacing(2),
+    bottom: isMobileScreen
+      ? mobileBottomNavHeight
+      : isTabletScreen
+        ? mobileBottomNavHeight + 20
+        : theme.spacing(2),
+    borderRadius: isMobileScreen ? 0 : theme.spacing(2),
     boxShadow: `${alpha(theme.palette.common.black, 0.2)} 0px ${theme.spacing(1)} ${theme.spacing(
       4,
     )} 0px`,
     textAlign: 'center',
     lineHeight: 1.5,
-    marginRight: isMobileScreen ? theme.spacing(1) : theme.spacing(2),
+    marginRight: isMobileScreen ? 0 : theme.spacing(2),
     padding: isMobileScreen
-      ? `${theme.spacing(1)} ${theme.spacing(3)}`
+      ? `${theme.spacing(3)} ${theme.spacing(2)} `
       : `${theme.spacing(2)} ${theme.spacing(4)}`,
     zIndex: 5,
   };
   const acceptButtonStyle = {
     backgroundColor: 'secondary.main',
-    marginBottom: theme.spacing(1),
+    float: 'inline-end',
     ':hover': {
       backgroundColor: 'secondary.dark',
     },
   };
   const declineButtonStyle = {
-    fontSize: theme.typography.caption.fontSize,
+    float: 'inline-start',
     fontWeight: 'normal',
-    margin: 'auto',
-    display: 'block',
-    color: theme.palette.common.black,
+    color: theme.palette.text.primary,
   };
 
   const handleDecline = () => {
@@ -117,7 +121,7 @@ const Consent = () => {
       ariaDeclineLabel={tS('cookieConsent.declineLabel')}
       flipButtons={true}
     >
-      <Box width={[60, 70]} margin="auto" mb={1}>
+      <Box width={[50, 70]} margin="auto" mb={1}>
         <Image
           alt={tS('alt.cookieCat')}
           src={IllustrationCookieCat}
@@ -129,7 +133,7 @@ const Consent = () => {
         />
       </Box>
       <Box mb={2}>
-        <Typography fontSize={'1rem !important'}>
+        <Typography fontSize={'0.875rem !important'}>
           {tS('cookieConsent.cookieConsentExplainer')}
           <Link
             target="_blank"
@@ -144,4 +148,4 @@ const Consent = () => {
   );
 };
 
-export default Consent;
+export default CookieBanner;

--- a/components/layout/MobileBottomNav.tsx
+++ b/components/layout/MobileBottomNav.tsx
@@ -10,6 +10,8 @@ import { getImageSizes } from '@/lib/utils/imageSizes';
 import logEvent from '@/lib/utils/logEvent';
 import { getIsMaintenanceMode } from '@/lib/utils/maintenanceMode';
 
+export const mobileBottomNavHeight = 100;
+
 interface ProcessedMobileNavItem {
   label: string;
   href: string;
@@ -33,7 +35,7 @@ const mobileBottomNavStyle = {
   borderColor: 'background.paper',
   boxShadow: '0 -2px 10px rgba(0,0,0,0.1)',
   zIndex: 1100,
-  py: 1.5,
+  height: mobileBottomNavHeight,
   overflow: 'scroll',
 } as const;
 


### PR DESCRIPTION
### What changes did you make and why did you make them?
Fixes new mobile bottom nav positioning (#1606 ) to ensure the cookie banner can be dismissed/accepted. Previously the new nav was covering the accept/decline buttons