### PR TITLE
Enable user research banner

### DIFF
--- a/components/banner/UserResearchBanner.tsx
+++ b/components/banner/UserResearchBanner.tsx
@@ -2,7 +2,6 @@
 
 import { USER_BANNER_DISMISSED, USER_BANNER_INTERESTED } from '@/lib/constants/events';
 import { FeatureFlag } from '@/lib/featureFlag';
-import { useTypedSelector } from '@/lib/hooks/store';
 import logEvent from '@/lib/utils/logEvent';
 import { Alert, AlertTitle, Button, Collapse, Stack } from '@mui/material';
 import Cookies from 'js-cookie';
@@ -26,8 +25,6 @@ export default function UserResearchBanner() {
   const [open, setOpen] = useState(true);
   const locale = useLocale();
 
-  const userCookiesAccepted = useTypedSelector((state) => state.user.cookiesAccepted);
-
   const isBannerNotInteracted = !Boolean(Cookies.get(USER_RESEARCH_BANNER_INTERACTED));
   const isBannerFeatureEnabled = FeatureFlag.isUserResearchBannerEnabled();
   const isEnglish = locale === 'en';
@@ -35,7 +32,7 @@ export default function UserResearchBanner() {
   const showBanner = isBannerFeatureEnabled && isEnglish && isBannerNotInteracted;
 
   const handleClickAccepted = () => {
-    if (userCookiesAccepted) Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
+    Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
     logEvent(USER_BANNER_INTERESTED);
     setOpen(false);
 
@@ -43,7 +40,7 @@ export default function UserResearchBanner() {
   };
 
   const handleClickDeclined = () => {
-    if (userCookiesAccepted) Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
+    Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
     logEvent(USER_BANNER_DISMISSED);
     setOpen(false);
   };

--- a/components/banner/UserResearchBanner.tsx
+++ b/components/banner/UserResearchBanner.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { usePathname } from '@/i18n/routing';
 import { USER_BANNER_DISMISSED, USER_BANNER_INTERESTED } from '@/lib/constants/events';
 import { FeatureFlag } from '@/lib/featureFlag';
 import { useTypedSelector } from '@/lib/hooks/store';
 import logEvent from '@/lib/utils/logEvent';
 import { Alert, AlertTitle, Button, Collapse, Stack } from '@mui/material';
 import Cookies from 'js-cookie';
+import { useLocale } from 'next-intl';
 import { useState } from 'react';
 
 const alertStyle = {
@@ -24,21 +24,15 @@ const USER_RESEARCH_FORM_LINK =
 
 export default function UserResearchBanner() {
   const [open, setOpen] = useState(true);
-  const pathname = usePathname();
+  const locale = useLocale();
 
   const userCookiesAccepted = useTypedSelector((state) => state.user.cookiesAccepted);
-  const partnerAccesses = useTypedSelector((state) => state.partnerAccesses);
 
   const isBannerNotInteracted = !Boolean(Cookies.get(USER_RESEARCH_BANNER_INTERACTED));
   const isBannerFeatureEnabled = FeatureFlag.isUserResearchBannerEnabled();
-  // const isPublicUser = partnerAccesses.length === 0 && !partnerAdmin.id;
-  const isBadooUser = partnerAccesses.find((pa) => {
-    return pa.partner.name.toLowerCase() === 'badoo';
-  });
+  const isEnglish = locale === 'en';
 
-  const isTargetPage = !(pathname.includes('auth') || pathname.includes('partnerName'));
-
-  const showBanner = isBannerFeatureEnabled && isBadooUser && isTargetPage && isBannerNotInteracted;
+  const showBanner = isBannerFeatureEnabled && isEnglish && isBannerNotInteracted;
 
   const handleClickAccepted = () => {
     if (userCookiesAccepted) Cookies.set(USER_RESEARCH_BANNER_INTERACTED, 'true');
@@ -55,7 +49,17 @@ export default function UserResearchBanner() {
   };
 
   return showBanner ? (
-    <Stack sx={{ width: '100%' }} spacing={2}>
+    <Stack
+      sx={{
+        width: '100%',
+        flexBasis: '100%',
+        position: 'relative',
+        zIndex: 1,
+        marginTop: -2,
+        marginBottom: 4,
+      }}
+      spacing={2}
+    >
       <Collapse in={open}>
         <Alert
           icon={false}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -12,6 +12,7 @@ import { Box, Container, IconButton, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Image, { StaticImageData } from 'next/image';
 import { render, StoryblokRichtext } from 'storyblok-rich-text-react-renderer';
+import UserResearchBanner from '../banner/UserResearchBanner';
 
 export interface HeaderProps {
   title: string;
@@ -96,6 +97,7 @@ const Header = (props: HeaderProps) => {
 
   return (
     <Container sx={headerContainerStyle}>
+      <UserResearchBanner />
       {!children && (
         <IconButton
           sx={backButtonStyle}

--- a/components/layout/HomeHeader.tsx
+++ b/components/layout/HomeHeader.tsx
@@ -11,6 +11,7 @@ import { useTranslations } from 'next-intl';
 import Image, { StaticImageData } from 'next/image';
 import * as React from 'react';
 import { render } from 'storyblok-rich-text-react-renderer';
+import UserResearchBanner from '../banner/UserResearchBanner';
 
 interface HeaderProps {
   title:
@@ -73,6 +74,7 @@ const Header = (props: HeaderProps) => {
 
   return (
     <Container sx={headerContainerStyles}>
+      <UserResearchBanner />
       <Box sx={textContainerStyle}>
         <Box sx={textContentStyle}>
           <Typography variant="h1" component="h1" mb={3}>

--- a/components/pages/LoginPage.tsx
+++ b/components/pages/LoginPage.tsx
@@ -2,6 +2,7 @@
 
 import LoginForm from '@/components/forms/LoginForm';
 import { useRouter } from '@/i18n/routing';
+import { getImageSizes } from '@/lib/utils/imageSizes';
 import illustrationLeafMix from '@/public/illustration_leaf_mix.svg';
 import theme from '@/styles/theme';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
@@ -9,8 +10,6 @@ import { Box, Card, CardContent, IconButton, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import Head from 'next/head';
 import Image from 'next/image';
-import { getImageSizes } from '@/lib/utils/imageSizes';
-import UserResearchBanner from '../banner/UserResearchBanner';
 
 const imageContainerStyle = {
   position: 'relative',
@@ -73,7 +72,6 @@ export default function LoginPage() {
         <title>{`${t('login.title')} • Bloom`}</title>
       </Head>
       <Box sx={headerContainerStyle}>
-        <UserResearchBanner />
         <IconButton
           sx={backButtonStyle}
           onClick={() => router.back()}


### PR DESCRIPTION
### What changes did you make and why did you make them?
Enabled the UserResearchBanner to display for all English-locale users on all main content pages.

### Changes made:

Moved UserResearchBanner into Header.tsx and HomeHeader.tsx (the page title header components) so it appears consistently within the page header section across all content pages
Replaced partner/page-specific targeting logic with a simple English locale check (useLocale() === 'en'), showing the banner to all users rather than a subset
Removed the if (userCookiesAccepted) guard on Cookies.set so that dismissing the banner persists across page refreshes regardless of cookie consent status — consistent with how other banners (e.g. FruitzRetirementBanner) behave
Cleaned up unused variables and imports (isBadooUser, isTargetPage, useTypedSelector, usePathname)


