### PR TITLE
UTM partner support

### DIFF
--- a/components/layout/BaseLayout.tsx
+++ b/components/layout/BaseLayout.tsx
@@ -3,6 +3,7 @@ import CookieBanner from '@/components/layout/CookieBanner';
 import Footer from '@/components/layout/Footer';
 import LeaveSiteButton from '@/components/layout/LeaveSiteButton';
 import MobileBottomNav, { mobileBottomNavHeight } from '@/components/layout/MobileBottomNav';
+import ReferralPartnerTracker from '@/components/layout/ReferralPartnerTracker';
 import TopBar from '@/components/layout/TopBar';
 import { ReduxProvider } from '@/components/providers/ReduxProvider';
 import StoryblokProvider from '@/components/providers/StoryblokProvider';
@@ -92,6 +93,7 @@ export default async function BaseLayout({ children, locale }: BaseLayoutProps) 
                       to bind the event listener in time.
                     */}
                     <script src="/deffer-pwa.js" async></script>
+                    <ReferralPartnerTracker />
                     <TopBar />
                     <LeaveSiteButton />
                     <DesktopPwaBanner />

--- a/components/layout/ReferralPartnerTracker.tsx
+++ b/components/layout/ReferralPartnerTracker.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import useReferralPartner from '@/lib/hooks/useReferralPartner';
+
+// Runs the referral-partner detection app-wide so partner UTM links work on any
+// landing page (homepage, courses, etc.), not just welcome/register pages.
+// Renders nothing — it only stores the referring partner on entry.
+export default function ReferralPartnerTracker() {
+  useReferralPartner();
+  return null;
+}

--- a/components/pages/RegisterPage.tsx
+++ b/components/pages/RegisterPage.tsx
@@ -84,10 +84,14 @@ export default function RegisterPage() {
   const code = searchParams.get('code');
   const partner = searchParams.get('partner');
 
-  // Derive partner content and code param from URL and state
+  // Derive partner content and code param from URL and state.
+  // Prefer an explicit ?partner query, else fall back to a referral captured on entry
+  // (welcome link or partner UTM link) so the partner is still attached when signing up
+  // directly via /auth/register without a partner query.
   const { partnerContent, codeParam, allPartnersContent } = useMemo(() => {
-    if (partner) {
-      const partnerContentResult = getPartnerContent(partner + '');
+    const partnerName = partner || entryPartnerReferral;
+    if (partnerName) {
+      const partnerContentResult = getPartnerContent(partnerName + '');
       if (partnerContentResult) {
         // If code is in URL, use it; otherwise check if we have entry code for this partner
         const effectiveCode = code

--- a/cypress/integration/partners/register-partner-without-code.cy.tsx
+++ b/cypress/integration/partners/register-partner-without-code.cy.tsx
@@ -23,6 +23,29 @@ describe('Register without access code', () => {
     cy.get('h3').contains('What are boundaries').click();
   });
 
+  it('Partner in UTM link attaches partner and shows partner register form', () => {
+    cy.cleanUpTestState();
+    const utmUsername = `cypresstestemail+${Date.now()}@chayn.co`;
+
+    // Entry via a partner UTM link (e.g. a Bumble campaign) should attribute the
+    // referral, so registering shows the Bumble form (no access code) and attaches the partner.
+    cy.visit('/auth/register?utm_source=bumble');
+    cy.wait(2000); // waiting for referral detection + dom to rerender
+    cy.get('h2', { timeout: 8000 }).should('contain', 'Create account');
+    cy.get('#partnerAccessCode').should('not.exist');
+    cy.get('#name').type('Cypress test');
+    cy.get('#email').type(utmUsername);
+    cy.get('#password').type('testpassword');
+    cy.get('button[type="submit"]').contains('Create account').click();
+    cy.wait(4000); // Waiting for dom to rerender
+    cy.get('h2', { timeout: 8000 }).should('contain', 'Help us understand');
+    cy.get('a').contains('Skip').click();
+    cy.wait(2000); // Waiting for dom to rerender
+    // Bumble partner content is available, confirming the partner was attached at signup
+    cy.get('h3').contains('Dating, boundaries, and relationships').click();
+    cy.get('h3').contains('What are boundaries').click();
+  });
+
   after(() => {
     cy.logout();
   });

--- a/lib/constants/partners.ts
+++ b/lib/constants/partners.ts
@@ -89,6 +89,10 @@ const fruitzContent: PartnerContent = {
   tiktok: 'https://www.tiktok.com/@fruitz_app',
 };
 
+// Lowercase keys for all real (non-public) partners. Used to detect a partner
+// name within incoming UTM data so a referral can be attributed dynamically.
+export const partnerKeys = ['bumble', 'badoo'];
+
 export const getPartnerContent = (partnerName: string) => {
   const partner = partnerName.toLowerCase();
   if (partner === 'public') return publicContent;

--- a/lib/hooks/useReferralPartner.test.ts
+++ b/lib/hooks/useReferralPartner.test.ts
@@ -1,0 +1,87 @@
+import { expect } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import Cookies from 'js-cookie';
+import { usePathname } from '@/i18n/routing';
+import { useSearchParams } from 'next/navigation';
+import { setEntryPartnerReferral } from '../store/userSlice';
+import { useAppDispatch, useTypedSelector } from './store';
+import useReferralPartner from './useReferralPartner';
+
+// Mock partners constants to avoid pulling in SVG asset imports (the `@/` alias
+// resolves before the svg fileMock, so the real module fails to load under Jest).
+jest.mock('@/lib/constants/partners', () => ({
+  partnerKeys: ['bumble', 'badoo'],
+}));
+jest.mock('@/i18n/routing', () => ({
+  usePathname: jest.fn(),
+}));
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(),
+}));
+jest.mock('js-cookie');
+jest.mock('./store', () => ({
+  useTypedSelector: jest.fn(),
+  useAppDispatch: jest.fn(),
+}));
+jest.mock('../store/userSlice', () => ({
+  setEntryPartnerReferral: jest.fn((value) => ({ type: 'SET_ENTRY_PARTNER_REFERRAL', value })),
+  setEntryPartnerAccessCode: jest.fn((value) => ({ type: 'SET_ENTRY_PARTNER_ACCESS_CODE', value })),
+}));
+
+const makeSearchParams = (params: Record<string, string>) =>
+  ({ get: (key: string) => params[key] ?? null }) as unknown as ReturnType<typeof useSearchParams>;
+
+describe('useReferralPartner - UTM detection', () => {
+  let dispatchMock: jest.Mock;
+
+  beforeEach(() => {
+    dispatchMock = jest.fn();
+    (useAppDispatch as jest.MockedFunction<typeof useAppDispatch>).mockReturnValue(dispatchMock);
+    // cookiesAccepted true so the cookie is also set
+    (useTypedSelector as jest.MockedFunction<typeof useTypedSelector>).mockReturnValue(true);
+    (usePathname as jest.Mock).mockReturnValue('/');
+    Cookies.set = jest.fn();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('attributes the referral when a partner name is in utm_source', () => {
+    (useSearchParams as jest.Mock).mockReturnValue(makeSearchParams({ utm_source: 'bumble' }));
+
+    renderHook(() => useReferralPartner());
+
+    expect(setEntryPartnerReferral).toHaveBeenCalledWith('bumble');
+    expect(Cookies.set).toHaveBeenCalledWith('referralPartner', 'bumble');
+  });
+
+  it('detects a partner name embedded within a utm_campaign value', () => {
+    (useSearchParams as jest.Mock).mockReturnValue(
+      makeSearchParams({ utm_campaign: 'badoo-june-2026' }),
+    );
+
+    renderHook(() => useReferralPartner());
+
+    expect(setEntryPartnerReferral).toHaveBeenCalledWith('badoo');
+  });
+
+  it('ignores UTM data that does not contain a known partner', () => {
+    (useSearchParams as jest.Mock).mockReturnValue(
+      makeSearchParams({ utm_source: 'newsletter', utm_campaign: 'spring' }),
+    );
+
+    renderHook(() => useReferralPartner());
+
+    expect(setEntryPartnerReferral).not.toHaveBeenCalled();
+    expect(Cookies.set).not.toHaveBeenCalled();
+  });
+
+  it('prefers the welcome path partner over UTM data', () => {
+    (usePathname as jest.Mock).mockReturnValue('/welcome/bumble');
+    (useSearchParams as jest.Mock).mockReturnValue(makeSearchParams({ utm_source: 'badoo' }));
+
+    renderHook(() => useReferralPartner());
+
+    expect(setEntryPartnerReferral).toHaveBeenCalledWith('bumble');
+    expect(setEntryPartnerReferral).not.toHaveBeenCalledWith('badoo');
+  });
+});

--- a/lib/hooks/useReferralPartner.test.ts
+++ b/lib/hooks/useReferralPartner.test.ts
@@ -4,7 +4,7 @@ import Cookies from 'js-cookie';
 import { usePathname } from '@/i18n/routing';
 import { useSearchParams } from 'next/navigation';
 import { setEntryPartnerReferral } from '../store/userSlice';
-import { useAppDispatch, useTypedSelector } from './store';
+import { useAppDispatch } from './store';
 import useReferralPartner from './useReferralPartner';
 
 // Mock partners constants to avoid pulling in SVG asset imports (the `@/` alias
@@ -37,10 +37,9 @@ describe('useReferralPartner - UTM detection', () => {
   beforeEach(() => {
     dispatchMock = jest.fn();
     (useAppDispatch as jest.MockedFunction<typeof useAppDispatch>).mockReturnValue(dispatchMock);
-    // cookiesAccepted true so the cookie is also set
-    (useTypedSelector as jest.MockedFunction<typeof useTypedSelector>).mockReturnValue(true);
     (usePathname as jest.Mock).mockReturnValue('/');
     Cookies.set = jest.fn();
+    Cookies.get = jest.fn();
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -72,6 +71,26 @@ describe('useReferralPartner - UTM detection', () => {
     renderHook(() => useReferralPartner());
 
     expect(setEntryPartnerReferral).not.toHaveBeenCalled();
+    expect(Cookies.set).not.toHaveBeenCalled();
+  });
+
+  it('sets the referral cookie without requiring analytics consent', () => {
+    (useSearchParams as jest.Mock).mockReturnValue(makeSearchParams({ utm_source: 'bumble' }));
+
+    renderHook(() => useReferralPartner());
+
+    // No cookiesAccepted state is provided, yet the functional cookie is still written
+    expect(Cookies.set).toHaveBeenCalledWith('referralPartner', 'bumble');
+  });
+
+  it('rehydrates Redux from the cookie when no referral is in the URL (e.g. after a reload)', () => {
+    (useSearchParams as jest.Mock).mockReturnValue(makeSearchParams({}));
+    (Cookies.get as jest.Mock).mockReturnValue('bumble');
+
+    renderHook(() => useReferralPartner());
+
+    expect(setEntryPartnerReferral).toHaveBeenCalledWith('bumble');
+    // It rehydrates state but does not re-write the cookie when nothing new was detected
     expect(Cookies.set).not.toHaveBeenCalled();
   });
 

--- a/lib/hooks/useReferralPartner.ts
+++ b/lib/hooks/useReferralPartner.ts
@@ -4,7 +4,7 @@ import { setEntryPartnerAccessCode, setEntryPartnerReferral } from '@/lib/store/
 import Cookies from 'js-cookie';
 import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
-import { useAppDispatch, useTypedSelector } from './store';
+import { useAppDispatch } from './store';
 
 // Check if entry path is from a partner referral and if so, store referring partner and code in state and local storage
 // This enables us to redirect a user to the correct sign up page later (e.g. in SignUpBanner)
@@ -13,14 +13,15 @@ export default function useReferralPartner() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const dispatch = useAppDispatch();
-  const userCookiesAccepted =
-    useTypedSelector((state) => state.user.cookiesAccepted) ||
-    Cookies.get('analyticsConsent') === 'true';
 
   useEffect(() => {
-    async function setReferralPartner(referralPartner: string) {
-      if (userCookiesAccepted) Cookies.set('referralPartner', referralPartner);
-      await dispatch(setEntryPartnerReferral(referralPartner));
+    function setReferralPartner(referralPartner: string) {
+      // Essential/functional cookie (not analytics): remembers the referring partner for the
+      // current visit so the partner experience is shown and the partner is linked at sign up.
+      // Session-scoped (no expiry → cleared when the browser closes), so it is set without
+      // analytics consent, consistent with the Essential Cookies in our cookie policy.
+      Cookies.set('referralPartner', referralPartner);
+      dispatch(setEntryPartnerReferral(referralPartner));
     }
     async function setReferralCode(referralCode: string) {
       await dispatch(setEntryPartnerAccessCode(referralCode));
@@ -66,7 +67,14 @@ export default function useReferralPartner() {
       }
     }
 
-    if (referralPartner) setReferralPartner(referralPartner);
+    if (referralPartner) {
+      setReferralPartner(referralPartner);
+    } else {
+      // No referral in the URL — rehydrate Redux from the cookie so the partner survives full
+      // page loads (Redux resets on reload, but the session cookie persists for the visit).
+      const cookieReferralPartner = Cookies.get('referralPartner');
+      if (cookieReferralPartner) dispatch(setEntryPartnerReferral(cookieReferralPartner));
+    }
     if (referralCode) setReferralCode(referralCode);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/lib/hooks/useReferralPartner.ts
+++ b/lib/hooks/useReferralPartner.ts
@@ -1,13 +1,17 @@
 import { usePathname } from '@/i18n/routing';
+import { partnerKeys } from '@/lib/constants/partners';
 import { setEntryPartnerAccessCode, setEntryPartnerReferral } from '@/lib/store/userSlice';
 import Cookies from 'js-cookie';
+import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import { useAppDispatch, useTypedSelector } from './store';
 
 // Check if entry path is from a partner referral and if so, store referring partner and code in state and local storage
 // This enables us to redirect a user to the correct sign up page later (e.g. in SignUpBanner)
+// Referrals are detected from welcome/register paths and from a partner name in UTM link data.
 export default function useReferralPartner() {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const dispatch = useAppDispatch();
   const userCookiesAccepted =
     useTypedSelector((state) => state.user.cookiesAccepted) ||
@@ -48,6 +52,20 @@ export default function useReferralPartner() {
         }
       }
     }
+    // Partners include their name in UTM link data (e.g. ?utm_source=bumble or
+    // ?utm_campaign=bumble-june-2026)
+    if (!referralPartner && searchParams) {
+      const utmData = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term']
+        .map((key) => searchParams.get(key))
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+
+      if (utmData) {
+        referralPartner = partnerKeys.find((key) => utmData.includes(key));
+      }
+    }
+
     if (referralPartner) setReferralPartner(referralPartner);
     if (referralCode) setReferralCode(referralCode);
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
 Partners' UTM links (e.g. `?utm_source=bumble`) now set the existing `referralPartner`, so a user who lands on any page via a partner campaign gets that partner's footer branding and is created with the partner attached when they sign up — the same way welcome links already work.

Detection runs app-wide via `ReferralPartnerTracker` in the layout, and `RegisterPage` falls back to the captured referral when no `?partner=` query is present. Added unit + Cypress coverage.

Note this PR also fixes the `referralPartner` state being lost if the user hasn't accepted cookies - the "Referral partner cookie" was added as an essential session cookie cleared on browser session closed (doesn't persist for weeks/months)