### PR TITLE
fix: wrong variable for CSP headers

### DIFF
--- a/scriptUrls.js
+++ b/scriptUrls.js
@@ -78,6 +78,7 @@ const connectSrcUrls = [
   'https://*.youtube.com',
   'https://www.youtube.com',
   'https://vercel.live',
+  process.env.NEXT_PUBLIC_API_URL,
 ];
 const frameSrcUrls = [
   'https://*.hotjar.com',


### PR DESCRIPTION
### Resolves #enter-issue-number
n/a
Wrong variable used in enforced CSP headers

