### PR TITLE
Remove vercel bypass secret + run tests on all branches

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -157,6 +157,7 @@ jobs:
           CYPRESS_PUBLIC_PASSWORD: ${{secrets.CYPRESS_PUBLIC_PASSWORD}}
           CYPRESS_PUBLIC_NAME: ${{secrets.CYPRESS_PUBLIC_NAME}}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_CI_FIREWALL_BYPASS: ${{ secrets.CI_FIREWALL_BYPASS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Upload artifacts only on failure to reduce log size
@@ -238,4 +239,5 @@ jobs:
           CYPRESS_PUBLIC_PASSWORD: ${{secrets.CYPRESS_PUBLIC_PASSWORD}}
           CYPRESS_PUBLIC_NAME: ${{secrets.CYPRESS_PUBLIC_NAME}}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_CI_FIREWALL_BYPASS: ${{ secrets.CI_FIREWALL_BYPASS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -2,7 +2,6 @@ name: Cypress release tests
 
 on:
   push:
-    branches: [develop, dependabot/**, '*test*']
 
 # Cancel in-progress runs when a new run is triggered
 concurrency:
@@ -137,7 +136,6 @@ jobs:
           CYPRESS_PUBLIC_PASSWORD: ${{secrets.CYPRESS_PUBLIC_PASSWORD}}
           CYPRESS_PUBLIC_NAME: ${{secrets.CYPRESS_PUBLIC_NAME}}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          CYPRESS_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Upload artifacts only on failure to reduce log size
@@ -219,5 +217,4 @@ jobs:
           CYPRESS_PUBLIC_PASSWORD: ${{secrets.CYPRESS_PUBLIC_PASSWORD}}
           CYPRESS_PUBLIC_NAME: ${{secrets.CYPRESS_PUBLIC_NAME}}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          CYPRESS_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -32,35 +32,16 @@ jobs:
           for i in $(seq 1 $MAX_ATTEMPTS); do
             RESPONSE=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
               "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_TEAM_ID}&sha=${COMMIT_SHA}&limit=1")
-
             STATE=$(echo "$RESPONSE" | jq -r '.deployments[0].state // empty')
             DEPLOYMENT_ID=$(echo "$RESPONSE" | jq -r '.deployments[0].uid // empty')
 
             if [ "$STATE" = "READY" ] && [ -n "$DEPLOYMENT_ID" ]; then
-              echo "Deployment READY (id: ${DEPLOYMENT_ID}). Waiting for branch alias assignment..."
-
-              # The branch alias is assigned a few seconds after state=READY.
-              # We must wait for it — the unique deployment URL hits stricter Vercel
-              # edge rate limits than the branch alias, causing 429s under parallel load.
-              for j in $(seq 1 15); do
-                DETAILS=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-                  "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_TEAM_ID}")
-                BRANCH_ALIAS=$(echo "$DETAILS" | jq -r '[.alias[]? | select(contains("-git-"))][0] // empty')
-
-                if [ -n "$BRANCH_ALIAS" ] && [ "$BRANCH_ALIAS" != "null" ]; then
-                  echo "url=https://${BRANCH_ALIAS}" >> "$GITHUB_OUTPUT"
-                  echo "✓ Branch alias ready: https://${BRANCH_ALIAS}"
-                  exit 0
-                fi
-
-                echo "  Alias attempt ${j}/15: not yet assigned, waiting 3s..."
-                sleep 3
-              done
-
-              UNIQUE_URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url')
-              echo "::error::Branch alias never assigned after 45s. Full alias array: $(echo "$DETAILS" | jq -c '.alias')"
-              echo "::warning::Falling back to unique URL (may hit rate limits): https://${UNIQUE_URL}"
-              echo "url=https://${UNIQUE_URL}" >> "$GITHUB_OUTPUT"
+              # Prefer the branch alias (readable in test logs) over the unique URL.
+              URL=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+                "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_TEAM_ID}" \
+                | jq -r '[.alias[]? | select(contains("-git-"))][0] // .url')
+              echo "url=https://${URL}" >> "$GITHUB_OUTPUT"
+              echo "Deployment ready: https://${URL}"
               exit 0
             fi
 

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -35,22 +35,32 @@ jobs:
 
             STATE=$(echo "$RESPONSE" | jq -r '.deployments[0].state // empty')
             DEPLOYMENT_ID=$(echo "$RESPONSE" | jq -r '.deployments[0].uid // empty')
-            UNIQUE_URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url // empty')
 
             if [ "$STATE" = "READY" ] && [ -n "$DEPLOYMENT_ID" ]; then
-              # Fetch full deployment details to get the stable branch alias.
-              # The unique deployment URL (e.g. project-abc123-team.vercel.app) hits
-              # stricter Vercel edge rate limits than the branch alias
-              # (e.g. project-git-branch-team.vercel.app), which triggers 429s under
-              # parallel test load.
-              DETAILS=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-                "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_TEAM_ID}")
-              BRANCH_ALIAS=$(echo "$DETAILS" | jq -r '.alias[]? | select(contains("-git-"))' | head -n 1)
-              URL="${BRANCH_ALIAS:-$UNIQUE_URL}"
+              echo "Deployment READY (id: ${DEPLOYMENT_ID}). Waiting for branch alias assignment..."
 
-              FULL_URL="https://${URL}"
-              echo "Deployment ready: ${FULL_URL}"
-              echo "url=${FULL_URL}" >> "$GITHUB_OUTPUT"
+              # The branch alias is assigned a few seconds after state=READY.
+              # We must wait for it — the unique deployment URL hits stricter Vercel
+              # edge rate limits than the branch alias, causing 429s under parallel load.
+              for j in $(seq 1 15); do
+                DETAILS=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+                  "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_TEAM_ID}")
+                BRANCH_ALIAS=$(echo "$DETAILS" | jq -r '[.alias[]? | select(contains("-git-"))][0] // empty')
+
+                if [ -n "$BRANCH_ALIAS" ] && [ "$BRANCH_ALIAS" != "null" ]; then
+                  echo "url=https://${BRANCH_ALIAS}" >> "$GITHUB_OUTPUT"
+                  echo "✓ Branch alias ready: https://${BRANCH_ALIAS}"
+                  exit 0
+                fi
+
+                echo "  Alias attempt ${j}/15: not yet assigned, waiting 3s..."
+                sleep 3
+              done
+
+              UNIQUE_URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url')
+              echo "::error::Branch alias never assigned after 45s. Full alias array: $(echo "$DETAILS" | jq -c '.alias')"
+              echo "::warning::Falling back to unique URL (may hit rate limits): https://${UNIQUE_URL}"
+              echo "url=https://${UNIQUE_URL}" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 

--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -34,9 +34,20 @@ jobs:
               "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_TEAM_ID}&sha=${COMMIT_SHA}&limit=1")
 
             STATE=$(echo "$RESPONSE" | jq -r '.deployments[0].state // empty')
-            URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url // empty')
+            DEPLOYMENT_ID=$(echo "$RESPONSE" | jq -r '.deployments[0].uid // empty')
+            UNIQUE_URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url // empty')
 
-            if [ "$STATE" = "READY" ] && [ -n "$URL" ]; then
+            if [ "$STATE" = "READY" ] && [ -n "$DEPLOYMENT_ID" ]; then
+              # Fetch full deployment details to get the stable branch alias.
+              # The unique deployment URL (e.g. project-abc123-team.vercel.app) hits
+              # stricter Vercel edge rate limits than the branch alias
+              # (e.g. project-git-branch-team.vercel.app), which triggers 429s under
+              # parallel test load.
+              DETAILS=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+                "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_TEAM_ID}")
+              BRANCH_ALIAS=$(echo "$DETAILS" | jq -r '.alias[]? | select(contains("-git-"))' | head -n 1)
+              URL="${BRANCH_ALIAS:-$UNIQUE_URL}"
+
               FULL_URL="https://${URL}"
               echo "Deployment ready: ${FULL_URL}"
               echo "url=${FULL_URL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -34,9 +34,17 @@ jobs:
               "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_TEAM_ID}&sha=${COMMIT_SHA}&limit=1")
 
             STATE=$(echo "$RESPONSE" | jq -r '.deployments[0].state // empty')
-            URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url // empty')
+            DEPLOYMENT_ID=$(echo "$RESPONSE" | jq -r '.deployments[0].uid // empty')
+            UNIQUE_URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url // empty')
 
-            if [ "$STATE" = "READY" ] && [ -n "$URL" ]; then
+            if [ "$STATE" = "READY" ] && [ -n "$DEPLOYMENT_ID" ]; then
+              # Prefer the stable branch alias over the unique deployment URL — the
+              # unique URL hits stricter Vercel edge rate limits under automated load.
+              DETAILS=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+                "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_TEAM_ID}")
+              BRANCH_ALIAS=$(echo "$DETAILS" | jq -r '.alias[]? | select(contains("-git-"))' | head -n 1)
+              URL="${BRANCH_ALIAS:-$UNIQUE_URL}"
+
               FULL_URL="https://${URL}"
               echo "Deployment ready: ${FULL_URL}"
               echo "url=${FULL_URL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -35,19 +35,29 @@ jobs:
 
             STATE=$(echo "$RESPONSE" | jq -r '.deployments[0].state // empty')
             DEPLOYMENT_ID=$(echo "$RESPONSE" | jq -r '.deployments[0].uid // empty')
-            UNIQUE_URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url // empty')
 
             if [ "$STATE" = "READY" ] && [ -n "$DEPLOYMENT_ID" ]; then
-              # Prefer the stable branch alias over the unique deployment URL — the
-              # unique URL hits stricter Vercel edge rate limits under automated load.
-              DETAILS=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-                "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_TEAM_ID}")
-              BRANCH_ALIAS=$(echo "$DETAILS" | jq -r '.alias[]? | select(contains("-git-"))' | head -n 1)
-              URL="${BRANCH_ALIAS:-$UNIQUE_URL}"
+              echo "Deployment READY (id: ${DEPLOYMENT_ID}). Waiting for branch alias assignment..."
 
-              FULL_URL="https://${URL}"
-              echo "Deployment ready: ${FULL_URL}"
-              echo "url=${FULL_URL}" >> "$GITHUB_OUTPUT"
+              for j in $(seq 1 15); do
+                DETAILS=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+                  "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_TEAM_ID}")
+                BRANCH_ALIAS=$(echo "$DETAILS" | jq -r '[.alias[]? | select(contains("-git-"))][0] // empty')
+
+                if [ -n "$BRANCH_ALIAS" ] && [ "$BRANCH_ALIAS" != "null" ]; then
+                  echo "url=https://${BRANCH_ALIAS}" >> "$GITHUB_OUTPUT"
+                  echo "✓ Branch alias ready: https://${BRANCH_ALIAS}"
+                  exit 0
+                fi
+
+                echo "  Alias attempt ${j}/15: not yet assigned, waiting 3s..."
+                sleep 3
+              done
+
+              UNIQUE_URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url')
+              echo "::error::Branch alias never assigned after 45s. Full alias array: $(echo "$DETAILS" | jq -c '.alias')"
+              echo "::warning::Falling back to unique URL: https://${UNIQUE_URL}"
+              echo "url=https://${UNIQUE_URL}" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 

--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -32,32 +32,15 @@ jobs:
           for i in $(seq 1 $MAX_ATTEMPTS); do
             RESPONSE=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
               "https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&teamId=${VERCEL_TEAM_ID}&sha=${COMMIT_SHA}&limit=1")
-
             STATE=$(echo "$RESPONSE" | jq -r '.deployments[0].state // empty')
             DEPLOYMENT_ID=$(echo "$RESPONSE" | jq -r '.deployments[0].uid // empty')
 
             if [ "$STATE" = "READY" ] && [ -n "$DEPLOYMENT_ID" ]; then
-              echo "Deployment READY (id: ${DEPLOYMENT_ID}). Waiting for branch alias assignment..."
-
-              for j in $(seq 1 15); do
-                DETAILS=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-                  "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_TEAM_ID}")
-                BRANCH_ALIAS=$(echo "$DETAILS" | jq -r '[.alias[]? | select(contains("-git-"))][0] // empty')
-
-                if [ -n "$BRANCH_ALIAS" ] && [ "$BRANCH_ALIAS" != "null" ]; then
-                  echo "url=https://${BRANCH_ALIAS}" >> "$GITHUB_OUTPUT"
-                  echo "✓ Branch alias ready: https://${BRANCH_ALIAS}"
-                  exit 0
-                fi
-
-                echo "  Alias attempt ${j}/15: not yet assigned, waiting 3s..."
-                sleep 3
-              done
-
-              UNIQUE_URL=$(echo "$RESPONSE" | jq -r '.deployments[0].url')
-              echo "::error::Branch alias never assigned after 45s. Full alias array: $(echo "$DETAILS" | jq -c '.alias')"
-              echo "::warning::Falling back to unique URL: https://${UNIQUE_URL}"
-              echo "url=https://${UNIQUE_URL}" >> "$GITHUB_OUTPUT"
+              URL=$(curl -s -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+                "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_TEAM_ID}" \
+                | jq -r '[.alias[]? | select(contains("-git-"))][0] // .url')
+              echo "url=https://${URL}" >> "$GITHUB_OUTPUT"
+              echo "Deployment ready: https://${URL}"
               exit 0
             fi
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   defaultCommandTimeout: 10000,
   requestTimeout: 10000,
   responseTimeout: 10000,
+  retries: { runMode: 2, openMode: 0 },
   env: process.env, // Uses project environment variables set in .env
   e2e: {
     setupNodeEvents(on, config) {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -8,10 +8,9 @@ const customCommands = require('./commands.js');
 const firewallBypass = Cypress.env('CI_FIREWALL_BYPASS');
 if (firewallBypass) {
   // Cookie covers navigation and asset requests (cookies are auto-sent by the browser).
-  Cypress.Commands.overwrite('visit', (originalFn, ...args) => {
-    cy.setCookie('ci-firewall-bypass', firewallBypass);
-    return originalFn(...args);
-  });
+  Cypress.Commands.overwrite('visit', (originalFn, ...args) =>
+    cy.setCookie('ci-firewall-bypass', firewallBypass).then(() => originalFn(...args)),
+  );
 
   // Header covers cy.request (cookies from cy.setCookie aren't always sent with it).
   Cypress.Commands.overwrite('request', (originalFn, ...args) => {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -2,6 +2,38 @@
 import '@cypress/code-coverage/support';
 const customCommands = require('./commands.js');
 
+// Bypass Vercel Firewall Attack Challenge Mode for CI.
+// The firewall blocks automated requests with 429 challenges; an allow rule
+// matching this cookie/header short-circuits the challenge for CI traffic only.
+const firewallBypass = Cypress.env('CI_FIREWALL_BYPASS');
+if (firewallBypass) {
+  // Cookie covers navigation and asset requests (cookies are auto-sent by the browser).
+  Cypress.Commands.overwrite('visit', (originalFn, ...args) => {
+    cy.setCookie('ci-firewall-bypass', firewallBypass);
+    return originalFn(...args);
+  });
+
+  // Header covers cy.request (cookies from cy.setCookie aren't always sent with it).
+  Cypress.Commands.overwrite('request', (originalFn, ...args) => {
+    let options;
+    if (typeof args[0] === 'object') {
+      options = { ...args[0] };
+    } else if (typeof args[0] === 'string' && typeof args[1] === 'string') {
+      options = { method: args[0], url: args[1], body: args[2] };
+    } else {
+      options = { url: args[0], body: args[1] };
+    }
+    options.headers = { ...options.headers, 'x-ci-firewall-bypass': firewallBypass };
+    return originalFn(options);
+  });
+
+  // Re-set the cookie before each test — cleanUpTestState calls cy.clearAllCookies
+  // in its before() hook, which removes the cookie set by the first cy.visit.
+  beforeEach(() => {
+    cy.setCookie('ci-firewall-bypass', firewallBypass);
+  });
+}
+
 module.exports = {
   commands: customCommands,
 };

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -2,41 +2,6 @@
 import '@cypress/code-coverage/support';
 const customCommands = require('./commands.js');
 
-// Bypass Vercel Deployment Protection for automated tests.
-// 1. cy.visit: appends bypass query params so the first navigation isn't blocked,
-//    and x-vercel-set-bypass-cookie tells Vercel to set a session cookie.
-// 2. cy.request: adds the bypass header for direct HTTP requests (e.g. sitemap).
-// 3. beforeEach: re-sets the bypass cookie in case cy.clearAllCookies() removed it.
-const bypassSecret = Cypress.env('VERCEL_BYPASS_SECRET');
-if (bypassSecret) {
-  Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
-    const baseUrl = Cypress.config('baseUrl') || '';
-    const fullUrl = new URL(url, baseUrl);
-    fullUrl.searchParams.set('x-vercel-protection-bypass', bypassSecret);
-    fullUrl.searchParams.set('x-vercel-set-bypass-cookie', 'samesitenone');
-    return originalFn(fullUrl.toString(), options);
-  });
-
-  Cypress.Commands.overwrite('request', (originalFn, ...args) => {
-    let options = typeof args[0] === 'object' ? { ...args[0] } : {};
-    if (typeof args[0] === 'string' && typeof args[1] === 'string') {
-      options = { method: args[0], url: args[1], body: args[2] };
-    } else if (typeof args[0] === 'string') {
-      options = { url: args[0], body: args[1] };
-    }
-    options.headers = { ...options.headers, 'x-vercel-protection-bypass': bypassSecret };
-    return originalFn(options);
-  });
-
-  beforeEach(() => {
-    // Re-establish the Vercel bypass cookie before each test, in case
-    // cy.clearAllCookies() removed it (e.g. in cleanUpTestState).
-    // The cy.visit override adds the bypass query params automatically,
-    // which tells Vercel to set the _vercel_jwt session cookie.
-    cy.visit('/', { failOnStatusCode: false });
-  });
-}
-
 module.exports = {
   commands: customCommands,
 };

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Related to #1782 removes `CYPRESS_VERCEL_BYPASS_SECRET` as this is not being used

Also updates cypress CI action to run on all branch pushes now that tests are much faster in parallel