### PR TITLE
Front multiple attachments

### DIFF
--- a/components/messaging/MessageBubble.tsx
+++ b/components/messaging/MessageBubble.tsx
@@ -9,7 +9,7 @@ import { getDateLocale } from '@/lib/utils/dates';
 import { format } from 'date-fns';
 import { useLocale, useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
-import { ChatMessage } from './types';
+import { ChatMessage, MessageAttachment } from './types';
 
 const imagePreviewStyle = {
   display: 'block',
@@ -58,6 +58,20 @@ const filenameRowStyle = {
   display: 'flex',
   alignItems: 'center',
   gap: 0.5,
+} as const;
+
+// Multi-attachment messages stack their attachments vertically inside the bubble
+// — gives each file a clear hit area without ballooning bubble width.
+const attachmentsStackStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 0.75,
+} as const;
+
+const voiceRowStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 0.25,
 } as const;
 
 const useBlobUrl = (src: string) => {
@@ -163,6 +177,64 @@ const AudioAttachment = ({ src, unavailableLabel }: { src: string; unavailableLa
   );
 };
 
+interface AttachmentProps {
+  attachment: MessageAttachment;
+  audioUnavailableLabel: string;
+  voiceFallbackLabel: string;
+}
+
+const AttachmentItem = ({
+  attachment,
+  audioUnavailableLabel,
+  voiceFallbackLabel,
+}: AttachmentProps) => {
+  const { kind, name, url, previewUrl } = attachment;
+
+  if (kind === 'image') {
+    return (
+      <Box>
+        {previewUrl ? (
+          <Box component="img" src={previewUrl} alt={name ?? ''} sx={imagePreviewStyle} />
+        ) : url ? (
+          <ImageAttachment src={url} alt={name ?? ''} />
+        ) : null}
+        {name && (
+          <Box sx={filenameRowStyle}>
+            <ImageIcon sx={{ fontSize: 14, flexShrink: 0, opacity: 0.7 }} aria-hidden="true" />
+            <Typography variant="caption" sx={{ opacity: 0.8, wordBreak: 'break-all' }}>
+              {name}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    );
+  }
+
+  if (kind === 'voice') {
+    return (
+      <Box sx={voiceRowStyle}>
+        <Box sx={filenameRowStyle}>
+          <MicIcon sx={{ fontSize: 15, flexShrink: 0 }} aria-hidden="true" />
+          <Typography variant="body2">{name ?? voiceFallbackLabel}</Typography>
+        </Box>
+        {previewUrl ? (
+          <Box sx={{ mt: 0.5 }}>
+            <audio
+              src={previewUrl}
+              controls
+              style={{ height: 32, maxWidth: 220, display: 'block' }}
+            />
+          </Box>
+        ) : url ? (
+          <AudioAttachment src={url} unavailableLabel={audioUnavailableLabel} />
+        ) : null}
+      </Box>
+    );
+  }
+
+  return url ? <FileAttachment src={url} filename={name ?? 'attachment'} /> : null;
+};
+
 interface Props {
   message: ChatMessage;
   failedLabel: string;
@@ -173,6 +245,14 @@ export const MessageBubble = ({ message, failedLabel, sendingLabel }: Props) => 
   const t = useTranslations('Messaging.frontChat');
   const locale = useLocale();
   const isUser = message.direction === 'user';
+  const attachments = message.attachments ?? [];
+  // Hide body text when it's only there to label a single attachment (the attachment
+  // renders its own filename caption already). Multi-attachment bubbles always show
+  // the body so a real message above several files isn't dropped.
+  const singleAttachment = attachments.length === 1 ? attachments[0] : undefined;
+  const textDuplicatesAttachment =
+    !!singleAttachment && !!message.text && message.text === singleAttachment.name;
+  const showText = !!message.text && !textDuplicatesAttachment;
 
   return (
     <Box sx={isUser ? userBubbleStyle : agentBubbleStyle}>
@@ -185,50 +265,19 @@ export const MessageBubble = ({ message, failedLabel, sendingLabel }: Props) => 
         </Typography>
       )}
 
-      {message.kind === 'image' ? (
-        <>
-          {message.previewUrl ? (
-            <Box
-              component="img"
-              src={message.previewUrl}
-              alt={message.text ?? ''}
-              sx={imagePreviewStyle}
+      {showText && <Typography variant="body2">{message.text}</Typography>}
+
+      {attachments.length > 0 && (
+        <Box sx={{ ...attachmentsStackStyle, mt: showText ? 0.75 : 0 }}>
+          {attachments.map((attachment, i) => (
+            <AttachmentItem
+              key={attachment.url ?? attachment.previewUrl ?? i}
+              attachment={attachment}
+              audioUnavailableLabel={t('audioUnavailable')}
+              voiceFallbackLabel={t('voiceNote')}
             />
-          ) : message.attachmentUrl ? (
-            <ImageAttachment src={message.attachmentUrl} alt={message.text ?? ''} />
-          ) : null}
-          <Box sx={filenameRowStyle}>
-            <ImageIcon sx={{ fontSize: 14, flexShrink: 0, opacity: 0.7 }} aria-hidden="true" />
-            <Typography variant="caption" sx={{ opacity: 0.8, wordBreak: 'break-all' }}>
-              {message.text}
-            </Typography>
-          </Box>
-        </>
-      ) : message.kind === 'voice' ? (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
-          <Box sx={filenameRowStyle}>
-            <MicIcon sx={{ fontSize: 15, flexShrink: 0 }} aria-hidden="true" />
-            <Typography variant="body2">{message.text}</Typography>
-          </Box>
-          {message.previewUrl ? (
-            <Box sx={{ mt: 0.5 }}>
-              <audio
-                src={message.previewUrl}
-                controls
-                style={{ height: 32, maxWidth: 220, display: 'block' }}
-              />
-            </Box>
-          ) : message.attachmentUrl ? (
-            <AudioAttachment src={message.attachmentUrl} unavailableLabel={t('audioUnavailable')} />
-          ) : null}
+          ))}
         </Box>
-      ) : message.kind === 'file' && message.attachmentUrl ? (
-        <FileAttachment
-          src={message.attachmentUrl}
-          filename={message.attachmentName ?? message.text ?? 'attachment'}
-        />
-      ) : (
-        <Typography variant="body2">{message.text}</Typography>
       )}
 
       <Box sx={metaRowStyle}>

--- a/components/messaging/types.ts
+++ b/components/messaging/types.ts
@@ -2,24 +2,36 @@ export type MessageDirection = 'user' | 'agent';
 
 export type MessageStatus = 'sending' | 'sent' | 'failed';
 
-export type MessageKind = 'text' | 'image' | 'voice' | 'file';
+export type AttachmentKind = 'image' | 'voice' | 'file';
 
 export type ConnectionState = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error';
+
+export interface MessageAttachment {
+  kind: AttachmentKind;
+  /** Backend proxy URL — present for historical/agent attachments loaded from Front */
+  url?: string;
+  /** Original filename — used to label download links and image captions */
+  name?: string;
+  /** Object URL for a local preview — only populated on outgoing optimistic messages before page reload */
+  previewUrl?: string;
+}
 
 export interface ChatMessage {
   id: string;
   direction: MessageDirection;
-  kind: MessageKind;
   text?: string;
   authorName?: string;
   createdAt: number;
   status: MessageStatus;
-  /** Object URL for local image preview — only populated on outgoing image messages before page reload */
-  previewUrl?: string;
-  /** Backend proxy URL for historical image/audio/file messages loaded from Front */
-  attachmentUrl?: string;
-  /** Original filename — used to label the download link for `file` kind */
-  attachmentName?: string;
+  /** Files Front delivered with the message, in original order — agents can attach several at once */
+  attachments?: MessageAttachment[];
+}
+
+/** Shape received over the `agent_reply` socket event and inside a `history` entry — relative URLs that the client prefixes with API_URL. */
+export interface AttachmentPayload {
+  url: string;
+  name?: string;
+  kind: AttachmentKind;
 }
 
 export interface AgentReplyPayload {
@@ -29,21 +41,15 @@ export interface AgentReplyPayload {
   authorName?: string;
   /** Unix timestamp in seconds (multiply by 1000 to get ms) */
   emittedAt: number;
-  /** Relative proxy path — prefix with API_URL before use */
-  attachmentUrl?: string;
-  /** Original filename — used to label the download link for `file` kind */
-  attachmentName?: string;
-  kind?: 'image' | 'voice' | 'file';
+  attachments?: AttachmentPayload[];
 }
 
 /** Raw message shape returned by the /front-chat/messages history endpoint */
 export interface HistoryEntry {
   id: string;
   direction: 'user' | 'agent';
-  kind?: 'image' | 'voice' | 'file';
   text: string;
-  attachmentUrl?: string;
-  attachmentName?: string;
+  attachments?: AttachmentPayload[];
   authorName?: string;
   createdAt: number;
 }

--- a/lib/hooks/useMessaging.ts
+++ b/lib/hooks/useMessaging.ts
@@ -2,9 +2,11 @@
 
 import {
   AgentReplyPayload,
+  AttachmentPayload,
   ChatMessage,
   ConnectionState,
   HistoryEntry,
+  MessageAttachment,
 } from '@/components/messaging/types';
 import { getAuthToken } from '@/lib/auth';
 import { CHAT_MESSAGE_RECEIVED, CHAT_MESSAGE_SENT } from '@/lib/constants/events';
@@ -106,13 +108,28 @@ export function useMessaging(): UseMessagingResult {
   useEffect(() => {
     const prev = prevMessagesRef.current;
     prevMessagesRef.current = messages;
+    const liveUrls = new Set<string>();
+    for (const m of messages) {
+      m.attachments?.forEach((a) => a.previewUrl && liveUrls.add(a.previewUrl));
+    }
     for (const m of prev) {
-      if (!m.previewUrl) continue;
-      if (!messages.some((c) => c.previewUrl === m.previewUrl)) {
-        URL.revokeObjectURL(m.previewUrl);
-      }
+      m.attachments?.forEach((a) => {
+        if (a.previewUrl && !liveUrls.has(a.previewUrl)) URL.revokeObjectURL(a.previewUrl);
+      });
     }
   }, [messages]);
+
+  const toMessageAttachments = useCallback(
+    (payloads: AttachmentPayload[] | undefined): MessageAttachment[] | undefined => {
+      if (!payloads?.length) return undefined;
+      return payloads.map(({ url, name, kind }) => ({
+        kind,
+        url: `${API_URL}${url}`,
+        name,
+      }));
+    },
+    [],
+  );
 
   const upsertMessage = useCallback((message: ChatMessage) => {
     setMessages((prev) => {
@@ -124,46 +141,48 @@ export function useMessaging(): UseMessagingResult {
     });
   }, []);
 
-  const mergeHistoryEntries = useCallback((entries: HistoryEntry[]) => {
-    setMessages((prev) => {
-      const knownIds = new Set(prev.map((m) => m.id));
-      const next: ChatMessage[] = prev.slice();
+  const mergeHistoryEntries = useCallback(
+    (entries: HistoryEntry[]) => {
+      setMessages((prev) => {
+        const knownIds = new Set(prev.map((m) => m.id));
+        const next: ChatMessage[] = prev.slice();
 
-      for (const serverMsg of entries) {
-        if (knownIds.has(serverMsg.id)) continue;
+        for (const serverMsg of entries) {
+          if (knownIds.has(serverMsg.id)) continue;
 
-        const optimisticIdx = next.findIndex(
-          (local) =>
-            local.direction === serverMsg.direction &&
-            local.text === serverMsg.text &&
-            Math.abs(local.createdAt - serverMsg.createdAt) < OPTIMISTIC_RECONCILE_MS &&
-            !local.id.startsWith('msg_'),
-        );
+          const optimisticIdx = next.findIndex(
+            (local) =>
+              local.direction === serverMsg.direction &&
+              local.text === serverMsg.text &&
+              Math.abs(local.createdAt - serverMsg.createdAt) < OPTIMISTIC_RECONCILE_MS &&
+              !local.id.startsWith('msg_'),
+          );
 
-        const seeded: ChatMessage = {
-          id: serverMsg.id,
-          direction: serverMsg.direction,
-          kind: serverMsg.kind ?? 'text',
-          text: serverMsg.text,
-          authorName: serverMsg.authorName,
-          createdAt: serverMsg.createdAt,
-          status: 'sent',
-          ...(serverMsg.attachmentUrl && { attachmentUrl: `${API_URL}${serverMsg.attachmentUrl}` }),
-          ...(serverMsg.attachmentName && { attachmentName: serverMsg.attachmentName }),
-        };
+          const attachments = toMessageAttachments(serverMsg.attachments);
+          const seeded: ChatMessage = {
+            id: serverMsg.id,
+            direction: serverMsg.direction,
+            text: serverMsg.text,
+            authorName: serverMsg.authorName,
+            createdAt: serverMsg.createdAt,
+            status: 'sent',
+            ...(attachments && { attachments }),
+          };
 
-        if (optimisticIdx >= 0) {
-          next[optimisticIdx] = seeded;
-        } else {
-          next.push(seeded);
+          if (optimisticIdx >= 0) {
+            next[optimisticIdx] = seeded;
+          } else {
+            next.push(seeded);
+          }
+          knownIds.add(serverMsg.id);
+          if (serverMsg.direction === 'agent') seenAgentIdsRef.current.add(serverMsg.id);
         }
-        knownIds.add(serverMsg.id);
-        if (serverMsg.direction === 'agent') seenAgentIdsRef.current.add(serverMsg.id);
-      }
 
-      return next.sort((a, b) => a.createdAt - b.createdAt);
-    });
-  }, []);
+        return next.sort((a, b) => a.createdAt - b.createdAt);
+      });
+    },
+    [toMessageAttachments],
+  );
 
   const markAsRead = useCallback(async () => {
     const { token, error } = await getAuthToken();
@@ -188,7 +207,6 @@ export function useMessaging(): UseMessagingResult {
       const optimistic: ChatMessage = {
         id,
         direction: 'user',
-        kind: 'text',
         text: trimmed,
         createdAt: Date.now(),
         status: 'sending',
@@ -220,16 +238,14 @@ export function useMessaging(): UseMessagingResult {
       // Optimistic preview for both images and voice notes — the bubble renders this
       // immediately so the sender sees their own attachment without waiting for the
       // server's authenticated proxy URL on the next history refresh.
-      const previewUrl =
-        kind === 'image' || kind === 'voice' ? URL.createObjectURL(file) : undefined;
+      const name = file instanceof File ? file.name : undefined;
       const optimistic: ChatMessage = {
         id,
         direction: 'user',
-        kind,
-        text: file instanceof File ? file.name : displayText,
-        previewUrl,
+        text: name ?? displayText,
         createdAt: Date.now(),
         status: 'sending',
+        attachments: [{ kind, name, previewUrl: URL.createObjectURL(file) }],
       };
       upsertMessage(optimistic);
 
@@ -333,19 +349,19 @@ export function useMessaging(): UseMessagingResult {
         const id = payload.id ?? generateId();
         if (seenAgentIdsRef.current.has(id)) return;
         seenAgentIdsRef.current.add(id);
+        const attachments = toMessageAttachments(payload.attachments);
         upsertMessage({
           id,
           direction: 'agent',
-          kind: payload.kind ?? 'text',
           text: payload.body,
           authorName: payload.authorName,
           // Backend sends seconds (matching Front's emitted_at convention); multiply to get ms.
           createdAt: payload.emittedAt ? payload.emittedAt * 1000 : Date.now(),
           status: 'sent',
-          ...(payload.attachmentUrl && { attachmentUrl: `${API_URL}${payload.attachmentUrl}` }),
-          ...(payload.attachmentName && { attachmentName: payload.attachmentName }),
+          ...(attachments && { attachments }),
         });
-        logEvent(CHAT_MESSAGE_RECEIVED, { kind: payload.kind ?? 'text' });
+        // Analytics: capture the first attachment kind for parity with the previous schema.
+        logEvent(CHAT_MESSAGE_RECEIVED, { kind: attachments?.[0].kind ?? 'text' });
         if (markAsReadTimerRef.current) clearTimeout(markAsReadTimerRef.current);
         markAsReadTimerRef.current = setTimeout(() => markAsRead(), 500);
       });
@@ -356,7 +372,7 @@ export function useMessaging(): UseMessagingResult {
         tearDown();
         setMessages((prev) => {
           prev.forEach((m) => {
-            if (m.previewUrl) URL.revokeObjectURL(m.previewUrl);
+            m.attachments?.forEach((a) => a.previewUrl && URL.revokeObjectURL(a.previewUrl));
           });
           return [];
         });
@@ -371,7 +387,7 @@ export function useMessaging(): UseMessagingResult {
       unsubscribe();
       tearDown();
     };
-  }, [rollbar, upsertMessage, mergeHistoryEntries, markAsRead]);
+  }, [rollbar, upsertMessage, mergeHistoryEntries, markAsRead, toMessageAttachments]);
 
   return { messages, connectionState, sendText, sendAttachment };
 }


### PR DESCRIPTION
Adds support for agents sending multiple attachments in the front widget. Previously if 2 attachments were sent, only the first would be shown in the widget