### PR TITLE
fix: CSP headers blocking storyblok preview

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ const {
   connectSrcUrls,
   frameSrcUrls,
   mediaSrcUrls,
+  frameAncestorsUrls,
 } = require('./scriptUrls');
 const withNextIntl = require('next-intl/plugin')();
 
@@ -133,7 +134,7 @@ module.exports = withBundleAnalyzer(
                   object-src 'none';
                   base-uri 'self';
                   form-action 'self';
-                  frame-ancestors 'self';
+                  frame-ancestors ${frameAncestorsUrls.join(' ')};
                   upgrade-insecure-requests;
                 `
                   .replace(/\s{2,}/g, ' ')
@@ -149,7 +150,7 @@ module.exports = withBundleAnalyzer(
               },
               {
                 key: 'X-Frame-Options',
-                value: 'DENY',
+                value: 'SAMEORIGIN',
               },
               {
                 key: 'X-XSS-Protection',

--- a/scriptUrls.js
+++ b/scriptUrls.js
@@ -103,7 +103,7 @@ const mediaSrcUrls = ['https://*.storyblok.com', 'https://a.storyblok.com'];
 const objectSrcUrls = ['none'];
 const baseUriUrls = ['self'];
 const formActionUrls = ['self'];
-const frameAncestorsUrls = ['self'];
+const frameAncestorsUrls = ["'self'", 'https://app.storyblok.com'];
 
 module.exports = {
   scriptSrcUrls,


### PR DESCRIPTION
### What changes did you make and why did you make them?
1. frame-ancestors 'self' blocks Storyblok's iframe
Storyblok's visual editor loads your site inside an <iframe> hosted on app.storyblok.com. The frame-ancestors CSP directive in [next.config.js:136] is hardcoded to 'self', which blocks any external domain from embedding the page — including Storyblok.

Note that frameAncestorsUrls in [scriptUrls.js:106] is defined but never used in the CSP header — every other directive uses its corresponding array (${frameSrcUrls.join(' ')}, etc.) but frame-ancestors is hardcoded instead.

2. X-Frame-Options: DENY
[next.config.js:153-154]( sets X-Frame-Options: DENY, which also prevents the page from being loaded in any iframe. Modern browsers will honour CSP frame-ancestors over this, but it's still incorrect.

[scriptUrls.js:106]— frameAncestorsUrls now includes https://app.storyblok.com
[next.config.js:6-15] — frameAncestorsUrls destructured from scriptUrls
[next.config.js:136]— frame-ancestors now uses the array instead of hardcoded 'self'
[next.config.js:153]— X-Frame-Options changed from DENY to SAMEORIGIN


