### PR TITLE
Add notes US deliverability alert

### DIFF
--- a/components/pages/NotesPage.tsx
+++ b/components/pages/NotesPage.tsx
@@ -14,8 +14,20 @@ import { hasWhatsappSubscription } from '@/lib/utils/whatsappUtils';
 import illustrationActivites from '@/public/illustration_activites.svg';
 import notesExample from '@/public/notes_example.png';
 import { rowStyle } from '@/styles/common';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
-import { Box, Card, CardContent, Container, IconButton, Typography } from '@mui/material';
+import SmsFailedOutlined from '@mui/icons-material/SmsFailedOutlined';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Card,
+  CardContent,
+  Container,
+  IconButton,
+  Typography,
+} from '@mui/material';
 import { ISbStoryData } from '@storyblok/react/rsc';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
@@ -53,6 +65,34 @@ const illustrationStyle = {
   width: { xs: 200, md: 300 },
   height: { xs: 200, md: 300 },
   flexShrink: 0,
+} as const;
+
+const usNoticeStyle = {
+  mw: 600,
+  mb: 2,
+  backgroundColor: 'secondary.light',
+  borderRadius: '20px !important',
+  boxShadow: '0px 1px 3px 0px rgba(0, 0, 0, 0.12)',
+  '&::before': { display: 'none' },
+  '& .MuiAccordionSummary-root': {
+    py: 1,
+    pl: 1,
+    borderRadius: 20,
+    '&.Mui-expanded': {
+      minHeight: 'auto !important',
+      margin: '0 !important',
+    },
+  },
+  '& .MuiAccordionSummary-content': {
+    margin: '0.5rem !important',
+    alignItems: 'flex-start',
+  },
+  '& .MuiAccordionSummary-expandIconWrapper': {
+    marginTop: '2px',
+  },
+  '& .MuiAccordionDetails-root': {
+    pt: 0,
+  },
 } as const;
 
 const formContainerStyle = {
@@ -121,6 +161,18 @@ export default function NotesPage({ story }: Props) {
     return <NoDataAvailable />;
   }
 
+  const usNotice = (
+    <Accordion sx={usNoticeStyle}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <SmsFailedOutlined color="error" sx={{ mr: 1.25, mt: '1px' }} />
+        <Typography variant="body1">{t('notes.usNoticeTitle')}</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography variant="body2">{t('notes.usNoticeDescription')}</Typography>
+      </AccordionDetails>
+    </Accordion>
+  );
+
   const renderFormSection = () => {
     if (!userId) {
       // Unauthenticated user - show registration form
@@ -135,17 +187,20 @@ export default function NotesPage({ story }: Props) {
               style={{ objectFit: 'contain' }}
             />
           </Box>
-          <Card sx={formCardStyle}>
-            <CardContent>
-              <Typography variant="h2" component="h2">
-                {t('notes.createAccount')}
-              </Typography>
-              <Typography variant="body2" pb={2}>
-                {t('notes.createAccountDescription')}
-              </Typography>
-              <RegisterNotesForm />
-            </CardContent>
-          </Card>
+          <Box sx={{ maxWidth: 600 }}>
+            {usNotice}
+            <Card sx={formCardStyle}>
+              <CardContent>
+                <Typography variant="h2" component="h2">
+                  {t('notes.createAccount')}
+                </Typography>
+                <Typography variant="body2" pb={2}>
+                  {t('notes.createAccountDescription')}
+                </Typography>
+                <RegisterNotesForm />
+              </CardContent>
+            </Card>
+          </Box>
         </Box>
       );
     } else if (!hasActiveWhatsappSub) {
@@ -161,17 +216,20 @@ export default function NotesPage({ story }: Props) {
               style={{ objectFit: 'contain' }}
             />
           </Box>
-          <Card sx={formCardStyle}>
-            <CardContent>
-              <Typography variant="h2" component="h2">
-                {t('form.subscribeTitle')}
-              </Typography>
-              <Typography variant="body2" pb={2}>
-                {t('notes.subscribeDescription')}
-              </Typography>
-              <WhatsappSubscribeForm />
-            </CardContent>
-          </Card>
+          <Box sx={{ maxWidth: 600 }}>
+            {usNotice}
+            <Card sx={formCardStyle}>
+              <CardContent>
+                <Typography variant="h2" component="h2">
+                  {t('form.subscribeTitle')}
+                </Typography>
+                <Typography variant="body2" pb={2}>
+                  {t('notes.subscribeDescription')}
+                </Typography>
+                <WhatsappSubscribeForm />
+              </CardContent>
+            </Card>
+          </Box>
         </Box>
       );
     }
@@ -188,17 +246,20 @@ export default function NotesPage({ story }: Props) {
             style={{ objectFit: 'contain' }}
           />
         </Box>
-        <Card sx={formCardStyle}>
-          <CardContent>
-            <Typography variant="h2" component="h2">
-              {t('form.unsubscribeTitle')}
-            </Typography>
-            <Typography variant="body2" pb={2}>
-              {t('notes.unsubscribeDescription')}
-            </Typography>
-            <WhatsappUnsubscribeForm />
-          </CardContent>
-        </Card>
+        <Box sx={{ maxWidth: 600 }}>
+          {usNotice}
+          <Card sx={formCardStyle}>
+            <CardContent>
+              <Typography variant="h2" component="h2">
+                {t('form.unsubscribeTitle')}
+              </Typography>
+              <Typography variant="body2" pb={2}>
+                {t('notes.unsubscribeDescription')}
+              </Typography>
+              <WhatsappUnsubscribeForm />
+            </CardContent>
+          </Card>
+        </Box>
       </Box>
     );
   };

--- a/i18n/messages/whatsapp/de.json
+++ b/i18n/messages/whatsapp/de.json
@@ -28,6 +28,8 @@
       "step2": "Zweimal pro Woche, jeden Mittwoch und Sonntag",
       "step3": "Wir teilen Affirmationen, Aktivitäten und Reflexionen",
       "step4": "Melde dich jederzeit ab, wenn du deine Meinung änderst",
+      "usNoticeTitle": "WhatsApp-Zustellungsprobleme für US-Abonnenten",
+      "usNoticeDescription": "Meta hat Änderungen vorgenommen, die unsere Fähigkeit beeinträchtigen, Notes an Abonnenten in den USA zu senden. Wir arbeiten intensiv daran, dies zu beheben, aber Nachrichten erreichen dich möglicherweise derzeit nicht. Du kannst dich gerne anmelden – wir informieren dich, wenn es wieder für alle funktioniert.",
       "subscribeDescription": "Abonniere Notes von Bloom, um WhatsApp-Nachrichten zu erhalten. Du kannst dich hier jederzeit abmelden.",
       "unsubscribeDescription": "Melde dich von Notes von Bloom ab, um keine WhatsApp-Nachrichten mehr zu erhalten oder um deine Nummer zu aktualisieren. Du kannst dich jederzeit wieder anmelden."
     }

--- a/i18n/messages/whatsapp/en.json
+++ b/i18n/messages/whatsapp/en.json
@@ -28,6 +28,8 @@
       "step2": "Twice a week, every Wednesday and Sunday",
       "step3": "We share affirmations, activities and reflections",
       "step4": "Unsubscribe any time if you change your mind",
+      "usNoticeTitle": "WhatsApp delivery issues for US subscribers",
+      "usNoticeDescription": "Meta has made changes that are affecting our ability to send Notes to subscribers in the USA. We're working hard to fix this, but messages may not reach you right now. Feel free to subscribe—we'll update you when it's working for everyone again.",
       "subscribeDescription": "Subscribe to Notes from Bloom to start receiving whatsapp messages. Unsubscribe here anytime.",
       "unsubscribeDescription": "Unsubscribe from Notes from Bloom to stop receiving whatsapp messages, or to update your number. Subscribe again anytime."
     }

--- a/i18n/messages/whatsapp/es.json
+++ b/i18n/messages/whatsapp/es.json
@@ -28,6 +28,8 @@
       "step2": "Dos veces por semana, cada miércoles y domingo",
       "step3": "Compartimos afirmaciones, actividades y reflexiones",
       "step4": "Cancela tu suscripción en cualquier momento si cambias de opinión",
+      "usNoticeTitle": "Problemas de entrega de WhatsApp para suscriptores en EE. UU.",
+      "usNoticeDescription": "Meta ha realizado cambios que están afectando nuestra capacidad de enviar Notas a suscriptores en EE. UU. Estamos trabajando para solucionarlo, pero es posible que los mensajes no te lleguen por ahora. Puedes suscribirte igualmente y te avisaremos cuando funcione para todos de nuevo.",
       "subscribeDescription": "Suscríbete a Notas de Bloom para comenzar a recibir mensajes de WhatsApp. Cancela tu suscripción aquí en cualquier momento.",
       "unsubscribeDescription": "Cancela tu suscripción a Notas de Bloom para dejar de recibir mensajes de WhatsApp, o para actualizar tu número. Suscríbete de nuevo en cualquier momento."
     }

--- a/i18n/messages/whatsapp/fr.json
+++ b/i18n/messages/whatsapp/fr.json
@@ -28,6 +28,8 @@
       "step2": "Deux fois par semaine, chaque mercredi et dimanche",
       "step3": "Nous partageons des affirmations, des activités et des réflexions",
       "step4": "Désabonnez-vous à tout moment si vous changez d'avis",
+      "usNoticeTitle": "Problèmes de livraison WhatsApp pour les abonnés aux États-Unis",
+      "usNoticeDescription": "Meta a apporté des modifications qui affectent notre capacité à envoyer des Notes aux abonnés aux États-Unis. Nous travaillons activement pour résoudre ce problème, mais les messages peuvent ne pas vous parvenir pour le moment. N'hésitez pas à vous abonner — nous vous tiendrons informé lorsque tout fonctionnera à nouveau pour tout le monde.",
       "subscribeDescription": "Abonnez-vous aux Notes de Bloom pour commencer à recevoir des messages WhatsApp. Désabonnez-vous ici à tout moment.",
       "unsubscribeDescription": "Désabonnez-vous des Notes de Bloom pour arrêter de recevoir des messages WhatsApp, ou pour mettre à jour votre numéro. Réabonnez-vous à tout moment."
     }

--- a/i18n/messages/whatsapp/hi.json
+++ b/i18n/messages/whatsapp/hi.json
@@ -28,6 +28,8 @@
       "step2": "Har hafte do baar, har Budhvaar aur Ravivaar",
       "step3": "Hum affirmations, activities aur reflections share karte hain",
       "step4": "Agar aap apna mann badlein toh kisi bhi samay unsubscribe kar sakte hain",
+      "usNoticeTitle": "US subscribers ke liye WhatsApp delivery mein samasya",
+      "usNoticeDescription": "Meta ne kuch badlaav kiye hain jinse USA mein subscribers ko Notes bhejne mein dikkat aa rahi hai. Hum ise theek karne mein lage hain, lekin abhi messages aap tak nahi pahunch rahe hain. Aap subscribe kar sakte hain — jab sab ke liye theek ho jayega, hum aapko suchit karenge.",
       "subscribeDescription": "WhatsApp messages prapt karna shuru karne ke liye Bloom se Notes ke liye subscribe karein. Yahan kabhi bhi unsubscribe karein.",
       "unsubscribeDescription": "WhatsApp messages band karne ke liye ya apna number update karne ke liye Bloom se Notes se unsubscribe karein. Kabhi bhi dobara subscribe kar sakte hain."
     }

--- a/i18n/messages/whatsapp/pt.json
+++ b/i18n/messages/whatsapp/pt.json
@@ -28,6 +28,8 @@
       "step2": "Duas vezes por semana, todas as quartas e domingos",
       "step3": "Compartilhamos afirmações, atividades e reflexões",
       "step4": "Cancele a assinatura a qualquer momento se mudar de ideia",
+      "usNoticeTitle": "Problemas de entrega do WhatsApp para assinantes nos EUA",
+      "usNoticeDescription": "A Meta fez alterações que estão afetando nossa capacidade de enviar Notas para assinantes nos EUA. Estamos trabalhando para resolver isso, mas as mensagens podem não chegar até você no momento. Fique à vontade para se inscrever — avisaremos quando estiver funcionando para todos novamente.",
       "subscribeDescription": "Assine as Notas do Bloom para começar a receber mensagens do WhatsApp. Cancele a assinatura aqui a qualquer momento.",
       "unsubscribeDescription": "Cancele a assinatura das Notas do Bloom para parar de receber mensagens do WhatsApp, ou para atualizar seu número. Assine novamente a qualquer momento."
     }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Adds warning card explaining notes for bloom deliverability issues in the US.

<img width="1271" height="693" alt="Screenshot 2026-03-31 at 12 57 28" src="https://github.com/user-attachments/assets/c0fca5b5-1c9e-445a-87d3-28b1a7fb9300" />
<img width="381" height="749" alt="Screenshot 2026-03-31 at 13 15 06" src="https://github.com/user-attachments/assets/39d7e5c5-878e-4b50-a042-8f61105d8e3f" />
