### PR TITLE
Storyblok preview state

### DIFF
--- a/app/[locale]/[slug]/page.tsx
+++ b/app/[locale]/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import StoryblokPage, { StoryblokPageProps } from '@/components/storyblok/StoryblokPage';
+import StoryblokPage from '@/components/storyblok/StoryblokPage';
 import { getStoryblokApi, ISbStoriesParams } from '@storyblok/react/rsc';
 
 import { routing } from '@/i18n/routing';
@@ -75,5 +75,5 @@ export default async function Page({ params }: { params: Params }) {
     notFound();
   }
 
-  return <StoryblokPage {...(story.content as StoryblokPageProps)} />;
+  return <StoryblokPage story={story} />;
 }

--- a/app/[locale]/conversations/[slug]/page.tsx
+++ b/app/[locale]/conversations/[slug]/page.tsx
@@ -1,6 +1,4 @@
-import StoryblokResourceConversationPage, {
-  StoryblokResourceConversationPageProps,
-} from '@/components/storyblok/StoryblokResourceConversationPage';
+import StoryblokResourceConversationPage from '@/components/storyblok/StoryblokResourceConversationPage';
 import { routing } from '@/i18n/routing';
 import { STORYBLOK_ENVIRONMENT } from '@/lib/constants/common';
 import { getStoryblokStory } from '@/lib/storyblok';
@@ -75,10 +73,5 @@ export default async function Page({ params }: { params: Params }) {
     notFound();
   }
 
-  return (
-    <StoryblokResourceConversationPage
-      {...(story.content as StoryblokResourceConversationPageProps)}
-      storyUuid={story.uuid}
-    />
-  );
+  return <StoryblokResourceConversationPage story={story} />;
 }

--- a/app/[locale]/courses/[slug]/[sessionSlug]/page.tsx
+++ b/app/[locale]/courses/[slug]/[sessionSlug]/page.tsx
@@ -1,6 +1,4 @@
-import StoryblokSessionPage, {
-  StoryblokSessionPageProps,
-} from '@/components/storyblok/StoryblokSessionPage';
+import StoryblokSessionPage from '@/components/storyblok/StoryblokSessionPage';
 import { routing } from '@/i18n/routing';
 import { STORYBLOK_ENVIRONMENT } from '@/lib/constants/common';
 import { getStoryblokStory } from '@/lib/storyblok';
@@ -75,9 +73,5 @@ export default async function Page({ params }: { params: Params }) {
     notFound();
   }
 
-  const content = story.content as StoryblokSessionPageProps;
-
-  return (
-    <StoryblokSessionPage {...content} storyUuid={story.uuid} storyPosition={story.position} />
-  );
+  return <StoryblokSessionPage story={story} />;
 }

--- a/app/[locale]/courses/[slug]/page.tsx
+++ b/app/[locale]/courses/[slug]/page.tsx
@@ -1,6 +1,4 @@
-import StoryblokCoursePage, {
-  StoryblokCoursePageProps,
-} from '@/components/storyblok/StoryblokCoursePage';
+import StoryblokCoursePage from '@/components/storyblok/StoryblokCoursePage';
 import { routing } from '@/i18n/routing';
 import { STORYBLOK_ENVIRONMENT } from '@/lib/constants/common';
 import { getStoryblokStory } from '@/lib/storyblok';
@@ -80,7 +78,5 @@ export default async function Page({ params }: { params: Params }) {
     notFound();
   }
 
-  return (
-    <StoryblokCoursePage {...(story.content as StoryblokCoursePageProps)} storyUuid={story.uuid} />
-  );
+  return <StoryblokCoursePage story={story} />;
 }

--- a/app/[locale]/meet-the-team/page.tsx
+++ b/app/[locale]/meet-the-team/page.tsx
@@ -1,7 +1,5 @@
 import NoDataAvailable from '@/components/common/NoDataAvailable';
-import StoryblokMeetTheTeamPage, {
-  StoryblokMeetTheTeamPageProps,
-} from '@/components/storyblok/StoryblokMeetTheTeamPage';
+import StoryblokMeetTheTeamPage from '@/components/storyblok/StoryblokMeetTheTeamPage';
 import { getStoryblokStory } from '@/lib/storyblok';
 import { generateMetadataBasic } from '@/lib/utils/generateMetadataBase';
 
@@ -33,5 +31,5 @@ export default async function Page({ params }: { params: Promise<{ locale: strin
     return <NoDataAvailable />;
   }
 
-  return <StoryblokMeetTheTeamPage {...(story.content as StoryblokMeetTheTeamPageProps)} />;
+  return <StoryblokMeetTheTeamPage story={story} />;
 }

--- a/app/[locale]/shorts/[slug]/page.tsx
+++ b/app/[locale]/shorts/[slug]/page.tsx
@@ -1,6 +1,4 @@
-import StoryblokResourceShortPage, {
-  StoryblokResourceShortPageProps,
-} from '@/components/storyblok/StoryblokResourceShortPage';
+import StoryblokResourceShortPage from '@/components/storyblok/StoryblokResourceShortPage';
 import { routing } from '@/i18n/routing';
 import { STORYBLOK_ENVIRONMENT } from '@/lib/constants/common';
 import { COURSE_CATEGORIES } from '@/lib/constants/enums';
@@ -101,20 +99,18 @@ export default async function Page({ params }: { params: Params }) {
 
     return (
       <StoryblokResourceShortPage
-        {...(story.content as StoryblokResourceShortPageProps)}
+        story={story}
         related_course={relatedCourse}
         related_session={relatedSessionData}
-        storyUuid={story.uuid}
       />
     );
   }
 
   return (
     <StoryblokResourceShortPage
-      {...(story.content as StoryblokResourceShortPageProps)}
+      story={story}
       related_course={relatedSessionData}
       related_session={undefined}
-      storyUuid={story.uuid}
     />
   );
 }

--- a/app/[locale]/videos/[slug]/page.tsx
+++ b/app/[locale]/videos/[slug]/page.tsx
@@ -1,9 +1,6 @@
-import StoryblokResourceSingleVideoPage, {
-  StoryblokResourceSingleVideoPageProps,
-} from '@/components/storyblok/StoryblokResourceSingleVideoPage';
+import StoryblokResourceSingleVideoPage from '@/components/storyblok/StoryblokResourceSingleVideoPage';
 import { routing } from '@/i18n/routing';
 import { STORYBLOK_ENVIRONMENT } from '@/lib/constants/common';
-import { STORYBLOK_TAGS } from '@/lib/constants/enums';
 import { getStoryblokStory } from '@/lib/storyblok';
 import { generateMetadataBasic } from '@/lib/utils/generateMetadataBase';
 import { getStoryblokApi, ISbStoriesParams } from '@storyblok/react/rsc';
@@ -80,11 +77,5 @@ export default async function Page({ params }: { params: Params }) {
     notFound();
   }
 
-  return (
-    <StoryblokResourceSingleVideoPage
-      {...(story.content as StoryblokResourceSingleVideoPageProps)}
-      tags={story.tag_list as STORYBLOK_TAGS[]}
-      storyUuid={story.uuid}
-    />
-  );
+  return <StoryblokResourceSingleVideoPage story={story} />;
 }

--- a/app/[locale]/welcome/[partnerName]/page.tsx
+++ b/app/[locale]/welcome/[partnerName]/page.tsx
@@ -1,6 +1,4 @@
-import StoryblokWelcomePage, {
-  StoryblokWelcomePageProps,
-} from '@/components/storyblok/StoryblokWelcomePage';
+import StoryblokWelcomePage from '@/components/storyblok/StoryblokWelcomePage';
 import { routing } from '@/i18n/routing';
 import { STORYBLOK_ENVIRONMENT } from '@/lib/constants/common';
 import { getStoryblokStory } from '@/lib/storyblok';
@@ -69,10 +67,5 @@ export default async function Page({ params }: { params: Params }) {
     notFound();
   }
 
-  return (
-    <StoryblokWelcomePage
-      {...(story.content as StoryblokWelcomePageProps)}
-      storySlug={story.slug}
-    />
-  );
+  return <StoryblokWelcomePage story={story} />;
 }

--- a/components/pages/HomePage.tsx
+++ b/components/pages/HomePage.tsx
@@ -9,6 +9,7 @@ import { useCookieReferralPartner } from '@/lib/hooks/useCookieReferralPartner';
 import { useTypedSelector } from '@/lib/hooks/store';
 import logEvent from '@/lib/utils/logEvent';
 import { Box, Button } from '@mui/material';
+import { useStoryblokState } from '@storyblok/react';
 import { ISbStoryData } from '@storyblok/react/rsc';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
@@ -18,7 +19,8 @@ interface Props {
   story: ISbStoryData | undefined;
 }
 
-export default function HomePage({ story }: Props) {
+export default function HomePage({ story: initialStory }: Props) {
+  const story = useStoryblokState(initialStory ?? null) ?? initialStory;
   const t = useTranslations('Welcome');
 
   const userId = useTypedSelector((state) => state.user.id);

--- a/components/storyblok/StoryblokCoursePage.tsx
+++ b/components/storyblok/StoryblokCoursePage.tsx
@@ -14,7 +14,8 @@ import hasAccessToPage from '@/lib/utils/hasAccessToPage';
 import logEvent from '@/lib/utils/logEvent';
 import { rowStyle } from '@/styles/common';
 import { Box, Container, Typography } from '@mui/material';
-import { storyblokEditable } from '@storyblok/react/rsc';
+import { useStoryblokState } from '@storyblok/react';
+import { ISbStoryData, storyblokEditable } from '@storyblok/react/rsc';
 import { useTranslations } from 'next-intl';
 import { useEffect, useMemo } from 'react';
 import { StoryblokRichtext } from 'storyblok-rich-text-react-renderer';
@@ -34,7 +35,6 @@ const cardsContainerStyle = {
 } as const;
 
 export interface StoryblokCoursePageProps {
-  storyUuid: string;
   _uid: string;
   _editable: string;
   name: string;
@@ -49,9 +49,9 @@ export interface StoryblokCoursePageProps {
   component: 'Course';
 }
 
-const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
+const StoryblokCoursePage = ({ story: initialStory }: { story: ISbStoryData }) => {
+  const story = useStoryblokState(initialStory) ?? initialStory;
   const {
-    storyUuid,
     _uid,
     _editable,
     name,
@@ -62,7 +62,8 @@ const StoryblokCoursePage = (props: StoryblokCoursePageProps) => {
     video_transcript,
     weeks,
     included_for_partners,
-  } = props;
+  } = story.content as StoryblokCoursePageProps;
+  const storyUuid = story.uuid;
 
   const t = useTranslations('Courses');
   const referralPartner = useCookieReferralPartner();

--- a/components/storyblok/StoryblokMeetTheTeamPage.tsx
+++ b/components/storyblok/StoryblokMeetTheTeamPage.tsx
@@ -8,7 +8,8 @@ import logEvent from '@/lib/utils/logEvent';
 import { RichTextOptions } from '@/lib/utils/richText';
 import theme from '@/styles/theme';
 import { Box, Container, Typography, useMediaQuery } from '@mui/material';
-import { storyblokEditable } from '@storyblok/react/rsc';
+import { useStoryblokState } from '@storyblok/react';
+import { ISbStoryData, storyblokEditable } from '@storyblok/react/rsc';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { render, StoryblokRichtext } from 'storyblok-rich-text-react-renderer';
@@ -49,7 +50,8 @@ export interface StoryblokMeetTheTeamPageProps {
   page_section_3: StoryblokPageSectionProps[];
 }
 
-const StoryblokMeetTheTeamPage = (props: StoryblokMeetTheTeamPageProps) => {
+const StoryblokMeetTheTeamPage = ({ story: initialStory }: { story: ISbStoryData }) => {
+  const story = useStoryblokState(initialStory) ?? initialStory;
   const {
     _uid,
     _editable,
@@ -68,7 +70,7 @@ const StoryblokMeetTheTeamPage = (props: StoryblokMeetTheTeamPageProps) => {
     page_section_1,
     page_section_2,
     page_section_3,
-  } = props;
+  } = story.content as StoryblokMeetTheTeamPageProps;
 
   const userId = useTypedSelector((state) => state.user.id);
   const authStateLoading = useTypedSelector((state) => state.user.authStateLoading);

--- a/components/storyblok/StoryblokPage.tsx
+++ b/components/storyblok/StoryblokPage.tsx
@@ -5,7 +5,8 @@ import ScrollToSignUpButton from '@/components/common/ScrollToSignUpButton';
 import Header from '@/components/layout/Header';
 import { usePathname } from '@/i18n/routing';
 import { useTypedSelector } from '@/lib/hooks/store';
-import { SbBlokData, storyblokEditable } from '@storyblok/react/rsc';
+import { useStoryblokState } from '@storyblok/react';
+import { ISbStoryData, SbBlokData, storyblokEditable } from '@storyblok/react/rsc';
 import { StoryblokRichtext } from 'storyblok-rich-text-react-renderer';
 import NotesFromBloomPromo from '../banner/NotesFromBloomPromo';
 import DynamicComponent from './DynamicComponent';
@@ -19,8 +20,10 @@ export interface StoryblokPageProps {
   page_sections: SbBlokData[];
 }
 
-const StoryblokPage = (props: StoryblokPageProps) => {
-  const { _uid, _editable, title, description, header_image, page_sections } = props;
+const StoryblokPage = ({ story: initialStory }: { story: ISbStoryData }) => {
+  const story = useStoryblokState(initialStory) ?? initialStory;
+  const { _uid, _editable, title, description, header_image, page_sections } =
+    story.content as StoryblokPageProps;
 
   const userId = useTypedSelector((state) => state.user.id);
   const authStateLoading = useTypedSelector((state) => state.user.authStateLoading);

--- a/components/storyblok/StoryblokResourceConversationPage.tsx
+++ b/components/storyblok/StoryblokResourceConversationPage.tsx
@@ -9,7 +9,8 @@ import hasAccessToPage from '@/lib/utils/hasAccessToPage';
 import logEvent from '@/lib/utils/logEvent';
 import userHasAccessToPartnerContent from '@/lib/utils/userHasAccessToPartnerContent';
 import { Box, Container } from '@mui/material';
-import { storyblokEditable } from '@storyblok/react/rsc';
+import { useStoryblokState } from '@storyblok/react';
+import { ISbStoryData, storyblokEditable } from '@storyblok/react/rsc';
 import { useLocale } from 'next-intl';
 import { useEffect, useMemo } from 'react';
 import { StoryblokRichtext } from 'storyblok-rich-text-react-renderer';
@@ -20,7 +21,6 @@ import { StoryblokPageSectionProps } from './StoryblokPageSection';
 import { StoryblokRelatedContent, StoryblokRelatedContentStory } from './StoryblokRelatedContent';
 
 export interface StoryblokResourceConversationPageProps {
-  storyUuid: string;
   _uid: string;
   _editable: string;
   name: string;
@@ -37,9 +37,9 @@ export interface StoryblokResourceConversationPageProps {
   included_for_partners: string[];
 }
 
-const StoryblokResourceConversationPage = (props: StoryblokResourceConversationPageProps) => {
+const StoryblokResourceConversationPage = ({ story: initialStory }: { story: ISbStoryData }) => {
+  const story = useStoryblokState(initialStory) ?? initialStory;
   const {
-    storyUuid,
     _uid,
     _editable,
     name,
@@ -52,7 +52,8 @@ const StoryblokResourceConversationPage = (props: StoryblokResourceConversationP
     related_exercises,
     languages,
     included_for_partners,
-  } = props;
+  } = story.content as StoryblokResourceConversationPageProps;
+  const storyUuid = story.uuid;
 
   const locale = useLocale();
   const userId = useTypedSelector((state) => state.user.id);

--- a/components/storyblok/StoryblokResourceShortPage.tsx
+++ b/components/storyblok/StoryblokResourceShortPage.tsx
@@ -44,7 +44,11 @@ interface Props {
   related_session?: ISbStoryData;
 }
 
-const StoryblokResourceShortPage = ({ story: initialStory, related_course, related_session }: Props) => {
+const StoryblokResourceShortPage = ({
+  story: initialStory,
+  related_course,
+  related_session,
+}: Props) => {
   const story = useStoryblokState(initialStory) ?? initialStory;
   const {
     _uid,

--- a/components/storyblok/StoryblokResourceShortPage.tsx
+++ b/components/storyblok/StoryblokResourceShortPage.tsx
@@ -11,6 +11,7 @@ import hasAccessToPage from '@/lib/utils/hasAccessToPage';
 import logEvent from '@/lib/utils/logEvent';
 import userHasAccessToPartnerContent from '@/lib/utils/userHasAccessToPartnerContent';
 import { Box, Container } from '@mui/material';
+import { useStoryblokState } from '@storyblok/react';
 import { ISbStoryData, storyblokEditable } from '@storyblok/react/rsc';
 import { useLocale } from 'next-intl';
 import { useEffect, useMemo } from 'react';
@@ -22,7 +23,6 @@ import { StoryblokPageSectionProps } from './StoryblokPageSection';
 import { StoryblokRelatedContent, StoryblokRelatedContentStory } from './StoryblokRelatedContent';
 
 export interface StoryblokResourceShortPageProps {
-  storyUuid: string;
   _uid: string;
   _editable: string;
   name: string;
@@ -31,8 +31,6 @@ export interface StoryblokResourceShortPageProps {
   video: { url: string };
   video_transcript: StoryblokRichtext;
   page_sections: StoryblokPageSectionProps[];
-  related_session?: ISbStoryData;
-  related_course?: ISbStoryData;
   related_content: StoryblokRelatedContentStory[];
   related_exercises: string[];
   languages: string[];
@@ -40,9 +38,15 @@ export interface StoryblokResourceShortPageProps {
   included_for_partners: string[];
 }
 
-const StoryblokResourceShortPage = (props: StoryblokResourceShortPageProps) => {
+interface Props {
+  story: ISbStoryData;
+  related_course?: ISbStoryData;
+  related_session?: ISbStoryData;
+}
+
+const StoryblokResourceShortPage = ({ story: initialStory, related_course, related_session }: Props) => {
+  const story = useStoryblokState(initialStory) ?? initialStory;
   const {
-    storyUuid,
     _uid,
     _editable,
     name,
@@ -50,13 +54,13 @@ const StoryblokResourceShortPage = (props: StoryblokResourceShortPageProps) => {
     video,
     video_transcript,
     page_sections,
-    related_session,
-    related_course,
     related_content,
     related_exercises,
     languages,
     included_for_partners,
-  } = props;
+  } = story.content as StoryblokResourceShortPageProps;
+  const storyUuid = story.uuid;
+
   const locale = useLocale();
   const referralPartner = useCookieReferralPartner();
   const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);

--- a/components/storyblok/StoryblokResourceSingleVideoPage.tsx
+++ b/components/storyblok/StoryblokResourceSingleVideoPage.tsx
@@ -15,7 +15,8 @@ import hasAccessToPage from '@/lib/utils/hasAccessToPage';
 import logEvent from '@/lib/utils/logEvent';
 import userHasAccessToPartnerContent from '@/lib/utils/userHasAccessToPartnerContent';
 import { Box, Container } from '@mui/material';
-import { storyblokEditable } from '@storyblok/react/rsc';
+import { useStoryblokState } from '@storyblok/react';
+import { ISbStoryData, storyblokEditable } from '@storyblok/react/rsc';
 import { useLocale } from 'next-intl';
 import { useEffect, useMemo } from 'react';
 import { StoryblokRichtext } from 'storyblok-rich-text-react-renderer';
@@ -30,7 +31,6 @@ import StoryblokTeamMembersSection, {
 import { StoryblokReferenceProps } from './StoryblokTypes';
 
 export interface StoryblokResourceSingleVideoPageProps {
-  storyUuid: string;
   _uid: string;
   _editable: string;
   name: string;
@@ -47,12 +47,11 @@ export interface StoryblokResourceSingleVideoPageProps {
   languages: string[];
   included_for_partners: string[];
   component: 'resource_single_video';
-  tags: STORYBLOK_TAGS[];
 }
 
-const StoryblokResourceSingleVideoPage = (props: StoryblokResourceSingleVideoPageProps) => {
+const StoryblokResourceSingleVideoPage = ({ story: initialStory }: { story: ISbStoryData }) => {
+  const story = useStoryblokState(initialStory) ?? initialStory;
   const {
-    storyUuid,
     _uid,
     _editable,
     name,
@@ -67,8 +66,9 @@ const StoryblokResourceSingleVideoPage = (props: StoryblokResourceSingleVideoPag
     references,
     languages,
     included_for_partners,
-    tags,
-  } = props;
+  } = story.content as StoryblokResourceSingleVideoPageProps;
+  const storyUuid = story.uuid;
+  const tags = story.tag_list as STORYBLOK_TAGS[];
 
   const locale = useLocale();
   const referralPartner = useCookieReferralPartner();

--- a/components/storyblok/StoryblokSessionPage.tsx
+++ b/components/storyblok/StoryblokSessionPage.tsx
@@ -20,6 +20,7 @@ import { ArrowBack } from '@mui/icons-material';
 import LinkIcon from '@mui/icons-material/Link';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 import { Box, Container, Link } from '@mui/material';
+import { useStoryblokState } from '@storyblok/react';
 import { ISbStoryData, storyblokEditable } from '@storyblok/react/rsc';
 import { useLocale, useTranslations } from 'next-intl';
 import { useMemo } from 'react';
@@ -47,8 +48,6 @@ const backToCourseLinkStyle = {
 } as const;
 
 export interface StoryblokSessionPageProps {
-  storyUuid: string;
-  storyPosition: number;
   _uid: string;
   _editable: string;
   course: ISbStoryData;
@@ -65,10 +64,9 @@ export interface StoryblokSessionPageProps {
   included_for_partners: string[];
 }
 
-const StoryblokSessionPage = (props: StoryblokSessionPageProps) => {
+const StoryblokSessionPage = ({ story: initialStory }: { story: ISbStoryData }) => {
+  const story = useStoryblokState(initialStory) ?? initialStory;
   const {
-    storyUuid,
-    storyPosition,
     _uid,
     _editable,
     course,
@@ -80,7 +78,9 @@ const StoryblokSessionPage = (props: StoryblokSessionPageProps) => {
     video_outro,
     activity,
     bonus,
-  } = props;
+  } = story.content as StoryblokSessionPageProps;
+  const storyUuid = story.uuid;
+  const storyPosition = story.position;
 
   const t = useTranslations('Courses');
   const locale = useLocale();

--- a/components/storyblok/StoryblokWelcomePage.tsx
+++ b/components/storyblok/StoryblokWelcomePage.tsx
@@ -15,7 +15,8 @@ import { RichTextOptions } from '@/lib/utils/richText';
 import illustrationBloomHeadYellow from '@/public/illustration_bloom_head_yellow.svg';
 import welcomeToBloom from '@/public/welcome_to_bloom.svg';
 import { Box, Button, Container } from '@mui/material';
-import { storyblokEditable } from '@storyblok/react/rsc';
+import { useStoryblokState } from '@storyblok/react';
+import { ISbStoryData, storyblokEditable } from '@storyblok/react/rsc';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useRef } from 'react';
@@ -43,15 +44,17 @@ const introTextStyle = {
 export interface StoryblokWelcomePageProps {
   _uid: string;
   _editable: string;
-  storySlug: string;
   title: string;
   introduction: StoryblokRichtext;
   header_image: { filename: string; alt: string };
   page_sections: StoryblokPageSectionProps[];
 }
 
-const StoryblokWelcomePage = (props: StoryblokWelcomePageProps) => {
-  const { _uid, _editable, storySlug, title, introduction, header_image, page_sections } = props;
+const StoryblokWelcomePage = ({ story: initialStory }: { story: ISbStoryData }) => {
+  const story = useStoryblokState(initialStory) ?? initialStory;
+  const { _uid, _editable, title, introduction, header_image, page_sections } =
+    story.content as StoryblokWelcomePageProps;
+  const storySlug = story.slug;
 
   const partnerContent = getPartnerContent(storySlug) as PartnerContent;
 


### PR DESCRIPTION
### Resolves #enter-issue-number

### What changes did you make and why did you make them?

**Fix: Storyblok visual editor preview and click-to-edit**

Two issues were preventing the Storyblok visual editor from working on staging:

**CSP headers blocking the Storyblok iframe** — frame-ancestors was hardcoded to 'self' and X-Frame-Options was set to DENY, preventing app.storyblok.com from embedding the staging site. Fixed by adding https://app.storyblok.com to the frameAncestorsUrls allowlist in scriptUrls.js and updating next.config.js to use it.

**Click-to-edit not working** — All Storyblok page components were receiving story.content spread as props from server components, so the Storyblok Bridge was never activated client-side. Fixed by adding useStoryblokState directly into each page component (StoryblokPage, StoryblokCoursePage, StoryblokSessionPage, StoryblokResourceSingleVideoPage, StoryblokResourceShortPage, StoryblokResourceConversationPage, StoryblokWelcomePage, StoryblokMeetTheTeamPage, HomePage). Each component now accepts a full ISbStoryData story object and activates the bridge internally, enabling live content updates and click-to-edit in the visual editor.
