### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cypress-release-test.yml
+++ b/.github/workflows/cypress-release-test.yml
@@ -165,6 +165,8 @@ jobs:
     name: Check for ungrouped tests
     needs: wait-for-vercel-deployment
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/chaynHQ/bloom-frontend/security/code-scanning/40](https://github.com/chaynHQ/bloom-frontend/security/code-scanning/40)

Add an explicit `permissions` block for the `check-ungrouped` job so its `GITHUB_TOKEN` is scoped to the minimum required privileges.  
Best fix without changing behavior: define `permissions: contents: read` directly under `runs-on` for `check-ungrouped`, mirroring CodeQL’s minimal baseline. This job checks out code and runs tests; no write scopes are clearly required in the shown snippet.

Change region:
- File: `.github/workflows/cypress-release-test.yml`
- Job: `check-ungrouped` (around lines 165–168 in the provided snippet)
- Add:
  - `permissions:`
  - `contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
