### PR TITLE
Tidy up typos and grammar in the environment config docs

### DIFF
--- a/docs/configure-env.md
+++ b/docs/configure-env.md
@@ -81,9 +81,7 @@ NEXT_PUBLIC_ROLLBAR_TOKEN= # Rollbar logging
 
 ### Configure Firebase Variables:
 
-To configure the Firebase variables, [create a Firebase project in the Firebase console](https://firebase.google.com/) (Google account required). Ensure the toggle is turned on to enable Google Analytics as it is required for `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID`
-
-###
+To configure the Firebase variables, [create a Firebase project in the Firebase console](https://firebase.google.com/) (Google account required). Ensure the toggle is turned on to enable Google Analytics as it is required for `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID`.
 
 ### Create New Environment Variables:
 
@@ -91,11 +89,11 @@ If creating new environment variables, please tag Chayn staff developers in PR /
 
 #### Additional Helper Environment Variables (optional):
 
-- `FF_DISABLED_COURSES`: This feature flag is intended to remove courses from the users course home page. Note that this does not prevent the user from accessing the course completely - the user may still be able to access the course if they navigate to the URL.
+- `FF_DISABLED_COURSES`: This feature flag is intended to remove courses from the users' course home page. Note that this does not prevent the user from accessing the course completely - the user may still be able to access the course if they navigate to the URL.
 
-  In terms of use, the variable could be used to disable a course when it has not been translated to a particular language e.g. if the `healing-from-sexual-trauma/` course is ready in English but not in French, then the course can be enabled in storyblok but still disabled in french. To do this, the the french url slug `fr/courses/healing-from-sexual-trauma/` should be included in the environment variable. This means the course will be hidden in the French version of bloom but still visible to the English version of bloom. If multiple courses need to be disabled, the slugs will need to be separated by commas.
+  In terms of use, the variable could be used to disable a course when it has not been translated to a particular language e.g. if the `healing-from-sexual-trauma/` course is ready in English but not in French, then the course can be enabled in storyblok but still disabled in French. To do this, the French url slug `fr/courses/healing-from-sexual-trauma/` should be included in the environment variable. This means the course will be hidden in the French version of bloom but still visible to the English version of bloom. If multiple courses need to be disabled, the slugs will need to be separated by commas.
 
-- `NEXT_PUBLIC_FF_USER_RESEARCH_BANNER`: This feature flag enables a banner which displays a banner message aimed to gathering users for Bloom feedback. It is intended to be turned on temporarily, for saw 1-2 weeks at a time. It links to an external form which users can fill out if they would like to take part in research.
+- `NEXT_PUBLIC_FF_USER_RESEARCH_BANNER`: This feature flag enables a banner which displays a banner message aimed at gathering users for Bloom feedback. It is intended to be turned on temporarily, for say 1-2 weeks at a time. It links to an external form which users can fill out if they would like to take part in research.
 
 #### Front Chat (1:1 Messaging):
 


### PR DESCRIPTION
### Resolves #1946

### What changes did you make and why did you make them?

Text fixes in `docs/configure-env.md`, all in the feature-flag section:

- "the the french url slug" -> "the French url slug" (and "french" ->
  "French" in the sentence above, which capitalises French and English
  everywhere else)
- "for saw 1-2 weeks at a time" -> "for say 1-2 weeks at a time"
- "aimed to gathering users for Bloom feedback" -> "aimed at gathering"
- "the users course home page" -> "the users' course home page"
- removed the empty `###` heading sitting above "Create New Environment
  Variables", and added the missing full stop to the Firebase paragraph
  before it

No environment variable names, values or code are touched.

### Did you run tests? Share screenshot of results:

Nothing to run - the change is a single Markdown file with no code or
config in it. I did check the file still renders as intended and that no
variable name in the doc changed.

### How did you find us? (GitHub, Google search, social media, etc.):

GitHub - I was reading the setup docs while looking around the chaynHQ
repos and these stood out.

### PR CHECKLIST:
- [x] Answered the questions above.
- [x] Enabled "Allow edits and access to secrets by maintainers" on this PR.
- [ ] If applicable, include images in the description. (Docs text only.)
