### PR TITLE
fix: add recaptcha to connectSrcUrl

### DIFF
--- a/scriptUrls.js
+++ b/scriptUrls.js
@@ -84,6 +84,8 @@ const connectSrcUrls = [
   'https://i.ytimg.com',
   'https://vercel.live',
   'https://cdnjs.cloudflare.com/ajax/libs/twemoji/',
+  'https://www.google.com/recaptcha/',
+  'https://www.gstatic.com/recaptcha/',
 ];
 const frameSrcUrls = [
   'https://*.hotjar.com',


### PR DESCRIPTION
This pull request makes a small update to the `scriptUrls.js` file by adding two new URLs to the `connectSrcUrls` array. These changes allow connections to Google reCAPTCHA services, which may be required for bot protection or user verification features.

- Added `https://www.google.com/recaptcha/` and `https://www.gstatic.com/recaptcha/` to the `connectSrcUrls` array in `scriptUrls.js` to support Google reCAPTCHA connections.
