### PR TITLE
Fix bloom button color

### DIFF
--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -230,56 +230,73 @@ export const createAppTheme = (direction: Direction = 'ltr'): Theme => {
             marginInlineEnd: ownerState.size === 'small' ? -2 : -4,
             marginInlineStart: 8,
           }),
-          outlinedPrimary: {
-            color: '#000000',
-            borderColor: theme.palette.primary.dark,
-          },
-          containedPrimary: {
-            borderColor: 'transparent',
-            '&.Mui-disabled': {
-              backgroundColor: lighten(theme.palette.primary.main, 0.2),
-              color: theme.palette.grey[800],
-            },
-          },
-          containedSecondary: {
-            borderColor: 'transparent',
-            backgroundColor: theme.palette.secondary.dark,
-            '&:hover': {
-              backgroundColor: lighten(theme.palette.secondary.dark, 0.2),
-            },
-            '& .MuiTouchRipple-root span': {
-              backgroundColor: theme.palette.secondary.dark,
-              opacity: 0.1,
-            },
-            '&.Mui-disabled': {
-              backgroundColor: lighten(theme.palette.secondary.main, 0.2),
-              color: theme.palette.grey[800],
-            },
-          },
-          outlinedSecondary: {
-            color: '#000000',
-            borderColor: theme.palette.secondary.dark,
-            '& .MuiTouchRipple-root span': {
-              backgroundColor: theme.palette.secondary.dark,
-              opacity: 0.1,
-            },
-            '&:hover': {
-              backgroundColor: theme.palette.secondary.light,
-              borderColor: theme.palette.secondary.dark,
-            },
-          },
-          containedError: {
-            backgroundColor: theme.palette.primary.dark,
-            color: theme.palette.common.white,
-            '&:hover': {
-              backgroundColor: lighten(theme.palette.primary.dark, 0.3),
-            },
-            '&.Mui-disabled': {
-              backgroundColor: lighten(theme.palette.primary.dark, 0.3),
-              color: `${theme.palette.common.white} !important`,
-            },
-          },
         },
+        variants: [
+          {
+            props: { variant: 'outlined', color: 'primary' },
+            style: {
+              color: '#000000',
+              borderColor: theme.palette.primary.dark,
+            },
+          },
+          {
+            props: { variant: 'contained', color: 'primary' },
+            style: {
+              borderColor: 'transparent',
+              '&.Mui-disabled': {
+                backgroundColor: lighten(theme.palette.primary.main, 0.2),
+                color: theme.palette.grey[800],
+              },
+            },
+          },
+          {
+            props: { variant: 'contained', color: 'secondary' },
+            style: {
+              borderColor: 'transparent',
+              backgroundColor: theme.palette.secondary.dark,
+              '&:hover': {
+                backgroundColor: lighten(theme.palette.secondary.dark, 0.2),
+              },
+              '& .MuiTouchRipple-root span': {
+                backgroundColor: theme.palette.secondary.dark,
+                opacity: 0.1,
+              },
+              '&.Mui-disabled': {
+                backgroundColor: lighten(theme.palette.secondary.main, 0.2),
+                color: theme.palette.grey[800],
+              },
+            },
+          },
+          {
+            props: { variant: 'outlined', color: 'secondary' },
+            style: {
+              color: '#000000',
+              borderColor: theme.palette.secondary.dark,
+              '& .MuiTouchRipple-root span': {
+                backgroundColor: theme.palette.secondary.dark,
+                opacity: 0.1,
+              },
+              '&:hover': {
+                backgroundColor: theme.palette.secondary.light,
+                borderColor: theme.palette.secondary.dark,
+              },
+            },
+          },
+          {
+            props: { variant: 'contained', color: 'error' },
+            style: {
+              backgroundColor: theme.palette.primary.dark,
+              color: theme.palette.common.white,
+              '&:hover': {
+                backgroundColor: lighten(theme.palette.primary.dark, 0.3),
+              },
+              '&.Mui-disabled': {
+                backgroundColor: lighten(theme.palette.primary.dark, 0.3),
+                color: `${theme.palette.common.white} !important`,
+              },
+            },
+          },
+        ],
       },
       MuiIconButton: {
         styleOverrides: {


### PR DESCRIPTION
Fixes bloom button variants following v9 update. The hover colours were not being applied correctly.

**Root cause**

PR #1878 "Update all dependencies" (commit 05ec748) bumped @mui/material from v7 → v9. MUI removed the composite variant+color styleOverrides slots (containedSecondary, outlinedSecondary, containedError, containedPrimary, outlinedPrimary). Those keys don't error — they just silently stop applying.

Why the hover turned light pink specifically: the MuiButton.root override defines a blanket hover in [styles/theme.ts:200-202](vscode-webview://0jiq9f1op9s81o2310n8e8nfmmg8af292roievm39rf3u484o1fm/styles/theme.ts#L200-L202):

'&:hover': { backgroundColor: lighten(theme.palette.primary.main, 0.1) }  // primary.main = #F3D6D8 → light pink
In v7, the peach button's own containedSecondary['&:hover'] (lighten(secondary.dark #FF976A, 0.2) → lighter peach) overrode that root hover. In v9 the containedSecondary slot vanished, so every peach/secondary button fell through to the root hover — light pink. That's exactly your symptom, and it hit all colored buttons at once (the "changed them all" you suspected), not just one.

**The fix**

All five composite slots are migrated to MUI's variants API (props-based matching — the documented v6+ replacement), reproducing the original v7 style values verbatim: [styles/theme.ts:238-303](vscode-webview://0jiq9f1op9s81o2310n8e8nfmmg8af292roievm39rf3u484o1fm/styles/theme.ts#L238-L303). Because variants are applied after root, the per-color &:hover correctly wins again.

I verified against git show HEAD:styles/theme.ts that each of the five migrated blocks matches the old slot definitions value-for-value, so the "long-standing design" is restored exactly.