### PR TITLE
rm skip tests

### DIFF
--- a/components/storyblok/StoryblokResourceVideoPage.tsx
+++ b/components/storyblok/StoryblokResourceVideoPage.tsx
@@ -142,7 +142,7 @@ const StoryblokResourceVideoPage = ({ story: initialStory }: { story: ISbStoryDa
         beforeSections={
           keyReferences.length > 0 && (
             <Box>
-              <Typography sx={{ mb: 1 }}>{t('references.keyReferences')}</Typography>
+              <Typography sx={{ pb: 1 }}>{t('references.keyReferences')}</Typography>
               <References references={keyReferences} />
             </Box>
           )

--- a/cypress/integration/user-content/audio.cy.tsx
+++ b/cypress/integration/user-content/audio.cy.tsx
@@ -7,7 +7,7 @@ describe('Audio Flow', () => {
     cy.createUser({ emailInput: email, passwordInput: password });
   });
 
-  it.skip('Should allow a user to navigate to the library, select an audio resource, log in and play it', () => {
+  it('Should allow a user to navigate to the library, select an audio resource, log in and play it', () => {
     // User visits the home page
     cy.visit('/');
 

--- a/cypress/integration/user-content/library.cy.tsx
+++ b/cypress/integration/user-content/library.cy.tsx
@@ -124,7 +124,7 @@ describe('Library page', () => {
       cards().each(($card) => expect($card.attr('data-kind')).to.equal('session'));
     });
 
-    it.skip('filters by content type, returning only sessions of that format', () => {
+    it('filters by content type, returning only sessions of that format', () => {
       filterRow('Audio').find('input[type=checkbox]').check().should('be.checked');
 
       expectCount((count) => expect(count).to.be.greaterThan(0));
@@ -134,7 +134,7 @@ describe('Library page', () => {
       });
     });
 
-    it.skip('disables and clears the session-only filters while "Courses" is selected', () => {
+    it('disables and clears the session-only filters while "Courses" is selected', () => {
       filterRow('Audio').find('input[type=checkbox]').check().should('be.checked');
 
       cy.get('[qa-id=library-kind-course]').click();
@@ -146,7 +146,7 @@ describe('Library page', () => {
       filterRow('Audio').find('input[type=checkbox]').should('not.be.disabled');
     });
 
-    it.skip('combines search with the kind filter, and the empty state clears everything', () => {
+    it('combines search with the kind filter, and the empty state clears everything', () => {
       readCount().then((all) => {
         cy.get('[qa-id=library-search-input]').type('somatics');
         expectCount((count) => expect(count).to.be.lessThan(all));
@@ -215,7 +215,7 @@ describe('Library page', () => {
       cy.get('[qa-id=library-search-input]').should('have.value', 'somatics');
     };
 
-    it.skip('restores the filters on browser back', () => {
+    it('restores the filters on browser back', () => {
       applyFilters();
 
       cards().first().find('a').first().click();
@@ -225,7 +225,7 @@ describe('Library page', () => {
       expectFiltersRestored();
     });
 
-    it.skip('restores the filters from a content page\'s "Back to library" link', () => {
+    it('restores the filters from a content page\'s "Back to library" link', () => {
       applyFilters();
 
       cards().first().find('a').first().click();

--- a/cypress/integration/user-content/video.cy.tsx
+++ b/cypress/integration/user-content/video.cy.tsx
@@ -7,7 +7,7 @@ describe('Video Flow', () => {
     cy.createUser({ emailInput: email, passwordInput: password });
   });
 
-  it.skip('plays a public short without an account', () => {
+  it('plays a public short without an account', () => {
     cy.visit('/');
 
     cy.get(`[qa-id=secondary-nav-library-button]`, { timeout: 10000 }).should('exist').click();
@@ -22,7 +22,7 @@ describe('Video Flow', () => {
     cy.wait(2000);
   });
 
-  it.skip('gates a private video behind sign-up, then plays it after logging in', () => {
+  it('gates a private video behind sign-up, then plays it after logging in', () => {
     cy.visit('/');
 
     cy.get(`[qa-id=secondary-nav-library-button]`, { timeout: 10000 }).should('exist').click();


### PR DESCRIPTION
Removes skipping library tests following migration complete (they failed temporarily whilst moving pages to new routes)