### PR TITLE
Remove ping /hello api route

### DIFF
--- a/app/api/hello/route.ts
+++ b/app/api/hello/route.ts
@@ -1,5 +1,0 @@
-export async function GET(request: Request) {
-  return new Response('Blood frontend server running...', {
-    status: 200,
-  });
-}


### PR DESCRIPTION
Removes ping `/api/hello` route as it is not used and opens the app to requiring rate limiting and protections from DoSS attacks