### PR TITLE
Fix: Update the deployment platform name

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -127,6 +127,6 @@ In addition to unit and integration testing, contributors should ensure their ha
 
 Create new branches from the `develop` base branch. There is no need to run the build command before pushing changes to GitHub, simply push and create a pull request for the new branch. GitHub Actions will run build and linting tasks automatically. Rebase and merge feature/bug branches into `develop`.
 
-This will trigger an automatic deployment to the staging app by Heroku.
+This will trigger an automatic deployment to the staging app by Vercel.
 
-When changes have been tested in staging, merge `develop` into `main`. This will trigger an automatic deployment to the production app by Heroku.
+When changes have been tested in staging, merge `develop` into `main`. This will trigger an automatic deployment to the production app by Vercel.


### PR DESCRIPTION
### Resolves no issue
I found an outdated info on the deployment platform when reading the README and contribution guidelines.

### What changes did you make and why did you make them?
This is to reflect the tech stack bloom frontend is using. Heroku seems to be the old deployment platform that was replaced by Vercel.

### Did you run tests? Share screenshot of results:
I didn't run any tests, bc it's a no-code change.

### How did you find us? (GitHub, Google search, social media, etc.):
Old Twitter.

<!---ABOUT RUNNING TESTS :->
- Directions for running tests are in the README.md.
- Tests are not required to pass. 
- Run unit tests
- Run Cypress tests if required for contribution.
- Some tests may require multiple runs before success.
- Some test failures may not be due to your contribution and can be ignored. We are always upgrading testing performance.

<!--- PR CHECKLIST: —>
Before submitting, check that you have completed the following tasks:
- [ ] Answered the questions above.
- [ ] Enabled "Allow edits and access to secrets by maintainers" on this PR.
- [ ] If applicable, include images in the description.
After submitting, please be available for discussion. Thank you!