### PR TITLE
Test replacing wait-for-vercel action

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -17,13 +17,39 @@ jobs:
     outputs:
       preview_url: ${{ steps.waitForVercelDeployment.outputs.url }}
     steps:
-      - name: Wait for Vercel preview deployment to be ready
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
+      - name: Wait for Vercel deployment
         id: waitForVercelDeployment
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 1000
-          check_interval: 20
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+        run: |
+          COMMIT_SHA="${GITHUB_SHA}"
+          MAX_ATTEMPTS=50
+          INTERVAL=20
+
+          echo "Waiting for Vercel deployment for commit ${COMMIT_SHA}..."
+
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            RESPONSE=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+              "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_TEAM_ID}&meta-githubCommitSha=${COMMIT_SHA}&limit=1")
+
+            STATE=$(echo "$RESPONSE" | jq -r '.deployments[0].state // empty')
+            URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url // empty')
+
+            if [ "$STATE" = "READY" ] && [ -n "$URL" ]; then
+              FULL_URL="https://${URL}"
+              echo "Deployment ready: ${FULL_URL}"
+              echo "url=${FULL_URL}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "Attempt ${i}/${MAX_ATTEMPTS}: state=${STATE:-not found}, waiting ${INTERVAL}s..."
+            sleep $INTERVAL
+          done
+
+          echo "::error::Timed out waiting for Vercel deployment"
+          exit 1
 
   # Parallel test execution using matrix strategy
   cypress-run:

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -137,6 +137,7 @@ jobs:
           CYPRESS_PUBLIC_PASSWORD: ${{secrets.CYPRESS_PUBLIC_PASSWORD}}
           CYPRESS_PUBLIC_NAME: ${{secrets.CYPRESS_PUBLIC_NAME}}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Upload artifacts only on failure to reduce log size
@@ -218,4 +219,5 @@ jobs:
           CYPRESS_PUBLIC_PASSWORD: ${{secrets.CYPRESS_PUBLIC_PASSWORD}}
           CYPRESS_PUBLIC_NAME: ${{secrets.CYPRESS_PUBLIC_NAME}}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -32,7 +32,7 @@ jobs:
 
           for i in $(seq 1 $MAX_ATTEMPTS); do
             RESPONSE=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-              "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_TEAM_ID}&meta-githubCommitSha=${COMMIT_SHA}&limit=1")
+              "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_TEAM_ID}&sha=${COMMIT_SHA}&limit=1")
 
             STATE=$(echo "$RESPONSE" | jq -r '.deployments[0].state // empty')
             URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url // empty')

--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -16,13 +16,39 @@ jobs:
       deployments: read
       statuses: read
     steps:
-      - name: Wait for Vercel preview deployment to be ready
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
+      - name: Wait for Vercel deployment
         id: waitForVercelDeployment
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 1000
-          check_interval: 5
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+        run: |
+          COMMIT_SHA="${GITHUB_SHA}"
+          MAX_ATTEMPTS=50
+          INTERVAL=20
+
+          echo "Waiting for Vercel deployment for commit ${COMMIT_SHA}..."
+
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            RESPONSE=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+              "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_TEAM_ID}&meta-githubCommitSha=${COMMIT_SHA}&limit=1")
+
+            STATE=$(echo "$RESPONSE" | jq -r '.deployments[0].state // empty')
+            URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url // empty')
+
+            if [ "$STATE" = "READY" ] && [ -n "$URL" ]; then
+              FULL_URL="https://${URL}"
+              echo "Deployment ready: ${FULL_URL}"
+              echo "url=${FULL_URL}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "Attempt ${i}/${MAX_ATTEMPTS}: state=${STATE:-not found}, waiting ${INTERVAL}s..."
+            sleep $INTERVAL
+          done
+
+          echo "::error::Timed out waiting for Vercel deployment"
+          exit 1
 
   lighthouse-desktop:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -31,7 +31,7 @@ jobs:
 
           for i in $(seq 1 $MAX_ATTEMPTS); do
             RESPONSE=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-              "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_TEAM_ID}&meta-githubCommitSha=${COMMIT_SHA}&limit=1")
+              "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_TEAM_ID}&sha=${COMMIT_SHA}&limit=1")
 
             STATE=$(echo "$RESPONSE" | jq -r '.deployments[0].state // empty')
             URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url // empty')

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -29,7 +29,11 @@ if (bypassSecret) {
   });
 
   beforeEach(() => {
-    cy.setCookie('x-vercel-protection-bypass', bypassSecret);
+    // Re-establish the Vercel bypass cookie before each test, in case
+    // cy.clearAllCookies() removed it (e.g. in cleanUpTestState).
+    // The cy.visit override adds the bypass query params automatically,
+    // which tells Vercel to set the _vercel_jwt session cookie.
+    cy.visit('/', { failOnStatusCode: false });
   });
 }
 

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -2,6 +2,14 @@
 import '@cypress/code-coverage/support';
 const customCommands = require('./commands.js');
 
+// Bypass Vercel Deployment Protection for automated tests
+const bypassSecret = Cypress.env('VERCEL_BYPASS_SECRET');
+if (bypassSecret) {
+  beforeEach(() => {
+    cy.setCookie('x-vercel-protection-bypass', bypassSecret);
+  });
+}
+
 module.exports = {
   commands: customCommands,
 };

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -2,11 +2,18 @@
 import '@cypress/code-coverage/support';
 const customCommands = require('./commands.js');
 
-// Bypass Vercel Deployment Protection for automated tests
+// Bypass Vercel Deployment Protection for automated tests.
+// Appends bypass query params on cy.visit so the first navigation
+// is not redirected to Vercel's auth page. The x-vercel-set-bypass-cookie
+// param tells Vercel to set a session cookie for all subsequent requests.
 const bypassSecret = Cypress.env('VERCEL_BYPASS_SECRET');
 if (bypassSecret) {
-  beforeEach(() => {
-    cy.setCookie('x-vercel-protection-bypass', bypassSecret);
+  Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+    const baseUrl = Cypress.config('baseUrl') || '';
+    const fullUrl = new URL(url, baseUrl);
+    fullUrl.searchParams.set('x-vercel-protection-bypass', bypassSecret);
+    fullUrl.searchParams.set('x-vercel-set-bypass-cookie', 'samesitenone');
+    return originalFn(fullUrl.toString(), options);
   });
 }
 

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -3,9 +3,10 @@ import '@cypress/code-coverage/support';
 const customCommands = require('./commands.js');
 
 // Bypass Vercel Deployment Protection for automated tests.
-// Appends bypass query params on cy.visit so the first navigation
-// is not redirected to Vercel's auth page. The x-vercel-set-bypass-cookie
-// param tells Vercel to set a session cookie for all subsequent requests.
+// 1. cy.visit: appends bypass query params so the first navigation isn't blocked,
+//    and x-vercel-set-bypass-cookie tells Vercel to set a session cookie.
+// 2. cy.request: adds the bypass header for direct HTTP requests (e.g. sitemap).
+// 3. beforeEach: re-sets the bypass cookie in case cy.clearAllCookies() removed it.
 const bypassSecret = Cypress.env('VERCEL_BYPASS_SECRET');
 if (bypassSecret) {
   Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
@@ -14,6 +15,21 @@ if (bypassSecret) {
     fullUrl.searchParams.set('x-vercel-protection-bypass', bypassSecret);
     fullUrl.searchParams.set('x-vercel-set-bypass-cookie', 'samesitenone');
     return originalFn(fullUrl.toString(), options);
+  });
+
+  Cypress.Commands.overwrite('request', (originalFn, ...args) => {
+    let options = typeof args[0] === 'object' ? { ...args[0] } : {};
+    if (typeof args[0] === 'string' && typeof args[1] === 'string') {
+      options = { method: args[0], url: args[1], body: args[2] };
+    } else if (typeof args[0] === 'string') {
+      options = { url: args[0], body: args[1] };
+    }
+    options.headers = { ...options.headers, 'x-vercel-protection-bypass': bypassSecret };
+    return originalFn(options);
+  });
+
+  beforeEach(() => {
+    cy.setCookie('x-vercel-protection-bypass', bypassSecret);
   });
 }
 


### PR DESCRIPTION
Fetches vercel deployments directly, removing the `patrickedqvist/wait-for-vercel-preview` action. Attempts to fix the 429 error recently occuring during that action/step