### PR TITLE
Fix flakey tests duplicate user

### DIFF
--- a/cypress/integration/tests/navigation.cy.tsx
+++ b/cypress/integration/tests/navigation.cy.tsx
@@ -46,7 +46,7 @@ describe('Navigation', () => {
 
   describe('A logged in bumble user', () => {
     before(() => {
-      const newUserEmail = `cypresstestemail+${Date.now()}@chayn.co`;
+      const newUserEmail = `cypresstestemail+${Date.now() + 1}@chayn.co`;
       const password = 'testpassword';
       cy.cleanUpTestState();
 
@@ -92,7 +92,7 @@ describe('Navigation', () => {
 
   describe('A logged in badoo user with therapy access', () => {
     before(() => {
-      const newUserEmail = `cypresstestemail+${Date.now()}@chayn.co`;
+      const newUserEmail = `cypresstestemail+${Date.now() + 2}@chayn.co`;
       const password = 'testpassword';
       cy.cleanUpTestState();
 

--- a/cypress/integration/tests/notes.cy.tsx
+++ b/cypress/integration/tests/notes.cy.tsx
@@ -115,7 +115,7 @@ describe('Notes from Bloom page', () => {
   });
 
   describe('Authenticated user - subscribed', () => {
-    const TEST_EMAIL = `cypresstestemail+${Date.now()}@chayn.co`;
+    const TEST_EMAIL = `cypresstestemail+${Date.now() + 1}@chayn.co`;
     const TEST_PASSWORD = 'testpassword123';
     const PHONE_NUMBER = '+447700900000';
 

--- a/cypress/integration/tests/superadmin-mfa.cy.tsx
+++ b/cypress/integration/tests/superadmin-mfa.cy.tsx
@@ -28,7 +28,7 @@ describe('Superadmin MFA Flow', () => {
   });
 
   it('should show MFA setup form for superadmin without MFA', () => {
-    const testEmail = `cypresstestemail+${Date.now()}@chayn.co`;
+    const testEmail = `cypresstestemail+${Date.now() + 1}@chayn.co`;
     const password = 'testpassword';
 
     // Mock the user API response to return a superadmin without MFA
@@ -73,7 +73,7 @@ describe('Superadmin MFA Flow', () => {
   });
 
   it('should complete MFA setup with phone number and verification code', () => {
-    const testEmail = `cypresstestemail+${Date.now()}@chayn.co`;
+    const testEmail = `cypresstestemail+${Date.now() + 2}@chayn.co`;
     const password = 'testpassword';
 
     // Mock superadmin user without MFA
@@ -134,7 +134,7 @@ describe('Superadmin MFA Flow', () => {
   });
 
   it('should require email verification before MFA setup', () => {
-    const testEmail = `cypresstestemail+${Date.now()}@chayn.co`;
+    const testEmail = `cypresstestemail+${Date.now() + 3}@chayn.co`;
     const password = 'testpassword';
 
     // Mock superadmin user with unverified email

--- a/cypress/integration/tests/user-update-email.cy.tsx
+++ b/cypress/integration/tests/user-update-email.cy.tsx
@@ -28,7 +28,7 @@ describe('User account settings page', () => {
   });
 
   it('Should successfully update email', () => {
-    const newEmail = `cypresstestemail+${Date.now()}@chayn.co`;
+    const newEmail = `cypresstestemail+${Date.now() + 1}@chayn.co`;
     cy.visit('/account/settings');
     cy.get('#email').clear().type(newEmail);
     cy.get('#profile-settings-submit').click();


### PR DESCRIPTION
### What changes did you make and why did you make them?
Fixes flakey tests caused by `CREATE_USER_ALREADY_EXISTS` error thrown on files with 2+ instances of creating a new user with `cypresstestemail+${Date.now()}@chayn.co`