### PR TITLE
Remove duplicate header api url

### DIFF
--- a/scriptUrls.js
+++ b/scriptUrls.js
@@ -78,7 +78,6 @@ const connectSrcUrls = [
   'https://*.youtube.com',
   'https://www.youtube.com',
   'https://vercel.live',
-  process.env.NEXT_PUBLIC_API_URL,
 ];
 const frameSrcUrls = [
   'https://*.hotjar.com',


### PR DESCRIPTION
### What changes did you make and why did you make them?
Removes duplicate API  url from header exception urls list. `process.env.NEXT_PUBLIC_API_URL` duplicated ` API_URL,` above 